### PR TITLE
Add opt-in physical device signing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ endif()
 
 set(CMAKE_OSX_DEPLOYMENT_TARGET "17.0" CACHE STRING "Minimum iOS/iPadOS version")
 
+set(GOLDENPAD_BUNDLE_IDENTIFIER "com.chrissotraidis.goldenpad" CACHE STRING
+    "Bundle identifier used by the iOS/iPadOS app")
+set(GOLDENPAD_DEVELOPMENT_TEAM "" CACHE STRING
+    "Apple development team ID; leave empty for reproducible unsigned builds")
 set(GOLDENPAD_RT64_ARCHIVE_DIR "" CACHE PATH "Directory containing the four RT64 mobile archives")
 set(GOLDENPAD_RT64_SOURCE_DIR "" CACHE PATH "Pinned RT64 source checkout used for Plume headers")
 set(GOLDENPAD_MGB64_SOURCE_DIR "" CACHE PATH "Pinned MGB64 checkout used for the native game core")
@@ -51,6 +55,13 @@ add_executable(GoldenPad MACOSX_BUNDLE
     ${goldenpad_rt64_bridge}
 )
 
+set(goldenpad_code_signing_allowed "NO")
+set(goldenpad_code_signing_required "NO")
+if(GOLDENPAD_DEVELOPMENT_TEAM)
+    set(goldenpad_code_signing_allowed "YES")
+    set(goldenpad_code_signing_required "YES")
+endif()
+
 set_source_files_properties(
     Support/MGB64/mgb64_metal_surface_bridge.mm
     PROPERTIES COMPILE_OPTIONS "-fobjc-arc")
@@ -60,16 +71,18 @@ include(Support/MGB64/MGB64Core.cmake)
 set_target_properties(GoldenPad PROPERTIES
     MACOSX_BUNDLE TRUE
     MACOSX_BUNDLE_BUNDLE_NAME "GoldenPad"
-    MACOSX_BUNDLE_GUI_IDENTIFIER "com.chrissotraidis.goldenpad"
+    MACOSX_BUNDLE_GUI_IDENTIFIER "${GOLDENPAD_BUNDLE_IDENTIFIER}"
     MACOSX_BUNDLE_SHORT_VERSION_STRING "0.1.0"
     MACOSX_BUNDLE_BUNDLE_VERSION "1"
     MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Config/Info.plist.in"
-    XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
-    XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO"
+    XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "${goldenpad_code_signing_allowed}"
+    XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "${goldenpad_code_signing_required}"
+    XCODE_ATTRIBUTE_CODE_SIGN_STYLE "Automatic"
+    XCODE_ATTRIBUTE_DEVELOPMENT_TEAM "${GOLDENPAD_DEVELOPMENT_TEAM}"
     XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon"
     XCODE_ATTRIBUTE_GENERATE_INFOPLIST_FILE "NO"
     XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "17.0"
-    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "com.chrissotraidis.goldenpad"
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${GOLDENPAD_BUNDLE_IDENTIFIER}"
     XCODE_ATTRIBUTE_SUPPORTED_PLATFORMS "iphoneos iphonesimulator"
     XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST "NO"
     XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ copyrighted game image or extracted asset is included.
 | Option | Status | What to do |
 |---|---|---|
 | Local Simulator build | **Verified** | Build with the complete verifier below, then run from Xcode or `simctl`. |
-| Local iPhone/iPad build | **Builds for ARM64** | Configure signing with your Apple development team and install from Xcode. |
+| Local iPhone/iPad build | **Builds for ARM64** | Follow the opt-in signed-device workflow in [Building](docs/BUILDING.md#signed-physical-device-build). |
 | Unsigned `.ipa` | **Buildable locally** | Run `scripts/package-unsigned-ipa.sh`, then re-sign the result for your own device. |
 | GitHub release | **Not published** | No downloadable GoldenPad IPA is currently advertised. |
 | App Store / TestFlight | **Not announced** | Store distribution requires separate rights, signing, review, and device acceptance. |

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -125,6 +125,46 @@ clean checkouts produced the same device executable and byte-identical IPA, so
 the current package is byte reproducible. Exact hashes are recorded in
 `TESTING.md`.
 
+## Signed physical-device build
+
+Unsigned reproducibility remains the default. To build the same complete
+game-bearing target for a device, first confirm that Xcode has an Apple
+Development identity:
+
+```sh
+security find-identity -v -p codesigning
+```
+
+Then provide your Apple team ID and a bundle identifier owned by that team:
+
+```sh
+GOLDENPAD_DEVELOPMENT_TEAM=YOURTEAMID \
+GOLDENPAD_BUNDLE_IDENTIFIER=com.yourname.goldenpad \
+  ./scripts/verify-mgb64-ios-renderer.sh
+```
+
+This keeps the maintained MGB64 patches applied for the entire compile/sign
+operation, asks Xcode to manage provisioning, verifies the resulting signature
+and embedded provisioning profile, and writes the signed app separately from
+the reproducible unsigned build:
+
+```text
+build-mgb64-renderer-device-signed/Release-iphoneos/GoldenPad.app
+```
+
+With a trusted iPhone or iPad connected, list it and install the app:
+
+```sh
+xcrun devicectl list devices
+xcrun devicectl device install app \
+  --device DEVICE_ID \
+  build-mgb64-renderer-device-signed/Release-iphoneos/GoldenPad.app
+```
+
+Do not package this signed app with `package-unsigned-ipa.sh`; that script
+deliberately accepts only the separate unsigned build. Signing and installation
+require the developer's own identity, team provisioning and connected hardware.
+
 The Metal verifier applies `patches/mgb64-ios-metal.patch` only inside the exact
 ignored checkout, compiles the complete native Metal backend plus its combiner,
 backend selector and MSAA helper, verifies four-object ARM64 archives for both

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -321,6 +321,11 @@ and shut down, and the physical-device gaps remain named below. P6 is closed at
 merge commit `4ed057ecd926c4b9f66e53544411986b1b4e37e8`; local `main` and
 `origin/main` matched after PR #1 merged, with the worktree clean. These package
 and publication gates do not close the human gameplay or physical-device gates.
+The physical path no longer requires manually editing the generated project:
+an optional team ID and caller-owned bundle identifier keep the maintained
+patches active through Xcode-managed signing in separate build trees, while the
+default unsigned executable remains byte-identical. A real signature, install
+and device acceptance still require external identity, provisioning and hardware.
 
 ## Test rhythm
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -478,6 +478,16 @@ longer blocks MGB64 integration.
   `xcrun devicectl list devices`
   currently reports `No devices found` on this Mac, so this pass could not run
   signed physical-touch acceptance.
+- The physical build path is now actionable without editing generated Xcode
+  files: `GOLDENPAD_DEVELOPMENT_TEAM` enables automatic signing and
+  `GOLDENPAD_BUNDLE_IDENTIFIER` supplies a caller-owned identifier inside the
+  maintained renderer verifier's patch window. Generated-project probes proved
+  the default stays `CODE_SIGNING_ALLOWED/REQUIRED=NO/NO`, while an opt-in probe
+  produced `YES/YES`, the requested team and the requested bundle ID. The full
+  unsigned closure then rebuilt to the unchanged Simulator/device executable
+  hashes `818f1733...91a0` and `43bfe1b5...f389`. This Mac currently has zero
+  valid signing identities and `devicectl` still reports `No devices found`, so
+  signature/provisioning/install acceptance remains external.
 - Performance is not accepted. Resolution scaling proves that pixel workload is
   controllable, but produced-game cadence remains scene- and host-load-sensitive.
   Profiling showed the reported 4.9 FPS phone and 7.8 FPS iPad startup windows

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -64,6 +64,12 @@ Run sequentially:
 5. Repeat on physical iPhone/iPad for controller, real audio, thermals and any
    simulator-limited Metal/audio behavior.
 
+Before the physical pass, build the opt-in signed target exactly as documented
+in `BUILDING.md`. The signed renderer verifier must accept its code signature,
+find `embedded.mobileprovision`, and confirm the requested bundle identifier.
+Installation must use the resulting `build-mgb64-renderer-device-signed` app;
+the reproducible `build-mgb64-renderer-device` app remains unsigned by design.
+
 Do not publish screenshots containing copyrighted game imagery.
 
 ### Current foundation evidence

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -1,5 +1,25 @@
 # Worklog
 
+## 2026-08-04 — make the physical signing path real
+
+- Found that the public instructions told a developer to configure signing even
+  though the generated target hard-disabled it and the maintained MGB64 patches
+  were restored immediately after the unsigned verifier. Added opt-in team and
+  bundle-identifier inputs to the existing verifier so compile and automatic
+  provisioning happen inside the same safe patch window.
+- Kept signed Simulator/device trees separate from the reproducible unsigned
+  trees. The signed branch verifies the final code signature, embedded mobile
+  provision and requested bundle ID; the default branch still explicitly builds
+  with signing disabled.
+- Generated unsigned and signed probe projects. They respectively contained
+  `CODE_SIGNING_ALLOWED/REQUIRED=NO/NO` and `YES/YES`; the signed probe also
+  carried `ABCDE12345` and `com.example.goldenpad` exactly. Shell syntax passed.
+- Rebuilt the complete unsigned game/Metal/audio closure. Simulator and device
+  executables remained byte-identical at `818f1733...91a0` and
+  `43bfe1b5...f389`; the device app remained unsigned and `ref/mgb64` remained
+  clean. Actual signed installation is not claimed: this Mac reports zero valid
+  signing identities and no connected devices.
+
 ## 2026-08-04 — close the Simulator publication ledger
 
 - Reconciled the plan with the completed release handoff: PR #1 merged as

--- a/scripts/verify-mgb64-ios-renderer.sh
+++ b/scripts/verify-mgb64-ios-renderer.sh
@@ -3,10 +3,17 @@ set -eu
 
 repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 source_dir="${GOLDENPAD_MGB64_SOURCE_DIR:-$repo_root/ref/mgb64}"
+bundle_identifier="${GOLDENPAD_BUNDLE_IDENTIFIER:-com.chrissotraidis.goldenpad}"
+development_team="${GOLDENPAD_DEVELOPMENT_TEAM:-}"
 metal_patch="$repo_root/patches/mgb64-ios-metal.patch"
 fast3d_patch="$repo_root/patches/mgb64-ios-fast3d.patch"
-sim_build="$repo_root/build-mgb64-renderer-simulator"
-device_build="$repo_root/build-mgb64-renderer-device"
+if [ -n "$development_team" ]; then
+    sim_build="$repo_root/build-mgb64-renderer-simulator-signed"
+    device_build="$repo_root/build-mgb64-renderer-device-signed"
+else
+    sim_build="$repo_root/build-mgb64-renderer-simulator"
+    device_build="$repo_root/build-mgb64-renderer-device"
+fi
 metal_applied=0
 fast3d_applied=0
 
@@ -43,11 +50,20 @@ build_app() {
         -DCMAKE_SYSTEM_NAME=iOS \
         -DCMAKE_OSX_SYSROOT="$sdk" \
         -DCMAKE_OSX_ARCHITECTURES=arm64 \
+        -DGOLDENPAD_BUNDLE_IDENTIFIER="$bundle_identifier" \
+        -DGOLDENPAD_DEVELOPMENT_TEAM="$development_team" \
         -DGOLDENPAD_MGB64_SOURCE_DIR="$source_dir" \
         -DGOLDENPAD_MGB64_RENDERER=ON
-    xcodebuild -quiet -jobs 4 -project "$build_dir/GoldenPad.xcodeproj" \
-        -target GoldenPad -configuration Release \
-        -sdk "$sdk" CODE_SIGNING_ALLOWED=NO build
+    if [ "$sdk" = "iphoneos" ] && [ -n "$development_team" ]; then
+        xcodebuild -quiet -jobs 4 -project "$build_dir/GoldenPad.xcodeproj" \
+            -target GoldenPad -configuration Release \
+            -sdk "$sdk" -destination 'generic/platform=iOS' \
+            -allowProvisioningUpdates build
+    else
+        xcodebuild -quiet -jobs 4 -project "$build_dir/GoldenPad.xcodeproj" \
+            -target GoldenPad -configuration Release \
+            -sdk "$sdk" CODE_SIGNING_ALLOWED=NO build
+    fi
 }
 
 build_app "$sim_build" iphonesimulator
@@ -118,5 +134,15 @@ do
     fi
     echo "Verified $binary (ARM64, linked MGB64 game/Metal/audio lifecycle)"
 done
+
+if [ -n "$development_team" ]; then
+    signed_app="$device_build/Release-iphoneos/GoldenPad.app"
+    codesign --verify --deep --strict "$signed_app"
+    test -f "$signed_app/embedded.mobileprovision"
+    actual_bundle_identifier=$(plutil -extract CFBundleIdentifier raw -o - \
+        "$signed_app/Info.plist")
+    test "$actual_bundle_identifier" = "$bundle_identifier"
+    echo "Verified signed device app ($bundle_identifier, team $development_team)."
+fi
 
 echo "MGB64 iOS linked game/renderer/audio lifecycle passed."


### PR DESCRIPTION
## What changed

- adds caller-supplied Apple team and bundle-identifier inputs to the CMake target
- builds signed outputs in separate trees while preserving the unsigned defaults
- keeps the maintained MGB64 patches active through Xcode automatic provisioning
- verifies the signed app, embedded provisioning profile, and requested bundle ID
- documents the exact device build and `devicectl` installation flow

## Why

The public instructions said to configure signing, but the generated target hard-disabled signing and the renderer verifier restored its temporary upstream patches after the unsigned build. A developer therefore lacked a reliable way to create the complete signed app without manually reconstructing the build.

## Verification

- unsigned generated project: signing allowed/required `NO/NO`
- opt-in generated project: signing allowed/required `YES/YES`, exact supplied team and bundle ID
- renderer verifier shell syntax passes
- complete unsigned Simulator/device game, Metal, and audio closure passes
- executable hashes remain `818f1733...91a0` and `43bfe1b5...f389`
- unsigned IPA remains `6eed064c...c738d`, content `aed6b272...08a6c`
- ROM-data, source-license, package, game-core/notices, and README-link audits pass
- ignored MGB64 checkout remains clean

Actual signing and installation remain unclaimed on this Mac because it has zero valid signing identities and no connected device.
