### PR TITLE
Prepare GoldenPad public release handoff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to GoldenPad
+
+GoldenPad welcomes focused fixes to its Apple platform integration, build
+scripts, documentation, and legally clean upstream patches.
+
+## Before opening a change
+
+- Read `docs/LEGAL.md` and `docs/ARCHITECTURE.md`.
+- Never commit or attach ROMs, extracted game assets, saves, leaked/XBLA
+  material, certificates, provisioning profiles, private paths, or credentials.
+- Keep MGB64 pinned. Put upstream checkouts and private inputs only under the
+  ignored `ref/` area.
+- Prefer the smallest change that preserves the shared portable core and thin
+  Apple platform boundary.
+
+## Verify the change
+
+Run the checks relevant to your scope. A full production change should pass:
+
+```sh
+./scripts/verify-mgb64-ios-renderer.sh
+./scripts/verify-source-license-manifest.sh
+./scripts/package-unsigned-ipa.sh
+./scripts/verify-unsigned-ipa.sh --game-core \
+  dist/GoldenPad-0.1.0-unsigned.ipa
+./scripts/check-no-rom-data.sh
+```
+
+Meaningful mobile changes must be exercised sequentially: iPhone Simulator
+first, shut it down, then iPad Simulator. Physical-device claims require a
+signed build and direct human testing; automation and Simulator evidence do not
+substitute for touch feel, controller feel, audio routes, thermals, or mission
+and multiplayer completion.
+
+## Pull requests
+
+Explain the user-visible result, why the change is needed, which exact checks
+passed, and which acceptance gates remain open. Do not include copyrighted game
+screenshots or private runtime logs.

--- a/README.md
+++ b/README.md
@@ -30,15 +30,22 @@ audio, persistent EEPROM saves, modern and classic touch layouts, physical
 controller support, controller assignment for Players 1–4, and a reproducible
 ROM-free unsigned IPA build.
 
-## Native setup, without bundled game data
+## Current screenshots
 
-<p align="center">
-  <img src="docs/images/goldenpad-setup-iphone.png" width="59%" alt="GoldenPad retail-ROM setup on iPhone">
-  <img src="docs/images/goldenpad-setup-ipad.png" width="39%" alt="GoldenPad retail-ROM setup and control preview on iPad">
-</p>
+<table>
+  <tr>
+    <td width="60%"><img src="docs/images/goldenpad-setup-iphone.png" alt="GoldenPad retail-ROM setup on iPhone"></td>
+    <td width="40%"><img src="docs/images/goldenpad-setup-ipad.png" alt="GoldenPad retail-ROM setup and control preview on iPad"></td>
+  </tr>
+  <tr>
+    <td align="center"><strong>Bring your own retail data</strong><br>The app validates a supported dump through Files.</td>
+    <td align="center"><strong>Built for both device classes</strong><br>Phone and tablet layouts are independent.</td>
+  </tr>
+</table>
 
-These are ROM-free Simulator captures of GoldenPad's own setup surface. No
-copyrighted game image or extracted asset is included.
+These ROM-free Simulator captures show only GoldenPad's project-owned setup and
+control-preview surfaces. No copyrighted game image or extracted asset is
+included.
 
 ## Install status
 
@@ -76,21 +83,38 @@ release.
 See [Status](docs/STATUS.md) and [Testing](docs/TESTING.md) for the evidence
 ledger and the remaining physical-device gates.
 
+## Supported game
+
+| Game | Retail revision | Status |
+|---|---|---|
+| **GoldenEye 007** | Original US Nintendo 64 release | Supported after exact validation |
+| Other regions or revisions | Any other dump | Rejected; not interchangeable with the supported build |
+| GoldenEye XBLA | Leaked/unreleased Xbox 360 build | Prohibited and never used |
+
+GoldenPad is a native integration of reconstructed N64 game code, not a general
+emulator. Another N64 game or GoldenEye revision cannot be substituted.
+
 ## Get started
 
 You need:
 
 - an Apple Silicon Mac with Xcode and its command-line tools;
-- CMake 3.28 or newer and Git;
+- [Homebrew](https://brew.sh), CMake 3.28 or newer, and Git;
 - an Apple development team for a signed physical-device build; and
 - your own legally acquired supported US retail GoldenEye 007 N64 dump.
 
-Clone and build the complete native game/Metal closure:
+Install CMake, then clone the repository:
 
 ```sh
+brew install cmake
 git clone https://github.com/chrissotraidis/goldenpad.git
 cd goldenpad
+```
 
+For Simulator development and the reproducible unsigned device app, build the
+complete native game/Metal closure:
+
+```sh
 ./scripts/verify-mgb64-ios-renderer.sh
 ```
 
@@ -106,8 +130,26 @@ build-mgb64-renderer-simulator/Release-iphonesimulator/GoldenPad.app
 build-mgb64-renderer-device/Release-iphoneos/GoldenPad.app
 ```
 
-For signing, Simulator destinations, and the maintained RT64 reference path,
-see [Building](docs/BUILDING.md).
+For a physical iPad, add your Apple ID under **Xcode → Settings → Accounts**,
+connect and trust the iPad, then use your 10-character team ID and a bundle
+identifier owned by that team:
+
+```sh
+GOLDENPAD_DEVELOPMENT_TEAM=ABCDE12345 \
+GOLDENPAD_BUNDLE_IDENTIFIER=com.yourname.goldenpad \
+  ./scripts/verify-mgb64-ios-renderer.sh
+
+xcrun devicectl list devices
+xcrun devicectl device install app \
+  --device YOUR_DEVICE_ID \
+  build-mgb64-renderer-device-signed/Release-iphoneos/GoldenPad.app
+```
+
+The signed build stays separate from the reproducible unsigned app. If Xcode
+has not yet created an Apple Development certificate, use **Manage
+Certificates** in the Accounts panel first. See [Building](docs/BUILDING.md)
+for signing diagnostics, Simulator destinations, and the maintained RT64
+reference path.
 
 ## First launch
 
@@ -272,6 +314,17 @@ the separate rights questions around reconstructed game code. Read the
 [Legal and provenance policy](docs/LEGAL.md).
 </details>
 
+<details>
+<summary><strong>What is the licensing status?</strong></summary>
+
+GoldenPad is source-available, but this repository currently has no top-level
+outbound license grant. MGB64-authored port code and third-party libraries keep
+their respective licenses; reconstructed original-game code remains subject to
+the rights boundary described in [Source licenses](docs/SOURCE_LICENSES.md) and
+[Legal](docs/LEGAL.md). Do not infer commercial or redistribution rights from
+the repository being publicly readable.
+</details>
+
 ## Project map
 
 | Path | Purpose |
@@ -286,12 +339,22 @@ the separate rights questions around reconstructed game code. Read the
 | [`docs/RESEARCH.md`](docs/RESEARCH.md) | Pinned upstreams and production-core decision |
 | [`docs/BUILDING.md`](docs/BUILDING.md) | Full local build and signing workflow |
 | [`docs/TESTING.md`](docs/TESTING.md) | Reproducible verification procedures and hashes |
+| [`docs/RELEASE_CHECKLIST.md`](docs/RELEASE_CHECKLIST.md) | Clean-checkout, package, signing, and publication gates |
 | [`docs/LEGAL.md`](docs/LEGAL.md) | ROM, source, licensing, and distribution boundary |
 | [`docs/ART.md`](docs/ART.md) | Original app-icon provenance |
 | [`docs/WORKLOG.md`](docs/WORKLOG.md) | Chronological production log |
 
 Generated source trees, build directories, ROMs, saves, signing material, and
 release artifacts are ignored and must never be committed.
+
+## Contributing and support
+
+Read [Contributing](CONTRIBUTING.md) before proposing a change and
+[Security](SECURITY.md) before reporting a vulnerability. Reproducible platform
+or gameplay defects can be filed through
+[GitHub Issues](https://github.com/chrissotraidis/goldenpad/issues). Never attach,
+request, or link to ROMs, extracted assets, leaked builds, saves containing
+private data, signing identities, or provisioning profiles.
 
 ## Legal and acknowledgements
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Please use a private
+[GitHub security advisory](https://github.com/chrissotraidis/goldenpad/security/advisories/new)
+for vulnerabilities involving code execution, unsafe file import, sandbox or
+path escape, credentials, signing material, or sensitive local data.
+
+Do not open a public issue containing an exploit, ROM data, extracted assets,
+private filesystem paths, certificates, provisioning profiles, or secrets.
+
+Ordinary reproducible build, rendering, input, or gameplay defects that do not
+have security impact may be filed through GitHub Issues.
+
+## Supported version
+
+GoldenPad is currently a source-available developer preview. Security fixes
+target the latest commit on `main`; no older binary release line is maintained.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,59 @@
+# Release checklist
+
+GoldenPad's current public deliverable is the source repository and its
+reproducible ROM-free unsigned IPA recipe. No downloadable IPA, App Store build,
+or TestFlight is advertised.
+
+## Clean checkout
+
+From a new directory on an Apple Silicon Mac with Xcode and CMake installed:
+
+```sh
+git clone https://github.com/chrissotraidis/goldenpad.git
+cd goldenpad
+git status --short
+./scripts/verify-mgb64-ios-renderer.sh
+```
+
+The clone must fetch MGB64 at the documented commit, build the complete ARM64
+Simulator and device apps, pass the linked game/Metal/audio checks, restore the
+ignored upstream checkout to clean state, and leave tracked source unchanged.
+
+## Repository and package
+
+```sh
+./scripts/check-no-rom-data.sh
+./scripts/verify-source-license-manifest.sh
+./scripts/package-unsigned-ipa.sh
+./scripts/verify-unsigned-ipa.sh --game-core \
+  dist/GoldenPad-0.1.0-unsigned.ipa
+git diff --check
+git status --short
+```
+
+Confirm that only ignored build products exist, every README/docs link resolves,
+the app and IPA contain no ROM or extracted assets, and the package includes the
+required third-party notices. Audit the exact staged paths before pushing.
+
+## Physical iPad
+
+Follow the signed-device command in `docs/BUILDING.md` with the developer's own
+team and bundle identifier. Install through `devicectl`, import the supported
+retail dump through Files, and complete the human acceptance matrix in
+`docs/TESTING.md`.
+
+Do not claim physical acceptance until a person has completed touch gameplay,
+mission/save progression, controller assignment, a local multiplayer match,
+speaker and route changes, background/foreground recovery, and first-install
+plus warm performance checks on the target hardware.
+
+## Publication
+
+- Keep the README's install table and limitations accurate.
+- Keep repository visibility, source publication, and binary distribution as
+  separate decisions.
+- Do not publish an IPA until its exact file has passed the package audit.
+- Do not describe the project as official, commercially licensed, App Store
+  ready, or affiliated with any rights holder.
+- Verify the merged PR state, clean worktree, and equality of local `main`,
+  `origin/main`, and GitHub's default branch before handoff.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -522,6 +522,13 @@ ledger are also closed: PR #1 merged as
 and a clean iPhone-first/iPad-second no-ROM pass produced the two public setup
 screenshots before both app containers were removed and both simulators shut
 down. Those captures contain only project-owned UI.
+The final public-facing handoff also passed from a `--no-local` clone of commit
+`f6d33ee25d5abc05900c02ab5b483d643b085f31`: GitHub fetched the exact MGB64
+pin, both SDK closures built, the package reproduced its exact hashes, every
+tracked documentation link/image resolved, the upstream checkout was clean and
+the clone had no tracked changes. The README now exposes the signed iPad command
+directly and links concise contribution, security and release-checklist entry
+points. Repository visibility remains a separate owner decision.
 
 With no physical device attached, the first scene-specific warm bottleneck is
 removed and Metal's automatic cache makes shader compilation negligible after

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -779,3 +779,14 @@ Each checkout independently passed the source-manifest, ARM64, unsigned,
 game-core symbol, notices, private-path and ROM-contamination audits. This
 closes P2 for the current source state while retaining the older contrary result
 as historical evidence.
+
+The public-handoff commit `f6d33ee25d5abc05900c02ab5b483d643b085f31`
+was then cloned with `--no-local` into a new temporary path. That clone fetched
+MGB64 from GitHub at the exact pin, built both complete SDK closures, restored
+the ignored upstream checkout, packaged the nine-member IPA, resolved every
+tracked Markdown link and README image, and ended with no tracked changes. It
+reproduced the same Simulator executable `818f1733...91a0`, device executable
+`43bfe1b5...f389`, IPA `6eed064c...c738d`, and sorted content
+`aed6b272...08a6c`. The temporary clone was deleted after the pass. This proves
+the source handoff on another clean path; signing still requires the receiving
+Mac's own Apple identity, team and connected iPad.

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -1,5 +1,26 @@
 # Worklog
 
+## 2026-08-04 — prove the public another-Mac handoff
+
+- Compared GoldenPad directly with HarkinianPad's public README and aligned the
+  useful visitor structure: captioned current screenshots, install status,
+  supported game, direct signed-iPad commands, licensing FAQ, project map, and
+  contribution/security guidance. Claims remain narrower where physical proof
+  is absent.
+- Added `CONTRIBUTING.md`, `SECURITY.md` and `docs/RELEASE_CHECKLIST.md`. The
+  README now gives the exact Apple-team/bundle-ID build and `devicectl` install
+  path rather than requiring a reader to reconstruct it from engineering notes.
+- Cloned public-surface commit `f6d33ee25d5abc05900c02ab5b483d643b085f31`
+  with `--no-local` into a fresh temporary directory. It fetched MGB64 from its
+  public GitHub remote at the exact pin, built both ARM64 SDK apps, packaged and
+  audited the IPA, resolved all tracked Markdown/image targets, restored the
+  ignored upstream checkout and ended clean.
+- The clean clone reproduced Simulator executable `818f1733...91a0`, device
+  executable `43bfe1b5...f389`, IPA `6eed064c...c738d`, and sorted app content
+  `aed6b272...08a6c`. The temporary clone was deleted. Signed installation is
+  ready for a receiving Mac's own Apple identity and iPad, not falsely claimed
+  as completed here.
+
 ## 2026-08-04 — make the physical signing path real
 
 - Found that the public instructions told a developer to configure signing even


### PR DESCRIPTION
## What changed

- aligns the README more closely with HarkinianPad's visitor-oriented structure
- adds captioned ROM-free product screenshots and a supported-game matrix
- puts the exact another-Mac to signed-iPad build/install commands in the README
- states the current source-available licensing boundary directly
- adds concise contribution, security, and release-checklist entry points
- records a complete fresh-clone handoff proof

## Another-machine proof

A `--no-local` clone of commit `f6d33ee25d5abc05900c02ab5b483d643b085f31` fetched MGB64 from GitHub at its exact pin, built both complete ARM64 SDK apps, restored the ignored upstream checkout, packaged and audited the IPA, resolved all tracked Markdown/image targets, and ended with no tracked changes.

It reproduced:

- Simulator executable: `818f1733fac43edec9a759c81874faf3b6b5bd0d1558c1fdecfb3f76520291a0`
- Device executable: `43bfe1b5a0cfe46b16f48eeb33130ab3efd36bb1a1521adeba3db0277c91f389`
- Unsigned IPA: `6eed064c79ca7a9ebedb6a3cb2f4a5d97a8cd0ab426fa9503e94db535c3c738d`
- Sorted app content: `aed6b2725e2deac8cddb7c0901dca2d385f6966474125bdb5d5f1a628e408a6c`

## Additional checks

- ROM-data contamination scan
- source-license manifest
- nine-member IPA and game-core/notices audit
- `git diff --check`
- tracked Markdown links and README image targets
- exact temporary-clone cleanup

## Honest boundary

The source handoff and signed-build workflow are ready. A physical install still requires the receiving Mac's Apple identity/team, a connected iPad, and the documented human mission/multiplayer/device acceptance pass. No public IPA, App Store, TestFlight, or commercial-rights claim is added.
