### PR TITLE
Improve iPad controls and runtime stability

### DIFF
--- a/Sources/AppleRenderSurface.swift
+++ b/Sources/AppleRenderSurface.swift
@@ -169,8 +169,7 @@ final class AppleRenderSurface: ObservableObject {
                 height: view.bounds.height * view.contentScaleFactor
             )
         }
-        let refreshRate = view.window?.screen.maximumFramesPerSecond
-            ?? UIScreen.main.maximumFramesPerSecond
+        let refreshRate = view.preferredFramesPerSecond
         guard size != lastReportedSize || refreshRate != lastReportedRefreshRate else { return }
         lastReportedSize = size
         lastReportedRefreshRate = refreshRate

--- a/Sources/GoldenPadApp.swift
+++ b/Sources/GoldenPadApp.swift
@@ -17,6 +17,14 @@ private func goldenPadMGB64CoreProbe() -> UInt32
 @_silgen_name("goldenpad_mgb64_audio_output_probe")
 private func goldenPadMGB64AudioOutputProbe() -> Int32
 
+@_silgen_name("goldenpad_mgb64_audio_callback_stats")
+private func goldenPadMGB64AudioCallbackStats(
+    _ callbacks: UnsafeMutablePointer<UInt64>?,
+    _ requestedFrames: UnsafeMutablePointer<UInt64>?,
+    _ renderedFrames: UnsafeMutablePointer<UInt64>?,
+    _ shortfallFrames: UnsafeMutablePointer<UInt64>?
+)
+
 private enum MGB64CoreInfo {
     static let status: String = {
         let identity = String(cString: goldenPadMGB64CoreIdentity())
@@ -102,9 +110,24 @@ private struct FoundationView: View {
                 return
             }
             if goldenPadMGB64AudioOutputProbe() == 1 {
+                var callbacks: UInt64 = 0
+                var requestedFrames: UInt64 = 0
+                var renderedFrames: UInt64 = 0
+                var shortfallFrames: UInt64 = 0
+                goldenPadMGB64AudioCallbackStats(
+                    &callbacks,
+                    &requestedFrames,
+                    &renderedFrames,
+                    &shortfallFrames
+                )
                 print(
                     "[GoldenPad] Native PCM output probe: PASS " +
                     "after \(elapsedSeconds)s"
+                )
+                print(
+                    "[GoldenPad] Audio callback health: callbacks=\(callbacks) " +
+                    "requested=\(requestedFrames) rendered=\(renderedFrames) " +
+                    "shortfall=\(shortfallFrames)"
                 )
                 return
             }
@@ -259,17 +282,53 @@ private struct FoundationView: View {
         } else {
             nil
         }
+        let documentName: String? = if let flag = arguments.firstIndex(of: "--validate-rom-document"),
+                                       arguments.indices.contains(flag + 1) {
+            arguments[flag + 1]
+        } else {
+            nil
+        }
+        let validationURL: URL? = if let path = argumentPath
+            ?? ProcessInfo.processInfo.environment["GOLDENPAD_VALIDATE_ROM_PATH"] {
+            URL(fileURLWithPath: path)
+        } else if let documentName,
+                  let documents = FileManager.default.urls(
+                    for: .documentDirectory,
+                    in: .userDomainMask
+                  ).first {
+            documents.appendingPathComponent(documentName)
+        } else {
+            automaticROMDocumentURL()
+        }
 
         guard
             !performedAutomationValidation,
-            let path = argumentPath ?? ProcessInfo.processInfo.environment["GOLDENPAD_VALIDATE_ROM_PATH"]
+            let validationURL
         else { return }
 
         performedAutomationValidation = true
         validation = .validating
         validation = await Task.detached(priority: .userInitiated) {
-            ROMValidator.validate(url: URL(fileURLWithPath: path))
+            ROMValidator.validate(url: validationURL)
         }.value
+    }
+
+    private func automaticROMDocumentURL() -> URL? {
+        guard let documents = FileManager.default.urls(
+            for: .documentDirectory,
+            in: .userDomainMask
+        ).first else { return nil }
+
+        let supportedExtensions = Set(["z64", "v64", "n64", "rom"])
+        return try? FileManager.default
+            .contentsOfDirectory(
+                at: documents,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )
+            .filter { supportedExtensions.contains($0.pathExtension.lowercased()) }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+            .first
     }
 }
 

--- a/Sources/InputSystem.swift
+++ b/Sources/InputSystem.swift
@@ -19,6 +19,9 @@ private func goldenPadMGB64QueueControllerButtons(
     _ buttons: UInt32
 )
 
+@_silgen_name("goldenpad_mgb64_request_crouch_toggle")
+private func goldenPadMGB64RequestCrouchToggle()
+
 @_silgen_name("goldenpad_mgb64_controller_input_probe")
 private func goldenPadMGB64ControllerInputProbe() -> Int32
 
@@ -48,6 +51,13 @@ private func goldenPadMGB64GameplayState(
     _ watchState: UnsafeMutablePointer<Int32>?,
     _ outsideWatch: UnsafeMutablePointer<Int32>?,
     _ pausing: UnsafeMutablePointer<Int32>?
+)
+
+@_silgen_name("goldenpad_mgb64_player_vitals")
+private func goldenPadMGB64PlayerVitals(
+    _ ready: UnsafeMutablePointer<Int32>?,
+    _ health: UnsafeMutablePointer<Int32>?,
+    _ armor: UnsafeMutablePointer<Int32>?
 )
 
 @_silgen_name("goldenpad_mgb64_request_scripted_mission_success")
@@ -394,18 +404,27 @@ private extension SIMD2 where Scalar == Float {
 }
 
 private enum TouchLookAccumulator {
+    // A thumb swipe needs a shorter physical travel than a controller stick.
+    // Keep this gain on the touch path so paired gamepads retain their tuning.
+    static let touchGain: Float = 1.5
+
+    static func amplified(_ delta: SIMD2<Float>) -> SIMD2<Float> {
+        delta * touchGain
+    }
+
     static func appending(_ delta: SIMD2<Float>, to pending: SIMD2<Float>) -> SIMD2<Float> {
         (pending + delta).clampedUnitSquare()
     }
 
     static var probePasses: Bool {
-        let pending = appending(SIMD2(0.25, 0.50), to: .zero)
-        return appending(SIMD2(0.50, -0.25), to: pending) == SIMD2(0.75, 0.25)
+        let pending = appending(amplified(SIMD2(0.20, 0.40)), to: .zero)
+        return pending == SIMD2(0.30, 0.60) &&
+            appending(amplified(SIMD2(0.20, -0.20)), to: pending) == SIMD2(0.60, 0.30)
     }
 }
 
 private enum GameplayProbePhase {
-    case waiting, settle, movement, aim, fire
+    case waiting, settle, movement, aim, pitchHold, fire
     case reloadPulse, reloadWait, weaponPulse, weaponWait
     case pausePulse, pauseWait, complete
 }
@@ -428,6 +447,12 @@ private enum DamRouteProbePhase {
     case waitingForDam, route, complete
 }
 
+struct PlayerVitals: Equatable {
+    var isVisible = false
+    var health = 1.0
+    var armor = 0.0
+}
+
 @MainActor
 final class InputCoordinator: ObservableObject {
     @Published private(set) var diagnosticSummary = "input: neutral • controllers: 0"
@@ -435,6 +460,7 @@ final class InputCoordinator: ObservableObject {
     @Published private(set) var externalControllerCount = 0
     @Published private(set) var controllerAssignments: [ControllerAssignment] = []
     @Published private(set) var currentPreset = ControlPreset.modern
+    @Published private(set) var playerVitals = PlayerVitals()
 
     private var touch = InputSnapshot.neutral
     private var controllerSlots: [GCController?] = Array(repeating: nil, count: 4)
@@ -444,6 +470,7 @@ final class InputCoordinator: ObservableObject {
     private let motionManager = CMMotionManager()
     private var motionLook = SIMD2<Float>.zero
     private var didReportCoreInputProbe = false
+    private var nativeCrouchWasPressed = false
     private var menuProbeLastMenu: Int32 = .min
     private var menuProbeLastStage: Int32 = .min
     private var menuProbeLastPendingStage: Int32 = .min
@@ -583,7 +610,10 @@ final class InputCoordinator: ObservableObject {
         // SwiftUI may deliver several drag deltas before the renderer samples
         // input. Preserve the full swipe instead of keeping only the last event.
         guard value != .zero else { return }
-        touch.look = TouchLookAccumulator.appending(value, to: touch.look)
+        touch.look = TouchLookAccumulator.appending(
+            TouchLookAccumulator.amplified(value),
+            to: touch.look
+        )
         refreshSummary()
     }
 
@@ -643,6 +673,7 @@ final class InputCoordinator: ObservableObject {
     }
 
     func publishToCore() {
+        refreshPlayerVitals()
         runMenuProbeIfRequested()
         runGameplayProbeIfRequested()
         runMissionFlowProbeIfRequested()
@@ -658,6 +689,12 @@ final class InputCoordinator: ObservableObject {
                 buttons: [.fire, .interact]
             )
         }
+        let nativeCrouchIsPressed = snapshot(player: 0).buttons.contains(.crouch)
+        if nativeCrouchIsPressed && !nativeCrouchWasPressed {
+            goldenPadMGB64RequestCrouchToggle()
+        }
+        nativeCrouchWasPressed = nativeCrouchIsPressed
+
         for player in 0..<controllerSlots.count {
             let frame = player == 0
                 ? damRouteInput ?? facilityDoorRouteInput ?? mappedFrame(player: player)
@@ -706,6 +743,21 @@ final class InputCoordinator: ObservableObject {
                 "[GoldenPad] Touch look accumulation probe: " +
                 "\(TouchLookAccumulator.probePasses ? "PASS" : "FAIL")"
             )
+        }
+    }
+
+    private func refreshPlayerVitals() {
+        var ready: Int32 = 0
+        var health: Int32 = 1000
+        var armor: Int32 = 0
+        goldenPadMGB64PlayerVitals(&ready, &health, &armor)
+        let next = PlayerVitals(
+            isVisible: ready != 0,
+            health: Double(min(max(health, 0), 1000)) / 1000,
+            armor: Double(min(max(armor, 0), 1000)) / 1000
+        )
+        if next != playerVitals {
+            playerVitals = next
         }
     }
 
@@ -1682,6 +1734,29 @@ final class InputCoordinator: ObservableObject {
                 print(
                     "[GoldenPad] Gameplay probe aim/look: " +
                     "\(passed ? "PASS" : "FAIL") mode=\(aimMode) delta=\(angleDelta)"
+                )
+                gameplayProbePhase = .pitchHold
+                gameplayProbeFrames = 0
+            }
+
+        case .pitchHold:
+            // Relative touch look must hold its last pitch while moving. The
+            // original N64 look-ahead path recentred vertically whenever the
+            // movement stick was held, which fights touch and modern sticks.
+            touch.movement = SIMD2(0, 0.8)
+            touch.leftTrigger = 1
+            touch.buttons = [.aim]
+            // publishToCore runs before this frame's input reaches the core.
+            // Let the final queued look sample land, then measure only the
+            // stationary-look interval rather than counting that last sample.
+            if gameplayProbeFrames == 2 {
+                gameplayProbeStartPitch = pitch
+            }
+            if gameplayProbeFrames >= 122 {
+                let pitchDrift = abs(pitch - gameplayProbeStartPitch)
+                print(
+                    "[GoldenPad] Gameplay probe pitch hold: " +
+                    "\(pitchDrift <= 100 ? "PASS" : "FAIL") drift=\(pitchDrift)"
                 )
                 gameplayProbeFireAmmo = ammo
                 gameplayProbePhase = .fire

--- a/Sources/PlatformServices.swift
+++ b/Sources/PlatformServices.swift
@@ -41,13 +41,15 @@ enum RenderResolution: String, Codable, Sendable, CaseIterable {
 }
 
 struct HostSettings: Codable, Equatable, Sendable {
-    static let currentSchema = 5
+    static let currentSchema = 7
 
     var schemaVersion = currentSchema
     var controlPreset: ControlPreset = .modern
-    var lookSensitivity = 1.0
+    var lookSensitivity = 4.0
     var touchOpacity = 0.72
     var touchScale = 1.0
+    var moveGuideVisible = false
+    var lookGuideVisible = false
     var stickDeadZone = 0.12
     var gyroEnabled = false
     var touchAimBehavior: TouchAimBehavior = .toggle
@@ -62,6 +64,8 @@ struct HostSettings: Codable, Equatable, Sendable {
         case lookSensitivity
         case touchOpacity
         case touchScale
+        case moveGuideVisible
+        case lookGuideVisible
         case stickDeadZone
         case gyroEnabled
         case touchAimBehavior
@@ -80,6 +84,8 @@ struct HostSettings: Codable, Equatable, Sendable {
         lookSensitivity = try values.decodeIfPresent(Double.self, forKey: .lookSensitivity) ?? 1
         touchOpacity = try values.decodeIfPresent(Double.self, forKey: .touchOpacity) ?? 0.72
         touchScale = try values.decodeIfPresent(Double.self, forKey: .touchScale) ?? 1
+        moveGuideVisible = try values.decodeIfPresent(Bool.self, forKey: .moveGuideVisible) ?? false
+        lookGuideVisible = try values.decodeIfPresent(Bool.self, forKey: .lookGuideVisible) ?? false
         stickDeadZone = try values.decodeIfPresent(Double.self, forKey: .stickDeadZone) ?? 0.12
         gyroEnabled = try values.decodeIfPresent(Bool.self, forKey: .gyroEnabled) ?? false
         touchAimBehavior = try values.decodeIfPresent(
@@ -111,6 +117,8 @@ struct HostSettings: Codable, Equatable, Sendable {
         try values.encode(lookSensitivity, forKey: .lookSensitivity)
         try values.encode(touchOpacity, forKey: .touchOpacity)
         try values.encode(touchScale, forKey: .touchScale)
+        try values.encode(moveGuideVisible, forKey: .moveGuideVisible)
+        try values.encode(lookGuideVisible, forKey: .lookGuideVisible)
         try values.encode(stickDeadZone, forKey: .stickDeadZone)
         try values.encode(gyroEnabled, forKey: .gyroEnabled)
         try values.encode(touchAimBehavior, forKey: .touchAimBehavior)
@@ -123,7 +131,7 @@ struct HostSettings: Codable, Equatable, Sendable {
     func sanitized() -> HostSettings {
         var copy = self
         copy.schemaVersion = Self.currentSchema
-        copy.lookSensitivity = copy.lookSensitivity.clamped(to: 0.25...3.0)
+        copy.lookSensitivity = copy.lookSensitivity.clamped(to: 0.25...8.0)
         copy.touchOpacity = copy.touchOpacity.clamped(to: 0.25...1.0)
         copy.touchScale = copy.touchScale.clamped(to: 0.7...1.4)
         copy.stickDeadZone = copy.stickDeadZone.clamped(to: 0.0...0.4)
@@ -133,11 +141,22 @@ struct HostSettings: Codable, Equatable, Sendable {
         return copy
     }
 
+    func migrated() -> HostSettings {
+        var copy = self
+        if copy.schemaVersion < 6, abs(copy.lookSensitivity - 1.0) < 0.000_1 {
+            copy.lookSensitivity = 2.0
+        }
+        if copy.schemaVersion < 7, copy.lookSensitivity <= 2.0 {
+            copy.lookSensitivity *= 2.0
+        }
+        return copy.sanitized()
+    }
+
     static func layoutKey(
         deviceClass: TouchDeviceClass,
         preset: ControlPreset
     ) -> String {
-        "\(deviceClass.rawValue).\(preset.rawValue)-v4"
+        "\(deviceClass.rawValue).\(preset.rawValue)-v9"
     }
 }
 
@@ -212,7 +231,7 @@ struct PlatformStorage {
         guard stored.schemaVersion > 0, stored.schemaVersion <= HostSettings.currentSchema else {
             throw PlatformStorageError.unsupportedSettingsSchema(stored.schemaVersion)
         }
-        return stored.sanitized()
+        return stored.migrated()
     }
 
     func saveSettings(_ settings: HostSettings) throws {

--- a/Sources/TouchControlsView.swift
+++ b/Sources/TouchControlsView.swift
@@ -19,20 +19,47 @@ struct GameplayTouchControls: View {
                     opacity: platform.settings.touchOpacity,
                     globalScale: platform.settings.touchScale,
                     input: input,
-                    showsBackground: false
+                    showsBackground: false,
+                    showsMoveGuide: platform.settings.moveGuideVisible,
+                    showsLookGuide: platform.settings.lookGuideVisible
                 )
                 .ignoresSafeArea()
             }
 
-            Button { isSettingsPresented = true } label: {
-                Image(systemName: "slider.horizontal.3")
-                    .font(.system(size: 15, weight: .bold))
-                    .frame(width: 42, height: 42)
-                    .background(.black.opacity(0.46), in: Circle())
+            if input.playerVitals.isVisible {
+                PlayerVitalsHUD(vitals: input.playerVitals)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .padding(.top, 20)
+                    .padding(.leading, 24)
+                    .allowsHitTesting(false)
             }
-            .foregroundStyle(.white)
-            .padding(14)
-            .accessibilityLabel("Open game settings")
+
+            HStack(alignment: .center, spacing: 10) {
+                if input.shouldShowTouchControls,
+                   platform.settings.controlPreset != .classic {
+                    TouchControlVisual(
+                        id: .pause,
+                        input: input,
+                        editing: false,
+                        selected: false,
+                        showsGuide: true
+                    )
+                    .frame(width: 50, height: 50)
+                    .opacity(platform.settings.touchOpacity)
+                    .accessibilityLabel("Pause")
+                }
+
+                Button { isSettingsPresented = true } label: {
+                    Image(systemName: "slider.horizontal.3")
+                        .font(.system(size: 15, weight: .bold))
+                        .frame(width: 42, height: 42)
+                        .background(.black.opacity(0.46), in: Circle())
+                }
+                .foregroundStyle(.white)
+                .accessibilityLabel("Open game settings")
+            }
+            .padding(.top, 14)
+            .padding(.trailing, 50)
         }
         .sheet(isPresented: $isSettingsPresented) {
             GameplaySettingsView(deviceClass: deviceClass)
@@ -47,6 +74,49 @@ struct GameplayTouchControls: View {
             input.releaseTouchInput()
             renderSurface.setSystemOverlayPresented(false)
         }
+    }
+}
+
+private struct PlayerVitalsHUD: View {
+    let vitals: PlayerVitals
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            VitalBar(label: "HEALTH", value: vitals.health, tint: .green)
+            if vitals.armor > 0.001 {
+                VitalBar(label: "ARMOR", value: vitals.armor, tint: .cyan)
+            }
+        }
+        .padding(.horizontal, 11)
+        .padding(.vertical, 9)
+        .background(.black.opacity(0.48), in: RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+private struct VitalBar: View {
+    let label: String
+    let value: Double
+    let tint: Color
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(label)
+                .font(.system(size: 9, weight: .bold, design: .rounded))
+                .frame(width: 42, alignment: .leading)
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(.white.opacity(0.16))
+                    Capsule()
+                        .fill(tint)
+                        .frame(width: geometry.size.width * value)
+                }
+            }
+            .frame(width: 90, height: 7)
+            Text("\(Int((value * 100).rounded()))%")
+                .font(.system(size: 9, weight: .bold, design: .monospaced))
+                .frame(width: 34, alignment: .trailing)
+        }
+        .foregroundStyle(.white.opacity(0.9))
     }
 }
 
@@ -85,6 +155,18 @@ private struct GameplaySettingsView: View {
                     } label: {
                         Label("Physical Controllers", systemImage: "gamecontroller")
                     }
+                }
+
+                Section("Aiming") {
+                    LabeledSlider(
+                        title: "Look sensitivity",
+                        value: settingBinding(\.lookSensitivity),
+                        range: 0.25...8,
+                        valueLabel: String(format: "%.2fx", platform.settings.lookSensitivity)
+                    )
+                    Text("Higher values reach full turn speed with a smaller thumb movement.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
                 Section("Display") {
@@ -134,6 +216,17 @@ private struct GameplaySettingsView: View {
         )
     }
 
+    private func settingBinding(
+        _ keyPath: WritableKeyPath<HostSettings, Double>
+    ) -> Binding<Double> {
+        Binding(
+            get: { platform.settings[keyPath: keyPath] },
+            set: { value in
+                platform.updateSettings { $0[keyPath: keyPath] = value }
+            }
+        )
+    }
+
     private func boolSettingBinding(
         _ keyPath: WritableKeyPath<HostSettings, Bool>
     ) -> Binding<Bool> {
@@ -168,13 +261,6 @@ private struct TouchSettingsView: View {
     var body: some View {
         Form {
             Section("Aiming") {
-                LabeledSlider(
-                    title: "Look sensitivity",
-                    value: settingBinding(\.lookSensitivity),
-                    range: 0.25...3,
-                    valueLabel: String(format: "%.2fx", platform.settings.lookSensitivity)
-                )
-
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Aim button")
                         .font(.subheadline)
@@ -208,6 +294,8 @@ private struct TouchSettingsView: View {
                     "Hide when a controller connects",
                     isOn: boolSettingBinding(\.touchControlsAutoHide)
                 )
+                Toggle("Show movement guide", isOn: boolSettingBinding(\.moveGuideVisible))
+                Toggle("Show look guide", isOn: boolSettingBinding(\.lookGuideVisible))
             }
 
             Section("Layout") {
@@ -647,6 +735,8 @@ private struct TouchControlCanvas: View {
     let globalScale: Double
     let input: InputCoordinator
     var showsBackground = true
+    var showsMoveGuide = true
+    var showsLookGuide = true
     var editing = false
     var selectedID: TouchControlID?
     var onSelect: ((TouchControlID) -> Void)?
@@ -679,12 +769,15 @@ private struct TouchControlCanvas: View {
     @ViewBuilder
     private func control(_ placement: TouchControlPlacement, in size: CGSize) -> some View {
         let controlScale = CGFloat(placement.scale * globalScale) * canvasScale(for: size)
-        let baseSize = controlBaseSize(placement.id)
+        let baseSize = controlBaseSize(placement.id, editing: editing)
         let control = TouchControlVisual(
             id: placement.id,
             input: input,
             editing: editing,
-            selected: selectedID == placement.id
+            selected: selectedID == placement.id,
+            showsGuide: placement.id == .move
+                ? showsMoveGuide
+                : placement.id == .look ? showsLookGuide : true
         )
         .frame(
             width: baseSize.width * controlScale,
@@ -718,9 +811,14 @@ private struct TouchControlCanvas: View {
         min(max(size.width / 720, 0.62), 1.18)
     }
 
-    private func controlBaseSize(_ id: TouchControlID) -> CGSize {
+    private func controlBaseSize(_ id: TouchControlID, editing: Bool) -> CGSize {
         switch id {
-        case .move: CGSize(width: 128, height: 128)
+        case .move:
+            // The live movement surface is a generous bottom-corner zone. The
+            // editor keeps a compact marker so it remains easy to reposition.
+            editing
+                ? CGSize(width: 128, height: 128)
+                : CGSize(width: 300, height: 260)
         case .look: CGSize(width: 320, height: 220)
         case .pause, .n64Start, .weapon, .crouch, .n64L, .n64R:
             CGSize(width: 64, height: 64)
@@ -737,17 +835,22 @@ private struct TouchControlVisual: View {
     @ObservedObject var input: InputCoordinator
     let editing: Bool
     let selected: Bool
+    let showsGuide: Bool
 
     var body: some View {
         Group {
             if editing {
                 EditorControlFace(id: id, tint: tint)
             } else if id == .move {
-                VirtualStick(title: id.label, systemImage: "figure.walk") {
+                VirtualStick(
+                    title: id.label,
+                    systemImage: "figure.walk",
+                    showsGuide: showsGuide
+                ) {
                     input.updateMovement($0)
                 }
             } else if id == .look {
-                LookSurface { input.updateLook($0) }
+                LookSurface(showsGuide: showsGuide) { input.updateLook($0) }
             } else if id == .aim, input.touchAimBehavior == .toggle {
                 ToggleAction(
                     title: id.label,
@@ -834,6 +937,7 @@ private struct EditorControlFace: View {
 }
 
 private struct LookSurface: View {
+    let showsGuide: Bool
     let onChange: (SIMD2<Float>) -> Void
 
     @State private var normalized = SIMD2<Float>.zero
@@ -842,25 +946,32 @@ private struct LookSurface: View {
 
     var body: some View {
         GeometryReader { geometry in
-            let responseDistance = max(min(geometry.size.width, geometry.size.height) * 0.20, 38)
+            let responseDistance = max(min(geometry.size.width, geometry.size.height) * 0.05, 10)
 
             ZStack {
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .fill(.black.opacity(isTracking ? 0.16 : 0.08))
-                RoundedRectangle(cornerRadius: 24, style: .continuous)
-                    .stroke(.white.opacity(isTracking ? 0.24 : 0.12), lineWidth: 1)
-                Image(systemName: "scope")
-                    .font(.title3.weight(.medium))
-                    .foregroundStyle(.white.opacity(isTracking ? 0.72 : 0.34))
-                    .offset(
-                        x: CGFloat(normalized.x) * 18,
-                        y: CGFloat(-normalized.y) * 18
-                    )
-                Text("LOOK")
-                    .font(.system(size: 8, weight: .bold, design: .rounded))
-                    .tracking(1.2)
-                    .foregroundStyle(.white.opacity(0.36))
-                    .offset(y: 30)
+                // Keep a real rendered surface in the hierarchy even when the
+                // guide is hidden. An empty ZStack has no hit-testable content,
+                // so contentShape alone cannot receive the drag gesture.
+                Rectangle()
+                    .fill(.white.opacity(0.001))
+                if showsGuide {
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .fill(.black.opacity(isTracking ? 0.16 : 0.08))
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .stroke(.white.opacity(isTracking ? 0.24 : 0.12), lineWidth: 1)
+                    Image(systemName: "scope")
+                        .font(.title3.weight(.medium))
+                        .foregroundStyle(.white.opacity(isTracking ? 0.72 : 0.34))
+                        .offset(
+                            x: CGFloat(normalized.x) * 18,
+                            y: CGFloat(-normalized.y) * 18
+                        )
+                    Text("LOOK")
+                        .font(.system(size: 8, weight: .bold, design: .rounded))
+                        .tracking(1.2)
+                        .foregroundStyle(.white.opacity(0.36))
+                        .offset(y: 30)
+                }
             }
             .contentShape(Rectangle())
             .gesture(
@@ -945,47 +1056,74 @@ private extension TouchAimBehavior {
 private struct VirtualStick: View {
     let title: String
     let systemImage: String
+    let showsGuide: Bool
     let onChange: (SIMD2<Float>) -> Void
 
     @State private var normalized = SIMD2<Float>.zero
+    @State private var isTracking = false
+    @State private var anchor: CGPoint?
 
     var body: some View {
         GeometryReader { geometry in
-            let diameter = min(geometry.size.width, geometry.size.height)
+            let diameter = min(min(geometry.size.width, geometry.size.height) * 0.52, 150)
             let travel = diameter * 0.27
+            let center = anchor ?? CGPoint(
+                x: geometry.size.width / 2,
+                y: geometry.size.height / 2
+            )
 
             ZStack {
-                Circle().fill(.black.opacity(0.42))
-                Circle().stroke(.white.opacity(0.34), lineWidth: 1)
-                Circle()
-                    .fill(.white.opacity(0.18))
-                    .frame(width: diameter * 0.46, height: diameter * 0.46)
-                    .overlay {
-                        Image(systemName: systemImage)
-                            .font(.caption.weight(.bold))
-                            .foregroundStyle(.white.opacity(0.8))
-                    }
-                    .offset(
-                        x: CGFloat(normalized.x) * travel,
-                        y: CGFloat(-normalized.y) * travel
-                    )
-                Text(title)
-                    .font(.system(size: 8, weight: .bold, design: .rounded))
-                    .tracking(1)
-                    .foregroundStyle(.white.opacity(0.6))
-                    .offset(y: diameter * 0.38)
+                // Visually invisible, but intentionally nonzero-alpha so the
+                // movement zone continues to participate in hit testing.
+                Rectangle()
+                    .fill(.white.opacity(0.001))
+                if showsGuide || isTracking {
+                    Circle()
+                        .fill(.black.opacity(0.42))
+                        .frame(width: diameter, height: diameter)
+                        .position(center)
+                    Circle()
+                        .stroke(.white.opacity(0.34), lineWidth: 1)
+                        .frame(width: diameter, height: diameter)
+                        .position(center)
+                    Circle()
+                        .fill(.white.opacity(0.18))
+                        .frame(width: diameter * 0.46, height: diameter * 0.46)
+                        .overlay {
+                            Image(systemName: systemImage)
+                                .font(.caption.weight(.bold))
+                                .foregroundStyle(.white.opacity(0.8))
+                        }
+                        .position(
+                            x: center.x + CGFloat(normalized.x) * travel,
+                            y: center.y - CGFloat(normalized.y) * travel
+                        )
+                    Text(title)
+                        .font(.system(size: 8, weight: .bold, design: .rounded))
+                        .tracking(1)
+                        .foregroundStyle(.white.opacity(0.6))
+                        .position(x: center.x, y: center.y + diameter * 0.38)
+                }
             }
-            .frame(width: diameter, height: diameter)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .contentShape(Circle())
+            .contentShape(Rectangle())
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { value in
-                        let center = CGPoint(x: geometry.size.width / 2, y: geometry.size.height / 2)
-                        let radius = max(diameter / 2, 1)
+                        if !isTracking {
+                            isTracking = true
+                            anchor = value.location
+                            normalized = .zero
+                            onChange(.zero)
+                            return
+                        }
+                        let activeCenter = anchor ?? value.startLocation
+                        // Reach a full N64 stick before the thumb reaches the
+                        // edge of the touch zone, making running practical.
+                        let radius = max(diameter * 0.325, 1)
                         var vector = SIMD2<Float>(
-                            Float((value.location.x - center.x) / radius),
-                            Float((center.y - value.location.y) / radius)
+                            Float((value.location.x - activeCenter.x) / radius),
+                            Float((activeCenter.y - value.location.y) / radius)
                         )
                         let magnitude = simd_length(vector)
                         if magnitude > 1 { vector /= magnitude }
@@ -993,11 +1131,15 @@ private struct VirtualStick: View {
                         onChange(vector)
                     }
                     .onEnded { _ in
+                        isTracking = false
+                        anchor = nil
                         normalized = .zero
                         onChange(.zero)
                     }
             )
         }
+        .accessibilityLabel("Move")
+        .accessibilityHint("Touch anywhere in the lower-left area, then drag to move")
     }
 }
 

--- a/Sources/TouchLayout.swift
+++ b/Sources/TouchLayout.swift
@@ -96,26 +96,27 @@ enum TouchLayoutDefaults {
         switch preset {
         case .modern, .southpaw:
             let southpaw = preset == .southpaw
-            let moveX = southpaw ? (tablet ? 0.84 : 0.83) : (tablet ? 0.16 : 0.17)
-            let lookX = southpaw ? (tablet ? 0.31 : 0.38) : (tablet ? 0.69 : 0.62)
-            // Keep the action rail clear of a landscape phone's rounded edge.
-            // Tablets have enough inset for the wider placement.
+            let moveX = southpaw ? (tablet ? 0.87 : 0.86) : (tablet ? 0.13 : 0.14)
+            let lookX = southpaw ? (tablet ? 0.22 : 0.29) : (tablet ? 0.78 : 0.71)
+            // Keep the action rail close to the look surface, but clear of a
+            // landscape phone's rounded edge.
             let fireX = southpaw
                 ? (tablet ? 0.09 : 0.13)
                 : (tablet ? 0.91 : 0.87)
-            let aimX = fireX
-            let utilityX = southpaw ? 0.22 : 0.78
-            let weaponX = southpaw ? 0.34 : 0.66
-            let utilityY = tablet ? 0.90 : 0.82
+            let weaponX = southpaw
+                ? (tablet ? 0.29 : 0.35)
+                : (tablet ? 0.71 : 0.65)
+            let crouchX = southpaw
+                ? (tablet ? 0.19 : 0.24)
+                : (tablet ? 0.81 : 0.76)
             return [
-                placement(.move, moveX, tablet ? 0.75 : 0.74, tablet ? 1.14 : 1.08),
-                placement(.look, lookX, tablet ? 0.63 : 0.59),
-                placement(.fire, fireX, 0.52, 1.16),
-                placement(.aim, aimX, 0.75, 1.00),
-                placement(.interact, fireX, 0.27, 0.94),
-                placement(.crouch, utilityX, utilityY, 0.82),
-                placement(.weapon, weaponX, utilityY, 0.82),
-                placement(.pause, 0.50, 0.11, 0.72),
+                placement(.move, moveX, tablet ? 0.82 : 0.80, tablet ? 1.14 : 1.08),
+                placement(.look, lookX, tablet ? 0.72 : 0.68),
+                placement(.fire, fireX, tablet ? 0.71 : 0.69, 1.16),
+                placement(.aim, fireX, tablet ? 0.58 : 0.55),
+                placement(.interact, fireX, tablet ? 0.84 : 0.83, 0.94),
+                placement(.crouch, crouchX, tablet ? 0.89 : 0.85, 0.82),
+                placement(.weapon, weaponX, tablet ? 0.89 : 0.85, 0.82),
             ]
         case .classic:
             return [

--- a/Support/MGB64/mgb64_mobile_config.c
+++ b/Support/MGB64/mgb64_mobile_config.c
@@ -45,7 +45,7 @@ void goldenpad_mgb64_set_fps_overlay(int enabled) {
 float g_pcGamepadDeadzone = 0.0f;
 int g_pcGamepadFpsScale = 1;
 float g_pcGamepadLookCurve = 1.0f;
-float g_pcGamepadLookSpeed = 8.0f;
+float g_pcGamepadLookSpeed = 20.0f;
 int g_pcGamepadRadialDeadzone = 1;
 int g_pcHitMarkers = 1;
 int g_pcIntroSkipStyle = 0;
@@ -58,7 +58,9 @@ int g_pcMinimapObjectives = 1;
 int g_pcMinimapSharpOverlay = 1;
 int g_pcMinimapShowAllEnemies = 0;
 int g_pcModernCrosshair = 1;
-float g_pcMouseSensAim = 0.05f;
+/* The game already reduces right-stick speed to one third while aiming. Keep
+ * the sensitivity equal here so touch input is not slowed a second time. */
+float g_pcMouseSensAim = 0.15f;
 float g_pcMouseSensitivity = 0.15f;
 int g_pcPerPixelLight = 0;
 int g_pcReticleTargetFeedback = 1;
@@ -79,13 +81,17 @@ int g_pcSteadyView = 1;
 float g_pcSunShadowRadius = 500.0f;
 int g_pcTextureAnisotropy = 16;
 char g_pcTexturePack[1024] = "";
-float g_pcViewmodelFov = 50.0f;
+/* Match the original 60-degree first-person framing. The desktop remaster's
+ * tighter 50-degree default enlarges long weapons enough to crop the sniper
+ * rifle against an iPad's bottom/right edges. */
+float g_pcViewmodelFov = 60.0f;
 float g_pcViewmodelSway = 1.0f;
 int g_pcWeaponCycleBack = 0;
 int g_pcWeaponCycleForward = 0;
 
 int goldenpad_mgb64_mobile_config_probe(void) {
     return g_pcAdsEnabled == 0 && g_pcFovY == 50.0f &&
+           g_pcViewmodelFov == 60.0f &&
            g_pcStartLevel == -1 && g_pcStartRamrom == NULL &&
            g_pcFpsOverlay == 0 &&
            g_pcFaithfulSim == 0 && g_pcTexturePack[0] == '\0' &&

--- a/Support/MGB64/mgb64_mobile_host.c
+++ b/Support/MGB64/mgb64_mobile_host.c
@@ -36,6 +36,7 @@ static int goldenpad_watchdog_loading;
 static int goldenpad_watchdog_paused;
 static u32 goldenpad_watchdog_frames;
 static pthread_mutex_t goldenpad_controller_mutex = PTHREAD_MUTEX_INITIALIZER;
+static _Atomic int goldenpad_crouch_toggle_requested;
 
 #define GOLDENPAD_FRAME_STATS_RING_CAP 1024
 #define GOLDENPAD_FRAME_STATS_PUBLISH_MS 250.0
@@ -67,11 +68,14 @@ static u16 goldenpad_controller_queued_buttons[MAXCONTROLLERS];
 
 #define GOLDENPAD_AUDIO_RING_FRAMES 65536u
 static s16 goldenpad_audio_ring[GOLDENPAD_AUDIO_RING_FRAMES * 2];
-static u32 goldenpad_audio_read_frame;
-static u32 goldenpad_audio_frame_count;
-static u32 goldenpad_audio_dropped_buffers;
+static _Atomic u64 goldenpad_audio_read_frame;
+static _Atomic u64 goldenpad_audio_write_frame;
+static _Atomic u32 goldenpad_audio_dropped_buffers;
 static PortAiStats goldenpad_audio_stats;
-static pthread_mutex_t goldenpad_audio_mutex = PTHREAD_MUTEX_INITIALIZER;
+static _Atomic int goldenpad_audio_started;
+static _Atomic u64 goldenpad_audio_callback_count;
+static _Atomic u64 goldenpad_audio_callback_requested_frames;
+static _Atomic u64 goldenpad_audio_callback_shortfall_frames;
 static _Atomic u64 goldenpad_audio_rendered_frames;
 static _Atomic u64 goldenpad_audio_nonzero_samples;
 
@@ -109,6 +113,14 @@ void goldenpad_mgb64_queue_controller_buttons(int player, u32 buttons) {
     pthread_mutex_lock(&goldenpad_controller_mutex);
     goldenpad_controller_queued_buttons[player] |= (u16)buttons;
     pthread_mutex_unlock(&goldenpad_controller_mutex);
+}
+
+void goldenpad_mgb64_request_crouch_toggle(void) {
+    atomic_store(&goldenpad_crouch_toggle_requested, 1);
+}
+
+int goldenpad_mgb64_consume_crouch_toggle(void) {
+    return atomic_exchange(&goldenpad_crouch_toggle_requested, 0);
 }
 
 void goldenpad_mgb64_read_controller_pads(OSContPad *pads) {
@@ -170,18 +182,22 @@ int goldenpad_mgb64_controller_input_probe(void) {
 
 void platformDrainEvents(void) {}
 
-/* Audio synthesis remains single-threaded on mobile. AVAudioEngine pulls the
- * real MGB64 sequence/SFX mix from this bounded PCM ring. */
+/* AVAudioEngine pulls the real MGB64 sequence/SFX mix from this bounded PCM
+ * ring. The game/audio-synth side is the sole producer and AVAudioEngine is the
+ * sole consumer, so monotonic atomic cursors avoid ever dropping a render
+ * callback merely because the producer briefly owns a mutex. */
 void portSynthLockInit(void) {}
 void portAiInit(void) {
-    pthread_mutex_lock(&goldenpad_audio_mutex);
-    goldenpad_audio_read_frame = 0;
-    goldenpad_audio_frame_count = 0;
-    goldenpad_audio_dropped_buffers = 0;
+    atomic_store(&goldenpad_audio_read_frame, 0);
+    atomic_store(&goldenpad_audio_write_frame, 0);
+    atomic_store(&goldenpad_audio_dropped_buffers, 0);
     memset(&goldenpad_audio_stats, 0, sizeof(goldenpad_audio_stats));
+    atomic_store(&goldenpad_audio_started, 0);
+    atomic_store(&goldenpad_audio_callback_count, 0);
+    atomic_store(&goldenpad_audio_callback_requested_frames, 0);
+    atomic_store(&goldenpad_audio_callback_shortfall_frames, 0);
     atomic_store(&goldenpad_audio_rendered_frames, 0);
     atomic_store(&goldenpad_audio_nonzero_samples, 0);
-    pthread_mutex_unlock(&goldenpad_audio_mutex);
     printf("[GoldenPad] MGB64 audio mixer connected to mobile PCM ring\n");
 }
 
@@ -189,108 +205,160 @@ u32 osAiGetStatus(void) { return 0; }
 s32 osAiSetFrequency(u32 frequency) { return (s32)frequency; }
 
 s32 osAiSetNextBuffer(void *buffer, u32 size) {
+    static int audio_dump_enabled = -1;
     const s16 *source = (const s16 *)buffer;
     u32 incoming_frames = size / (2u * (u32)sizeof(s16));
+    u64 read_frame;
+    u64 write_frame;
+    u64 queued_frames;
+    u64 available_frames;
     if (source == NULL || incoming_frames == 0) {
         return 0;
+    }
+    /* Diagnostic-only final-mix tap. audi_port.c's music dump runs before SFX;
+     * this matching tap runs after SFX and master gain, immediately before the
+     * mobile PCM transport. With both dumps armed, their difference isolates
+     * the effects bus without altering normal device audio. */
+    if (audio_dump_enabled < 0) {
+        audio_dump_enabled = getenv("GE007_AUDIO_DUMP") != NULL ? 1 : 0;
+    }
+    if (audio_dump_enabled) {
+        extern void portAudioDump(const void *buf, unsigned int bytes);
+        portAudioDump(buffer, size);
     }
     if (incoming_frames > GOLDENPAD_AUDIO_RING_FRAMES) {
         source += (incoming_frames - GOLDENPAD_AUDIO_RING_FRAMES) * 2u;
         incoming_frames = GOLDENPAD_AUDIO_RING_FRAMES;
     }
 
-    pthread_mutex_lock(&goldenpad_audio_mutex);
+    read_frame = atomic_load_explicit(
+        &goldenpad_audio_read_frame, memory_order_acquire);
+    write_frame = atomic_load_explicit(
+        &goldenpad_audio_write_frame, memory_order_relaxed);
+    queued_frames = write_frame >= read_frame ? write_frame - read_frame : 0;
+    if (queued_frames > GOLDENPAD_AUDIO_RING_FRAMES) {
+        queued_frames = GOLDENPAD_AUDIO_RING_FRAMES;
+    }
+    available_frames = GOLDENPAD_AUDIO_RING_FRAMES - queued_frames;
     goldenpad_audio_stats.queue_before_bytes =
-        goldenpad_audio_frame_count * 2u * (u32)sizeof(s16);
+        (u32)queued_frames * 2u * (u32)sizeof(s16);
     goldenpad_audio_stats.requested_bytes = size;
-    if (incoming_frames > GOLDENPAD_AUDIO_RING_FRAMES - goldenpad_audio_frame_count) {
-        u32 discard = incoming_frames -
-            (GOLDENPAD_AUDIO_RING_FRAMES - goldenpad_audio_frame_count);
-        goldenpad_audio_read_frame =
-            (goldenpad_audio_read_frame + discard) % GOLDENPAD_AUDIO_RING_FRAMES;
-        goldenpad_audio_frame_count -= discard;
-        goldenpad_audio_dropped_buffers++;
+    if ((u64)incoming_frames > available_frames) {
+        u32 discard = incoming_frames - (u32)available_frames;
+        source += discard * 2u;
+        incoming_frames -= discard;
+        atomic_fetch_add(&goldenpad_audio_dropped_buffers, 1);
         goldenpad_audio_stats.dropped_bytes += discard * 2u * (u32)sizeof(s16);
     }
-    u32 write_frame =
-        (goldenpad_audio_read_frame + goldenpad_audio_frame_count) %
-        GOLDENPAD_AUDIO_RING_FRAMES;
     for (u32 frame = 0; frame < incoming_frames; ++frame) {
-        u32 destination = ((write_frame + frame) % GOLDENPAD_AUDIO_RING_FRAMES) * 2u;
+        u32 destination = (u32)(
+            (write_frame + frame) % GOLDENPAD_AUDIO_RING_FRAMES) * 2u;
         goldenpad_audio_ring[destination] = source[frame * 2u];
         goldenpad_audio_ring[destination + 1u] = source[frame * 2u + 1u];
     }
-    goldenpad_audio_frame_count += incoming_frames;
+    atomic_store_explicit(
+        &goldenpad_audio_write_frame,
+        write_frame + incoming_frames,
+        memory_order_release);
+    atomic_store_explicit(&goldenpad_audio_started, 1, memory_order_release);
     goldenpad_audio_stats.accepted_bytes = incoming_frames * 2u * (u32)sizeof(s16);
     goldenpad_audio_stats.queue_after_bytes =
-        goldenpad_audio_frame_count * 2u * (u32)sizeof(s16);
+        ((u32)queued_frames + incoming_frames) * 2u * (u32)sizeof(s16);
     goldenpad_audio_stats.queue_limit_bytes = sizeof(goldenpad_audio_ring);
-    goldenpad_audio_stats.dropped_buffers = goldenpad_audio_dropped_buffers;
-    pthread_mutex_unlock(&goldenpad_audio_mutex);
+    goldenpad_audio_stats.dropped_buffers =
+        atomic_load(&goldenpad_audio_dropped_buffers);
     return 0;
 }
 
 u32 osAiGetLength(void) {
-    u32 bytes;
-    pthread_mutex_lock(&goldenpad_audio_mutex);
-    bytes = goldenpad_audio_frame_count * 2u * (u32)sizeof(s16);
-    pthread_mutex_unlock(&goldenpad_audio_mutex);
-    return bytes;
+    u64 read_frame = atomic_load_explicit(
+        &goldenpad_audio_read_frame, memory_order_acquire);
+    u64 write_frame = atomic_load_explicit(
+        &goldenpad_audio_write_frame, memory_order_acquire);
+    u64 queued_frames = write_frame >= read_frame ? write_frame - read_frame : 0;
+    if (queued_frames > GOLDENPAD_AUDIO_RING_FRAMES) {
+        queued_frames = GOLDENPAD_AUDIO_RING_FRAMES;
+    }
+    return (u32)queued_frames * 2u * (u32)sizeof(s16);
 }
 
 int osAiQueueBelowLimit(void) {
-    int below;
-    pthread_mutex_lock(&goldenpad_audio_mutex);
-    below = goldenpad_audio_frame_count < GOLDENPAD_AUDIO_RING_FRAMES / 2u;
-    pthread_mutex_unlock(&goldenpad_audio_mutex);
-    return below;
+    return osAiGetLength() <
+        (GOLDENPAD_AUDIO_RING_FRAMES / 2u) * 2u * (u32)sizeof(s16);
 }
 
 u32 portAiGetDroppedBufferCount(void) {
-    u32 count;
-    pthread_mutex_lock(&goldenpad_audio_mutex);
-    count = goldenpad_audio_dropped_buffers;
-    pthread_mutex_unlock(&goldenpad_audio_mutex);
-    return count;
+    return atomic_load(&goldenpad_audio_dropped_buffers);
 }
 void portAiGetStats(PortAiStats *stats) {
     if (stats == NULL) {
         return;
     }
-    pthread_mutex_lock(&goldenpad_audio_mutex);
     *stats = goldenpad_audio_stats;
-    pthread_mutex_unlock(&goldenpad_audio_mutex);
 }
 
 u32 goldenpad_mgb64_audio_render(float *left, float *right, u32 frames) {
-    u32 produced = 0;
+    u64 read_frame;
+    u64 write_frame;
+    u64 available_frames;
+    u32 produced;
     u32 nonzero = 0;
     if (left == NULL || right == NULL) {
         return 0;
     }
-    if (pthread_mutex_trylock(&goldenpad_audio_mutex) == 0) {
-        produced = frames < goldenpad_audio_frame_count
-            ? frames : goldenpad_audio_frame_count;
-        for (u32 frame = 0; frame < produced; ++frame) {
-            u32 source =
-                ((goldenpad_audio_read_frame + frame) % GOLDENPAD_AUDIO_RING_FRAMES) * 2u;
-            left[frame] = (float)goldenpad_audio_ring[source] / 32768.0f;
-            right[frame] = (float)goldenpad_audio_ring[source + 1u] / 32768.0f;
-            nonzero += goldenpad_audio_ring[source] != 0;
-            nonzero += goldenpad_audio_ring[source + 1u] != 0;
-        }
-        goldenpad_audio_read_frame =
-            (goldenpad_audio_read_frame + produced) % GOLDENPAD_AUDIO_RING_FRAMES;
-        goldenpad_audio_frame_count -= produced;
-        pthread_mutex_unlock(&goldenpad_audio_mutex);
+    read_frame = atomic_load_explicit(
+        &goldenpad_audio_read_frame, memory_order_relaxed);
+    write_frame = atomic_load_explicit(
+        &goldenpad_audio_write_frame, memory_order_acquire);
+    available_frames = write_frame >= read_frame ? write_frame - read_frame : 0;
+    if (available_frames > GOLDENPAD_AUDIO_RING_FRAMES) {
+        available_frames = GOLDENPAD_AUDIO_RING_FRAMES;
     }
+    produced = frames < available_frames ? frames : (u32)available_frames;
+    for (u32 frame = 0; frame < produced; ++frame) {
+        u32 source = (u32)(
+            (read_frame + frame) % GOLDENPAD_AUDIO_RING_FRAMES) * 2u;
+        left[frame] = (float)goldenpad_audio_ring[source] / 32768.0f;
+        right[frame] = (float)goldenpad_audio_ring[source + 1u] / 32768.0f;
+        nonzero += goldenpad_audio_ring[source] != 0;
+        nonzero += goldenpad_audio_ring[source + 1u] != 0;
+    }
+    atomic_store_explicit(
+        &goldenpad_audio_read_frame,
+        read_frame + produced,
+        memory_order_release);
     for (u32 frame = produced; frame < frames; ++frame) {
         left[frame] = 0.0f;
         right[frame] = 0.0f;
     }
+    if (atomic_load_explicit(&goldenpad_audio_started, memory_order_acquire)) {
+        atomic_fetch_add(&goldenpad_audio_callback_count, 1);
+        atomic_fetch_add(&goldenpad_audio_callback_requested_frames, frames);
+        atomic_fetch_add(
+            &goldenpad_audio_callback_shortfall_frames, frames - produced);
+    }
     atomic_fetch_add(&goldenpad_audio_rendered_frames, produced);
     atomic_fetch_add(&goldenpad_audio_nonzero_samples, nonzero);
     return produced;
+}
+
+void goldenpad_mgb64_audio_callback_stats(
+    u64 *callbacks, u64 *requested_frames, u64 *rendered_frames,
+    u64 *shortfall_frames) {
+    if (callbacks != NULL) {
+        *callbacks = atomic_load(&goldenpad_audio_callback_count);
+    }
+    if (requested_frames != NULL) {
+        *requested_frames = atomic_load(
+            &goldenpad_audio_callback_requested_frames);
+    }
+    if (rendered_frames != NULL) {
+        *rendered_frames = atomic_load(&goldenpad_audio_rendered_frames);
+    }
+    if (shortfall_frames != NULL) {
+        *shortfall_frames = atomic_load(
+            &goldenpad_audio_callback_shortfall_frames);
+    }
 }
 
 int goldenpad_mgb64_audio_output_probe(void) {

--- a/Support/MGB64/mgb64_mobile_os.c
+++ b/Support/MGB64/mgb64_mobile_os.c
@@ -14,6 +14,7 @@
 #include "game/chrobjhandler.h"
 #include "game/file2.h"
 #include "game/loadobjectmodel.h"
+#include "game/lvl.h"
 #include "game/mp_music.h"
 #include "game/objective_status.h"
 #include "game/player.h"
@@ -66,6 +67,12 @@ static _Atomic int goldenpad_gameplay_trigger_timer;
 static _Atomic int goldenpad_gameplay_watch_state;
 static _Atomic int goldenpad_gameplay_outside_watch = 1;
 static _Atomic int goldenpad_gameplay_pausing;
+static _Atomic int goldenpad_player_vitals_ready;
+static _Atomic int goldenpad_player_health = 1000;
+static _Atomic int goldenpad_player_armor;
+static int goldenpad_combat_last_stage = -1;
+static int goldenpad_combat_last_difficulty = -1;
+static int goldenpad_combat_last_health = -1;
 static _Atomic int goldenpad_scripted_mission_success_requested;
 static _Atomic int goldenpad_scripted_mission_success_applied;
 static _Atomic int goldenpad_progression_ready;
@@ -1117,9 +1124,20 @@ s32 osContGetReadData(OSContPad *pads) {
     extern s32 port_front_hover_folder;
     extern f32 cursor_h_pos;
     extern f32 cursor_v_pos;
+    extern int g_pcCrouchRequest;
+    extern int goldenpad_mgb64_consume_crouch_toggle(void);
     save_data *dam_save;
 
     goldenpad_mgb64_read_controller_pads(pads);
+    if (goldenpad_mgb64_consume_crouch_toggle()) {
+        if (g_StageNum != LEVELID_TITLE &&
+            g_CurrentPlayer != NULL &&
+            g_CurrentPlayer->prop != NULL &&
+            !g_CurrentPlayer->bonddead) {
+            g_pcCrouchRequest = 1;
+            fprintf(stderr, "[GoldenPad] Native crouch toggle accepted\n");
+        }
+    }
 
     /*
      * Diagnostics-only mission seam. This deliberately mirrors MGB64's
@@ -1193,6 +1211,58 @@ s32 osContGetReadData(OSContPad *pads) {
         atomic_store(&goldenpad_gameplay_pausing, g_CurrentPlayer->pausing_flag);
     } else {
         atomic_store(&goldenpad_gameplay_ready, 0);
+    }
+
+    if (g_StageNum != LEVELID_TITLE &&
+        g_CurrentPlayer != NULL &&
+        g_CurrentPlayer->prop != NULL) {
+        int health = (int)(g_CurrentPlayer->bondhealth * 1000.0f);
+        int armor = (int)(g_CurrentPlayer->bondarmour * 1000.0f);
+        int selected_difficulty = (int)lvlGetSelectedDifficulty();
+        if (health < 0) health = 0;
+        if (health > 1000) health = 1000;
+        if (armor < 0) armor = 0;
+        if (armor > 1000) armor = 1000;
+        atomic_store(&goldenpad_player_health, health);
+        atomic_store(&goldenpad_player_armor, armor);
+        atomic_store(&goldenpad_player_vitals_ready, 1);
+        if (goldenpad_combat_last_stage != g_StageNum ||
+            goldenpad_combat_last_difficulty != selected_difficulty) {
+            fprintf(stderr,
+                    "[GoldenPad] Combat state stage=%d difficulty=%d "
+                    "ai_accuracy=%.3f ai_damage=%.3f invincible=(%d,%d)\n",
+                    g_StageNum,
+                    selected_difficulty,
+                    g_AiAccuracyModifier,
+                    g_AiDamageModifier,
+                    g_CurrentPlayer->bondinvincible,
+                    g_PlayerInvincible);
+        }
+        if (goldenpad_combat_last_health >= 0 &&
+            goldenpad_combat_last_health != health) {
+            fprintf(stderr,
+                    "[GoldenPad] Health delta stage=%d difficulty=%d "
+                    "health=%d->%d armor=%d damage_show=%d "
+                    "ai_accuracy=%.3f ai_damage=%.3f invincible=(%d,%d)\n",
+                    g_StageNum,
+                    selected_difficulty,
+                    goldenpad_combat_last_health,
+                    health,
+                    armor,
+                    bondviewGetIfCurrentPlayerDamageShowTime(),
+                    g_AiAccuracyModifier,
+                    g_AiDamageModifier,
+                    g_CurrentPlayer->bondinvincible,
+                    g_PlayerInvincible);
+        }
+        goldenpad_combat_last_stage = g_StageNum;
+        goldenpad_combat_last_difficulty = selected_difficulty;
+        goldenpad_combat_last_health = health;
+    } else {
+        atomic_store(&goldenpad_player_vitals_ready, 0);
+        goldenpad_combat_last_stage = -1;
+        goldenpad_combat_last_difficulty = -1;
+        goldenpad_combat_last_health = -1;
     }
 
     if (g_StageNum == LEVELID_FACILITY) {
@@ -1297,6 +1367,12 @@ void goldenpad_mgb64_gameplay_state(
         *outside_watch = atomic_load(&goldenpad_gameplay_outside_watch);
     }
     if (pausing != NULL) *pausing = atomic_load(&goldenpad_gameplay_pausing);
+}
+
+void goldenpad_mgb64_player_vitals(int *ready, int *health, int *armor) {
+    if (ready != NULL) *ready = atomic_load(&goldenpad_player_vitals_ready);
+    if (health != NULL) *health = atomic_load(&goldenpad_player_health);
+    if (armor != NULL) *armor = atomic_load(&goldenpad_player_armor);
 }
 
 void goldenpad_mgb64_request_scripted_mission_success(void) {

--- a/Support/MGB64/mgb64_rom_bridge.c
+++ b/Support/MGB64/mgb64_rom_bridge.c
@@ -151,6 +151,9 @@ extern void portWatchdogInit(void);
 static void *goldenpad_mgb64_game_thread(void *unused) {
     (void)unused;
     pthread_setname_np("GoldenEye game");
+    /* The original sniper root is oversized at the iPad camera FOV. Keep an
+     * explicit launch override available, but use a compact mobile default. */
+    setenv("GE007_FP_HEAVY_SCALE", "0.72", 0);
     portAudioInit();
     portWatchdogInit();
     atomic_store(&goldenpad_game_state, 2);

--- a/patches/mgb64-ios-fast3d.patch
+++ b/patches/mgb64-ios-fast3d.patch
@@ -11,6 +11,110 @@ diff --git a/src/game/rsp.c b/src/game/rsp.c
      {
          size_t dl_size = (size_t)((u8 *)gdl - (u8 *)firstGdl);
          if (dl_size > 512 * 1024) {
+diff --git a/src/game/bondview.c b/src/game/bondview.c
+--- a/src/game/bondview.c
++++ b/src/game/bondview.c
+@@ -12002,6 +12002,17 @@ static void bondviewApplyNativeMoveIntent(struct MoveData *moveData, s8 stick_x
+     /* Native mouse/right-stick look owns camera pitch in gameplay. */
+     moveData->canNaturalPitch = 0;
+     moveData->analogPitch = 0;
++    moveData->disableLookAhead = 1;
++
++    /* The original controller path recenters pitch while Bond runs. Relative
++     * touch look and a modern right stick need the camera to remain where the
++     * player left it, including while the movement stick is held. */
++    if (g_CurrentPlayer != NULL) {
++        g_CurrentPlayer->automovecentre = FALSE;
++        g_CurrentPlayer->field_104 = 0;
++        g_CurrentPlayer->field_10C = 0;
++        g_CurrentPlayer->speedverta = 0.0f;
++    }
+
+     if (in_tank_flag == 1) {
+         /* In the tank, WASD is a driving surface: W/S throttle, A/D hull
+diff --git a/src/game/lvl.c b/src/game/lvl.c
+index 481a099..b5b3e78 100644
+--- a/src/game/lvl.c
++++ b/src/game/lvl.c
+@@ -391,6 +391,10 @@ s32 D_80048380 = 0;
+  * local_player_number (get_cur_playernum(), 0..MAXCONTROLLERS-1). */
+ static f32 s_gpLookRemX[MAXCONTROLLERS];
+ static f32 s_gpLookRemY[MAXCONTROLLERS];
++/* Once a player has supplied native vertical look, that pitch belongs to the
++ * relative mouse/right-stick path. Preserve it across the retail movement
++ * update, which otherwise eases the camera back toward look-ahead. */
++static s32 s_nativePitchOwned[MAXCONTROLLERS];
+
+ void pcResetGamepadLookRemainders(void)
+ {
+@@ -398,6 +402,7 @@ void pcResetGamepadLookRemainders(void)
+     for (i = 0; i < MAXCONTROLLERS; i++) {
+         s_gpLookRemX[i] = 0.0f;
+         s_gpLookRemY[i] = 0.0f;
++        s_nativePitchOwned[i] = 0;
+     }
+ }
+ #endif
+@@ -5861,6 +5866,10 @@ void lvlViewMoveTick(void)
+     s32 padding;
+     f32 temp_f0;
+     f32 temp_f2;
++#ifdef NATIVE_PORT
++    f32 native_pitch_before_move = 0.0f;
++    s32 native_pitch_was_owned = 0;
++#endif
+
+ #ifdef NATIVE_PORT
+     /* Skip gameplay tick entirely if level has no geometry data (stub levels) */
+@@ -5868,6 +5877,13 @@ void lvlViewMoveTick(void)
+ #endif
+
+     local_player_number = get_cur_playernum();
++#ifdef NATIVE_PORT
++    if (local_player_number >= 0 && local_player_number < MAXCONTROLLERS
++        && g_CurrentPlayer != NULL && s_nativePitchOwned[local_player_number]) {
++        native_pitch_before_move = g_CurrentPlayer->vv_verta;
++        native_pitch_was_owned = 1;
++    }
++#endif
+     cheat_buttons_mp_related();
+
+ #ifdef NATIVE_PORT
+@@ -5938,6 +5954,12 @@ void lvlViewMoveTick(void)
+             int mdx = 0, mdy = 0;
+             int grx = 0, gry = 0;
+             int live_look_allowed = pcNativeLiveLookAllowed();
++            int restored_native_pitch = 0;
++            if (live_look_allowed && native_pitch_was_owned) {
++                g_CurrentPlayer->vv_verta = native_pitch_before_move;
++                g_CurrentPlayer->speedverta = 0.0f;
++                restored_native_pitch = 1;
++            }
+             if (local_player_number == 0) {
+                 platformGetMouseDelta(&mdx, &mdy);
+             }
+@@ -6069,6 +6091,9 @@ void lvlViewMoveTick(void)
+                     g_CurrentPlayer->vv_theta += (f32)mdx * sens;
+                 }
+                 g_CurrentPlayer->vv_verta -= (f32)mdy * sens * (g_pcInvertY ? -1.0f : 1.0f);
++                if (mdy != 0) {
++                    s_nativePitchOwned[local_player_number] = 1;
++                }
+
+                 /* Wrap theta [0, 360) */
+                 while (g_CurrentPlayer->vv_theta < 0.0f)
+@@ -6098,6 +6123,11 @@ void lvlViewMoveTick(void)
+                  * world is shearing or leaning. */
+                 bondviewApplyVertaTheta();
+                 bondviewSyncViewBasisFromHead();
++            } else if (restored_native_pitch) {
++                /* The movement update already refreshed the basis using its
++                 * recentered pitch. Rebuild it after restoring the held angle. */
++                bondviewApplyVertaTheta();
++                bondviewSyncViewBasisFromHead();
+             }
+
+             /* Sync the PC rendering camera from the player's world position.
 diff --git a/src/platform/fast3d/gfx_pc.c b/src/platform/fast3d/gfx_pc.c
 index ae43b27..18fde7a 100644
 --- a/src/platform/fast3d/gfx_pc.c
@@ -122,3 +226,115 @@ index ae43b27..18fde7a 100644
  }
 
  void gfx_register_n64_dl_region(void *addr, size_t size) {
+
+diff --git a/src/platform/audio_pc.c b/src/platform/audio_pc.c
+index cef844e..e89a781 100644
+--- a/src/platform/audio_pc.c
++++ b/src/platform/audio_pc.c
+@@ -101,6 +101,8 @@ typedef struct {
+     u8  stopOnGainEnd;
+     u8  fxMix;
+     s32 delaySamples;
++    s32 autoReleaseSamplesRemaining;
++    s32 releaseSamples;
+     s32 active;
+ } PortVoice;
+
+@@ -697,11 +699,25 @@ static void portAudioSetVoiceEnvelopeLocked(PortVoice *voice, const PortSfxPlayP
+     voice->envSamplesRemaining = 0;
+     voice->envDecayTarget = 1.0f;
+     voice->envDecaySamples = 0;
++    voice->autoReleaseSamplesRemaining = -1;
++    voice->releaseSamples = 0;
+
+     if (!params || !params->useEnvelope) {
+         return;
+     }
+
++    /* The native sound player automatically posts STOP after attack+decay,
++     * then ramps through release. PORT_SND_STUBS bypasses that event queue,
++     * so carry the same authored lifetime on the mixer voice. A decay time of
++     * -1 is the native marker for a sustained sound that must be stopped by
++     * its owner. */
++    if (params->decayTime >= 0) {
++        voice->autoReleaseSamplesRemaining =
++            portAudioMicrosecondsToSamples(params->attackTime) +
++            portAudioMicrosecondsToSamples(params->decayTime);
++        voice->releaseSamples = portAudioMicrosecondsToSamples(params->releaseTime);
++    }
++
+     voice->envEnabled = 1;
+     voice->envDecayTarget = portAudioClamp01((f32)params->decayVolume / 127.0f);
+     voice->envDecaySamples = portAudioMicrosecondsToSamples(params->decayTime);
+@@ -763,6 +779,23 @@ static void portAudioAdvanceRampsLocked(PortVoice *voice)
+             }
+         }
+     }
++
++    if (voice->autoReleaseSamplesRemaining >= 0) {
++        if (voice->autoReleaseSamplesRemaining > 0) {
++            voice->autoReleaseSamplesRemaining--;
++        }
++        if (voice->autoReleaseSamplesRemaining == 0) {
++            voice->autoReleaseSamplesRemaining = -1;
++            if (voice->releaseSamples > 0) {
++                portAudioStartGainRampLocked(voice, 0.0f, voice->releaseSamples);
++                voice->stopOnGainEnd = 1;
++            } else {
++                voice->active = 0;
++                voice->stopOnGainEnd = 0;
++                s_sfxMixStats.voiceStops++;
++            }
++        }
++    }
+ }
+
+ static void portAudioComputeSpatial(f32 worldX, f32 worldY, f32 worldZ,
+@@ -1080,7 +1113,14 @@ static int portTraceWeaponAudio(void)
+  * (alAudioFrame + the libaudio low-pass) lives in audi_port.c
+  * (portAudioSynthWorkerRunJob) so it can reach that file's static synth state;
+  * this file owns only the thread + handshake. */
++#ifdef MGB64_APPLE_MOBILE
++/* Mobile rendering and the game simulation are separately paced. Keep the
++ * expensive music synth off the game thread so audio work cannot create
++ * visible frame hitches; the established worker adds one frame of latency. */
++static s32 s_audioSynthThread = 1;
++#else
+ static s32 s_audioSynthThread = 0;   /* Audio.SynthThread: 0/1, default 0 */
++#endif
+
+ #ifndef __EMSCRIPTEN__
+ #include <pthread.h>
+@@ -1838,6 +1878,7 @@ void portAudioReleaseVoice(s32 voiceIdx, ALMicroTime releaseUsec)
+     SDL_LockMutex(s_audioMutex);
+     if (s_voices[voiceIdx].active) {
+         wasActive = 1;
++        s_voices[voiceIdx].autoReleaseSamplesRemaining = -1;
+         if (releaseSamples > 0) {
+             portAudioStartGainRampLocked(&s_voices[voiceIdx], 0.0f, releaseSamples);
+             s_voices[voiceIdx].stopOnGainEnd = 1;
+diff --git a/src/platform/audio_pc.h b/src/platform/audio_pc.h
+index 671a14e..fea68d7 100644
+--- a/src/platform/audio_pc.h
++++ b/src/platform/audio_pc.h
+@@ -15,3 +15,4 @@ typedef struct PortSfxPlayParams_s {
+     ALMicroTime attackTime;
+     ALMicroTime decayTime;
++    ALMicroTime releaseTime;
+ } PortSfxPlayParams;
+diff --git a/src/snd.c b/src/snd.c
+index 180dfb2..3c3fed8 100644
+--- a/src/snd.c
++++ b/src/snd.c
+@@ -991,4 +991,9 @@ ALSoundState *sndPlaySfx(struct ALBankAlt_s *soundBank, s16 soundIndex, ALSoundS
+                 params.decayVolume = chainSound->envelope->decayVolume;
+-                params.attackTime = chainSound->envelope->attackTime;
+-                params.decayTime = chainSound->envelope->decayTime;
++                params.attackTime = (ALMicroTime)
++                    ((f32)chainSound->envelope->attackTime / params.pitch);
++                params.decayTime = chainSound->envelope->decayTime < 0
++                    ? -1
++                    : (ALMicroTime)((f32)chainSound->envelope->decayTime / params.pitch);
++                params.releaseTime = (ALMicroTime)
++                    ((f32)chainSound->envelope->releaseTime / params.pitch);
+             }

--- a/scripts/verify-mgb64-ios-core.sh
+++ b/scripts/verify-mgb64-ios-core.sh
@@ -104,6 +104,7 @@ do
     nm -gU "$binary" | grep -q '_goldenpad_mgb64_eeprom_snapshot'
     nm -gU "$binary" | grep -q '_goldenpad_mgb64_runtime_state'
     nm -gU "$binary" | grep -q '_goldenpad_mgb64_gameplay_state'
+    nm -gU "$binary" | grep -q '_goldenpad_mgb64_player_vitals'
     nm -gU "$binary" | grep -q '_goldenpad_mgb64_request_scripted_mission_success'
     nm -gU "$binary" | grep -q '_goldenpad_mgb64_progression_state'
     nm -gU "$binary" | grep -q '_goldenpad_mgb64_dam_route_state'

--- a/scripts/verify-mgb64-ios-renderer.sh
+++ b/scripts/verify-mgb64-ios-renderer.sh
@@ -104,6 +104,7 @@ do
         _goldenpad_mgb64_eeprom_snapshot \
         _goldenpad_mgb64_runtime_state \
         _goldenpad_mgb64_gameplay_state \
+        _goldenpad_mgb64_player_vitals \
         _goldenpad_mgb64_request_scripted_mission_success \
         _goldenpad_mgb64_progression_state \
         _goldenpad_mgb64_dam_route_state \
@@ -112,6 +113,7 @@ do
         _goldenpad_mgb64_dam_nav_linked_door_state \
         _goldenpad_mgb64_dam_nav_guard_state \
         _goldenpad_mgb64_queue_controller_buttons \
+        _goldenpad_mgb64_request_crouch_toggle \
         _goldenpad_mgb64_frame_stats_set_active \
         _goldenpad_mgb64_frame_stats_snapshot \
         _goldenpad_mgb64_set_fps_overlay \


### PR DESCRIPTION
## Summary

- rework the iPad touch layout for two-thumb play, including floating movement, touch-only look gain, aligned top controls, and a visible health HUD
- bridge Duck to the native crouch toggle, preserve touch pitch, and correct oversized sniper presentation
- stabilize the mobile PCM transport and add bounded combat, frame, and renderer diagnostics
- extend the iOS verification scripts for the new runtime bridges

## Validation

- `GOLDENPAD_DEVELOPMENT_TEAM=VKDH2T9UTF Scripts/verify-mgb64-ios-core.sh`
- `GOLDENPAD_DEVELOPMENT_TEAM=VKDH2T9UTF Scripts/verify-mgb64-ios-renderer.sh`
- signed build installed and launched on the attached physical iPad
- user ROM copied after installation and read back with matching SHA-1 `7dd376e996d77d108316ac7ced087125c5674fa4`
- EEPROM save read back before and after installation with matching SHA-1 `25529466f2538ee77e8c260eb5ebeba49e95894c`
