### PR TITLE
Promote playable RT64 recomp prototype

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ set(GOLDENPAD_RT64_ARCHIVE_DIR "" CACHE PATH "Directory containing the four RT64
 set(GOLDENPAD_RT64_SOURCE_DIR "" CACHE PATH "Pinned RT64 source checkout used for Plume headers")
 set(GOLDENPAD_MGB64_SOURCE_DIR "" CACHE PATH "Pinned MGB64 checkout used for the native game core")
 option(GOLDENPAD_MGB64_RENDERER "Link the opt-in MGB64 Fast3D/Metal renderer probe" OFF)
+option(GOLDENPAD_RECOMP_PROTOTYPE "Build the isolated RT64/N64Recomp prototype host" OFF)
+set(GOLDENPAD_RECOMP_BUNDLE_IDENTIFIER "com.chrissotraidis.goldenpad.recomp-prototype" CACHE STRING
+    "Bundle identifier used by the isolated recompilation prototype")
+set(GOLDENPAD_RECOMP_RT64_ARCHIVE_DIR "" CACHE PATH "Directory containing verified RT64 mobile archives for the prototype")
+set(GOLDENPAD_RECOMP_RT64_SOURCE_DIR "" CACHE PATH "Pinned RT64 source checkout used for prototype headers")
 
 set(goldenpad_rt64_bridge Support/RT64/rt64_bridge_stub.cpp)
 if(GOLDENPAD_RT64_ARCHIVE_DIR)
@@ -35,6 +40,69 @@ if(GOLDENPAD_RT64_ARCHIVE_DIR)
             message(FATAL_ERROR "Missing RT64 archive: ${archive}")
         endif()
     endforeach()
+endif()
+
+if(GOLDENPAD_RECOMP_PROTOTYPE)
+    set(goldenpad_recomp_rt64_bridge Support/RecompPrototype/recomp_rt64_surface_stub.cpp)
+    if(GOLDENPAD_RECOMP_RT64_ARCHIVE_DIR)
+        if(NOT GOLDENPAD_RECOMP_RT64_SOURCE_DIR)
+            message(FATAL_ERROR "GOLDENPAD_RECOMP_RT64_SOURCE_DIR is required when linking prototype RT64")
+        endif()
+        set(goldenpad_recomp_rt64_bridge Support/RecompPrototype/recomp_rt64_surface_bridge.cpp)
+        set(goldenpad_recomp_rt64_archives
+            "${GOLDENPAD_RECOMP_RT64_ARCHIVE_DIR}/rt64.a"
+            "${GOLDENPAD_RECOMP_RT64_ARCHIVE_DIR}/libplume.a"
+            "${GOLDENPAD_RECOMP_RT64_ARCHIVE_DIR}/libre-spirv.a"
+            "${GOLDENPAD_RECOMP_RT64_ARCHIVE_DIR}/libzstd.a"
+        )
+        foreach(archive IN LISTS goldenpad_recomp_rt64_archives)
+            if(NOT EXISTS "${archive}")
+                message(FATAL_ERROR "Missing prototype RT64 archive: ${archive}")
+            endif()
+        endforeach()
+    endif()
+
+    add_executable(GoldenPadRecompPrototype MACOSX_BUNDLE
+        Assets.xcassets
+        Config/ThirdPartyNotices.txt
+        Sources/RecompPrototypeApp.swift
+        Sources/RecompPrototypeMetalCanvas.swift
+        ${goldenpad_recomp_rt64_bridge}
+    )
+    set_target_properties(GoldenPadRecompPrototype PROPERTIES
+        MACOSX_BUNDLE TRUE
+        MACOSX_BUNDLE_BUNDLE_NAME "GoldenPad Recomp Prototype"
+        MACOSX_BUNDLE_GUI_IDENTIFIER "${GOLDENPAD_RECOMP_BUNDLE_IDENTIFIER}"
+        MACOSX_BUNDLE_SHORT_VERSION_STRING "0.0.1"
+        MACOSX_BUNDLE_BUNDLE_VERSION "1"
+        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Config/Info.plist.in"
+        XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
+        XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO"
+        XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon"
+        XCODE_ATTRIBUTE_GENERATE_INFOPLIST_FILE "NO"
+        XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "17.0"
+        XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${GOLDENPAD_RECOMP_BUNDLE_IDENTIFIER}"
+        XCODE_ATTRIBUTE_SUPPORTED_PLATFORMS "iphoneos iphonesimulator"
+        XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST "NO"
+        XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2"
+        XCODE_ATTRIBUTE_SWIFT_VERSION "5.0"
+    )
+    set_source_files_properties(Assets.xcassets Config/ThirdPartyNotices.txt
+        PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
+    target_link_libraries(GoldenPadRecompPrototype PRIVATE
+        "-framework SwiftUI"
+        "-framework Metal"
+        "-framework MetalKit"
+        "-framework QuartzCore"
+        "-framework UIKit"
+    )
+    if(GOLDENPAD_RECOMP_RT64_ARCHIVE_DIR)
+        target_include_directories(GoldenPadRecompPrototype PRIVATE
+            "${GOLDENPAD_RECOMP_RT64_SOURCE_DIR}/src/contrib/plume")
+        foreach(archive IN LISTS goldenpad_recomp_rt64_archives)
+            target_link_options(GoldenPadRecompPrototype PRIVATE "LINKER:-force_load,${archive}")
+        endforeach()
+    endif()
 endif()
 
 add_executable(GoldenPad MACOSX_BUNDLE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ set(GOLDENPAD_RECOMP_BUNDLE_IDENTIFIER "com.chrissotraidis.goldenpad.recomp-prot
     "Bundle identifier used by the isolated recompilation prototype")
 set(GOLDENPAD_RECOMP_RT64_ARCHIVE_DIR "" CACHE PATH "Directory containing verified RT64 mobile archives for the prototype")
 set(GOLDENPAD_RECOMP_RT64_SOURCE_DIR "" CACHE PATH "Pinned RT64 source checkout used for prototype headers")
+set(GOLDENPAD_RECOMP_AOT_DIR "" CACHE PATH "Private directory containing generated GoldenEye AOT sources")
+set(GOLDENPAD_RECOMP_RUNTIME_SOURCE_DIR "" CACHE PATH "Private pinned N64ModernRuntime source directory for the prototype")
+set(GOLDENPAD_RECOMP_RUNTIME_ARCHIVE_DIR "" CACHE PATH "Private AOT-only N64ModernRuntime archive directory for the prototype")
+set(GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR "" CACHE PATH "Pinned GoldenEye recompilation source used only by the prototype RT64 context")
 
 set(goldenpad_rt64_bridge Support/RT64/rt64_bridge_stub.cpp)
 if(GOLDENPAD_RT64_ARCHIVE_DIR)
@@ -43,7 +47,15 @@ if(GOLDENPAD_RT64_ARCHIVE_DIR)
 endif()
 
 if(GOLDENPAD_RECOMP_PROTOTYPE)
+    set(goldenpad_recomp_code_signing_allowed NO)
+    set(goldenpad_recomp_code_signing_required NO)
+    if(GOLDENPAD_DEVELOPMENT_TEAM)
+        set(goldenpad_recomp_code_signing_allowed YES)
+        set(goldenpad_recomp_code_signing_required YES)
+    endif()
     set(goldenpad_recomp_rt64_bridge Support/RecompPrototype/recomp_rt64_surface_stub.cpp)
+    set(goldenpad_recomp_aot_sources)
+    set(goldenpad_recomp_runtime_archives)
     if(GOLDENPAD_RECOMP_RT64_ARCHIVE_DIR)
         if(NOT GOLDENPAD_RECOMP_RT64_SOURCE_DIR)
             message(FATAL_ERROR "GOLDENPAD_RECOMP_RT64_SOURCE_DIR is required when linking prototype RT64")
@@ -62,12 +74,64 @@ if(GOLDENPAD_RECOMP_PROTOTYPE)
         endforeach()
     endif()
 
+    if(GOLDENPAD_RECOMP_AOT_DIR OR GOLDENPAD_RECOMP_RUNTIME_SOURCE_DIR OR GOLDENPAD_RECOMP_RUNTIME_ARCHIVE_DIR OR GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR)
+        if(NOT GOLDENPAD_RECOMP_AOT_DIR OR NOT GOLDENPAD_RECOMP_RUNTIME_SOURCE_DIR OR NOT GOLDENPAD_RECOMP_RUNTIME_ARCHIVE_DIR OR NOT GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR)
+            message(FATAL_ERROR "GOLDENPAD_RECOMP_AOT_DIR, GOLDENPAD_RECOMP_RUNTIME_SOURCE_DIR, GOLDENPAD_RECOMP_RUNTIME_ARCHIVE_DIR, and GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR must be set together")
+        endif()
+        if(NOT GOLDENPAD_RECOMP_RT64_ARCHIVE_DIR)
+            message(FATAL_ERROR "GOLDENPAD_RECOMP_RT64_ARCHIVE_DIR is required for the AOT prototype")
+        endif()
+
+        file(GLOB goldenpad_recomp_aot_c CONFIGURE_DEPENDS
+            "${GOLDENPAD_RECOMP_AOT_DIR}/RecompiledFuncs/*.c")
+        set(goldenpad_recomp_patch_sources
+            "${GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR}/RecompiledPatches/patches.c"
+            "${GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR}/RecompiledPatches/patches_bin.c"
+            "${GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR}/src/main/register_patches.cpp")
+        foreach(patch_source IN LISTS goldenpad_recomp_patch_sources)
+            if(NOT EXISTS "${patch_source}")
+                message(FATAL_ERROR
+                    "Missing upstream recomp patch output: ${patch_source}. Generate RecompiledPatches before configuring the AOT prototype.")
+            endif()
+        endforeach()
+        set(goldenpad_recomp_aot_sources
+            ${goldenpad_recomp_patch_sources}
+            ${goldenpad_recomp_aot_c}
+            "${GOLDENPAD_RECOMP_AOT_DIR}/RecompiledFuncs/lookup.cpp"
+            "${GOLDENPAD_RECOMP_AOT_DIR}/rsp/aspMain.cpp"
+            Support/RecompPrototype/recomp_aot_link_bridge.cpp
+            Support/RecompPrototype/recomp_game_start.cpp
+            Support/RecompPrototype/recomp_register_overlays.cpp
+            Support/RecompPrototype/recomp_ultra_shims.cpp
+            Support/RecompPrototype/recomp_ui_stub.cpp
+            "${GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR}/src/main/rt64_render_context.cpp")
+        set_source_files_properties(
+            "${GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR}/src/main/rt64_render_context.cpp"
+            PROPERTIES COMPILE_OPTIONS
+            "-include;${CMAKE_CURRENT_SOURCE_DIR}/Support/RecompPrototype/rt64_namespace_compat.hpp")
+        set(goldenpad_recomp_runtime_archives
+            "${GOLDENPAD_RECOMP_RUNTIME_ARCHIVE_DIR}/ultramodern/libultramodern.a"
+            "${GOLDENPAD_RECOMP_RUNTIME_ARCHIVE_DIR}/librecomp/liblibrecomp.a"
+            "${GOLDENPAD_RECOMP_RUNTIME_ARCHIVE_DIR}/librecomp/N64Recomp/libN64Recomp.a"
+            "${GOLDENPAD_RECOMP_RUNTIME_ARCHIVE_DIR}/librecomp/N64Recomp/librabbitizer.a"
+            "${GOLDENPAD_RECOMP_RUNTIME_ARCHIVE_DIR}/librecomp/N64Recomp/lib/fmt/libfmt.a"
+            "${GOLDENPAD_RECOMP_RUNTIME_ARCHIVE_DIR}/librecomp/N64Recomp/libSymbolLists.a")
+        foreach(archive IN LISTS goldenpad_recomp_runtime_archives)
+            if(NOT EXISTS "${archive}")
+                message(FATAL_ERROR "Missing AOT runtime archive: ${archive}")
+            endif()
+        endforeach()
+    endif()
+
     add_executable(GoldenPadRecompPrototype MACOSX_BUNDLE
         Assets.xcassets
         Config/ThirdPartyNotices.txt
         Sources/RecompPrototypeApp.swift
+        Sources/RecompPrototypeAudio.swift
+        Sources/RecompPrototypeInput.swift
         Sources/RecompPrototypeMetalCanvas.swift
         ${goldenpad_recomp_rt64_bridge}
+        ${goldenpad_recomp_aot_sources}
     )
     set_target_properties(GoldenPadRecompPrototype PROPERTIES
         MACOSX_BUNDLE TRUE
@@ -75,9 +139,11 @@ if(GOLDENPAD_RECOMP_PROTOTYPE)
         MACOSX_BUNDLE_GUI_IDENTIFIER "${GOLDENPAD_RECOMP_BUNDLE_IDENTIFIER}"
         MACOSX_BUNDLE_SHORT_VERSION_STRING "0.0.1"
         MACOSX_BUNDLE_BUNDLE_VERSION "1"
-        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Config/Info.plist.in"
-        XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
-        XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO"
+        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Config/RecompPrototypeInfo.plist.in"
+        XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "${goldenpad_recomp_code_signing_allowed}"
+        XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "${goldenpad_recomp_code_signing_required}"
+        XCODE_ATTRIBUTE_CODE_SIGN_STYLE "Automatic"
+        XCODE_ATTRIBUTE_DEVELOPMENT_TEAM "${GOLDENPAD_DEVELOPMENT_TEAM}"
         XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon"
         XCODE_ATTRIBUTE_GENERATE_INFOPLIST_FILE "NO"
         XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "17.0"
@@ -86,11 +152,15 @@ if(GOLDENPAD_RECOMP_PROTOTYPE)
         XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST "NO"
         XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2"
         XCODE_ATTRIBUTE_SWIFT_VERSION "5.0"
+        XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++20"
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED TRUE
     )
     set_source_files_properties(Assets.xcassets Config/ThirdPartyNotices.txt
         PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
     target_link_libraries(GoldenPadRecompPrototype PRIVATE
         "-framework SwiftUI"
+        "-framework AVFAudio"
         "-framework Metal"
         "-framework MetalKit"
         "-framework QuartzCore"
@@ -100,6 +170,37 @@ if(GOLDENPAD_RECOMP_PROTOTYPE)
         target_include_directories(GoldenPadRecompPrototype PRIVATE
             "${GOLDENPAD_RECOMP_RT64_SOURCE_DIR}/src/contrib/plume")
         foreach(archive IN LISTS goldenpad_recomp_rt64_archives)
+            target_link_options(GoldenPadRecompPrototype PRIVATE "LINKER:-force_load,${archive}")
+        endforeach()
+    endif()
+    if(GOLDENPAD_RECOMP_AOT_DIR)
+        target_compile_definitions(GoldenPadRecompPrototype PRIVATE
+            GOLDENPAD_RECOMP_AOT_LINKED=1
+            RT64_EMBEDDED_APPLE=1)
+        target_include_directories(GoldenPadRecompPrototype PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/Support/RecompPrototype"
+            "${GOLDENPAD_RECOMP_AOT_DIR}/RecompiledFuncs"
+            "${GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR}/RecompiledPatches"
+            "${GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR}/include"
+            "${GOLDENPAD_RECOMP_RUNTIME_SOURCE_DIR}/librecomp/include"
+            "${GOLDENPAD_RECOMP_RUNTIME_SOURCE_DIR}/ultramodern/include"
+            "${GOLDENPAD_RECOMP_RUNTIME_SOURCE_DIR}/N64Recomp/include"
+            "${GOLDENPAD_RECOMP_RUNTIME_SOURCE_DIR}/N64Recomp/lib/rabbitizer/include"
+            "${GOLDENPAD_RECOMP_RUNTIME_SOURCE_DIR}/N64Recomp/lib/rabbitizer/cplusplus/include"
+            "${GOLDENPAD_RECOMP_RUNTIME_SOURCE_DIR}/thirdparty"
+            "${GOLDENPAD_RECOMP_RUNTIME_SOURCE_DIR}/thirdparty/concurrentqueue"
+            "${GOLDENPAD_RECOMP_RUNTIME_SOURCE_DIR}/thirdparty/sse2neon"
+            "${GOLDENPAD_RECOMP_RT64_SOURCE_DIR}/src"
+            "${GOLDENPAD_RECOMP_RT64_SOURCE_DIR}/src/rhi"
+            "${GOLDENPAD_RECOMP_RT64_SOURCE_DIR}/src/contrib"
+            "${GOLDENPAD_RECOMP_RT64_SOURCE_DIR}/src/contrib/hlslpp/include"
+            "${GOLDENPAD_RECOMP_RT64_SOURCE_DIR}/src/contrib/mupen64plus-win32-deps/SDL2-2.26.3/include")
+        set_source_files_properties(${goldenpad_recomp_aot_c} PROPERTIES
+            COMPILE_OPTIONS "-Wno-implicit-function-declaration")
+        set_source_files_properties(
+            "${GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR}/RecompiledPatches/patches.c"
+            PROPERTIES COMPILE_OPTIONS "-fno-strict-aliasing;-Wno-implicit-function-declaration")
+        foreach(archive IN LISTS goldenpad_recomp_runtime_archives)
             target_link_options(GoldenPadRecompPrototype PRIVATE "LINKER:-force_load,${archive}")
         endforeach()
     endif()

--- a/Config/RecompPrototypeInfo.plist.in
+++ b/Config/RecompPrototypeInfo.plist.in
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleDisplayName</key>
+    <string>GoldenPad Recomp</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>GoldenPad Recomp Prototype</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.0.1</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.games</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>arm64</string>
+        <string>metal</string>
+    </array>
+    <key>UIRequiresFullScreen</key>
+    <true/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+</dict>
+</plist>

--- a/Sources/RecompPrototypeApp.swift
+++ b/Sources/RecompPrototypeApp.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+@main
+struct GoldenPadRecompPrototypeApp: App {
+    @StateObject private var surface = RecompPrototypeSurface()
+
+    var body: some Scene {
+        WindowGroup {
+            ZStack(alignment: .bottomLeading) {
+                RecompPrototypeMetalCanvas(surface: surface)
+                    .ignoresSafeArea()
+                Text(surface.status)
+                    .font(.footnote.monospaced())
+                    .foregroundStyle(.white)
+                    .padding(12)
+                    .background(.black.opacity(0.7), in: RoundedRectangle(cornerRadius: 8))
+                    .padding()
+            }
+        }
+    }
+}

--- a/Sources/RecompPrototypeApp.swift
+++ b/Sources/RecompPrototypeApp.swift
@@ -1,21 +1,365 @@
+import Foundation
 import SwiftUI
+import UIKit
+
+enum RecompPrototypeResolutionMode: String, CaseIterable {
+    case native
+    case double
+    case automatic
+
+    var title: String {
+        switch self {
+        case .native: "Native N64"
+        case .double: "2×"
+        case .automatic: "Automatic high resolution"
+        }
+    }
+
+    var nativeValue: Int32 {
+        switch self {
+        case .native: 0
+        case .double: 1
+        case .automatic: 2
+        }
+    }
+}
 
 @main
 struct GoldenPadRecompPrototypeApp: App {
     @StateObject private var surface = RecompPrototypeSurface()
+    @StateObject private var input = RecompPrototypeInput()
+    @StateObject private var audio = RecompPrototypeAudio()
+    @Environment(\.scenePhase) private var scenePhase
+    @AppStorage("recomp.lookSensitivity") private var lookSensitivity = 4.0
+    @AppStorage("recomp.aimBehavior") private var aimBehavior = RecompPrototypeAimBehavior.toggle.rawValue
+    @AppStorage("recomp.controllerLookMode") private var controllerLookMode = RecompPrototypeControllerLookMode.analog.rawValue
+    @AppStorage("recomp.invertAimY") private var invertAimY = false
+    @AppStorage("recomp.reticleEnabled") private var reticleEnabled = false
+    @AppStorage("recomp.msaaEnabled") private var msaaEnabled = true
+    @AppStorage("recomp.resolutionMode") private var resolutionMode = RecompPrototypeResolutionMode.automatic.rawValue
+    @AppStorage("recomp.threePointFiltering") private var threePointFiltering = true
+    @AppStorage("recomp.unlockAllMissions") private var unlockAllMissions = false
+    @State private var presentedSheet: RecompPrototypeSheet?
 
     var body: some Scene {
         WindowGroup {
-            ZStack(alignment: .bottomLeading) {
-                RecompPrototypeMetalCanvas(surface: surface)
+            ZStack(alignment: .topTrailing) {
+                Color.black
                     .ignoresSafeArea()
-                Text(surface.status)
-                    .font(.footnote.monospaced())
-                    .foregroundStyle(.white)
-                    .padding(12)
-                    .background(.black.opacity(0.7), in: RoundedRectangle(cornerRadius: 8))
-                    .padding()
+                RecompPrototypeMetalCanvas(
+                    surface: surface,
+                    msaaEnabled: msaaEnabled,
+                    resolutionMode: RecompPrototypeResolutionMode(rawValue: resolutionMode) ?? .automatic,
+                    threePointFiltering: threePointFiltering
+                )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .clipped()
+                    .ignoresSafeArea()
+                if reticleEnabled {
+                    RecompPrototypeReticle()
+                        .allowsHitTesting(false)
+                        .accessibilityHidden(true)
+                }
+                if input.externalControllerName == nil {
+                    RecompPrototypeTouchControls(input: input)
+                        .ignoresSafeArea()
+                }
+                utilityMenu
+                    .padding(.top, 10)
+                    .padding(.trailing, 14)
+            }
+            .onAppear {
+                input.configureLookSensitivity(lookSensitivity)
+                input.configureAimBehavior(aimBehavior)
+                input.configureControllerLookMode(controllerLookMode)
+                input.configureInvertAimY(invertAimY)
+                input.configureUnlockAllMissions(unlockAllMissions)
+                surface.setAppActive(true)
+                audio.activate()
+            }
+            .onChange(of: lookSensitivity) { _, value in
+                input.configureLookSensitivity(value)
+            }
+            .onChange(of: aimBehavior) { _, value in
+                input.configureAimBehavior(value)
+            }
+            .onChange(of: controllerLookMode) { _, value in
+                input.configureControllerLookMode(value)
+            }
+            .onChange(of: invertAimY) { _, value in
+                input.configureInvertAimY(value)
+            }
+            .onChange(of: unlockAllMissions) { _, value in
+                input.configureUnlockAllMissions(value)
+            }
+            .onChange(of: scenePhase) { _, phase in
+                switch phase {
+                case .active:
+                    surface.setAppActive(true)
+                    audio.activate()
+                case .inactive, .background:
+                    audio.deactivate()
+                    surface.setAppActive(false)
+                @unknown default:
+                    audio.deactivate()
+                    surface.setAppActive(false)
+                }
+            }
+            .sheet(item: $presentedSheet) { sheet in
+                switch sheet.content {
+                case .settings:
+                    RecompPrototypeSettingsView(
+                        lookSensitivity: Binding(
+                            get: { lookSensitivity },
+                            set: { lookSensitivity = $0 }
+                        ),
+                        aimBehavior: $aimBehavior,
+                        controllerLookMode: $controllerLookMode,
+                        invertAimY: $invertAimY,
+                        reticleEnabled: $reticleEnabled,
+                        msaaEnabled: $msaaEnabled,
+                        resolutionMode: $resolutionMode,
+                        threePointFiltering: $threePointFiltering,
+                        unlockAllMissions: $unlockAllMissions,
+                        runtimeStatus: surface.status,
+                        audioStatus: audio.status,
+                        controllerName: input.externalControllerName
+                    )
+                case let .share(url):
+                    RecompPrototypeShareSheet(items: [url])
+                }
             }
         }
+    }
+
+    private var utilityMenu: some View {
+        Menu {
+            Button("Settings", systemImage: "gearshape") {
+                presentedSheet = RecompPrototypeSheet(content: .settings)
+            }
+            Button("Share Diagnostics & Logs…", systemImage: "square.and.arrow.up") {
+                let url = RecompPrototypeDiagnostics.makeReport(
+                    runtimeStatus: surface.status,
+                    audioStatus: audio.status,
+                    controllerName: input.externalControllerName,
+                    lookSensitivity: lookSensitivity,
+                    aimBehavior: aimBehavior,
+                    controllerLookMode: controllerLookMode,
+                    invertAimY: invertAimY,
+                    reticleEnabled: reticleEnabled,
+                    msaaEnabled: msaaEnabled,
+                    resolutionMode: resolutionMode,
+                    threePointFiltering: threePointFiltering,
+                    unlockAllMissions: unlockAllMissions
+                )
+                presentedSheet = RecompPrototypeSheet(content: .share(url))
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 19, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 44, height: 44)
+                .background(.black.opacity(0.62), in: Circle())
+                .overlay(Circle().stroke(.white.opacity(0.34), lineWidth: 1))
+        }
+        .accessibilityLabel("GoldenPad menu")
+    }
+}
+
+private struct RecompPrototypeSheet: Identifiable {
+    enum Content {
+        case settings
+        case share(URL)
+    }
+
+    let id = UUID()
+    let content: Content
+}
+
+private struct RecompPrototypeSettingsView: View {
+    @Binding var lookSensitivity: Double
+    @Binding var aimBehavior: String
+    @Binding var controllerLookMode: String
+    @Binding var invertAimY: Bool
+    @Binding var reticleEnabled: Bool
+    @Binding var msaaEnabled: Bool
+    @Binding var resolutionMode: String
+    @Binding var threePointFiltering: Bool
+    @Binding var unlockAllMissions: Bool
+    let runtimeStatus: String
+    let audioStatus: String
+    let controllerName: String?
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Graphics") {
+                    Picker("Resolution", selection: $resolutionMode) {
+                        ForEach(RecompPrototypeResolutionMode.allCases, id: \.rawValue) { mode in
+                            Text(mode.title).tag(mode.rawValue)
+                        }
+                    }
+                    Toggle("2× anti-aliasing", isOn: $msaaEnabled)
+                    Toggle("N64 three-point texture filtering", isOn: $threePointFiltering)
+                    Text("Graphics changes apply on the next app launch. No HD texture pack is installed; these options change how RT64 renders the original ROM assets.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    LabeledContent("Presentation", value: "Original rate (stable)")
+                    LabeledContent("Renderer", value: "RT64 Metal")
+                }
+                Section("Controls") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Touch look sensitivity")
+                            Spacer()
+                            Text(String(format: "%.2f×", lookSensitivity))
+                                .foregroundStyle(.secondary)
+                        }
+                        Slider(value: $lookSensitivity, in: 0.5...8.0, step: 0.25)
+                    }
+                    Text("GoldenPad touch tuning keeps the old 1.5× swipe accumulation and 4.0× default. Experimental analog uses the old controller's 0.15 dead zone, 1.5 response curve, and slower aim rate; C-buttons bypasses the modern camera patch.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    Picker("Aim button", selection: $aimBehavior) {
+                        ForEach(RecompPrototypeAimBehavior.allCases, id: \.rawValue) { behavior in
+                            Text(behavior.title).tag(behavior.rawValue)
+                        }
+                    }
+                    Picker("Controller right stick", selection: $controllerLookMode) {
+                        ForEach(RecompPrototypeControllerLookMode.allCases, id: \.rawValue) { mode in
+                            Text(mode.title).tag(mode.rawValue)
+                        }
+                    }
+                    Toggle("Invert vertical while aiming", isOn: $invertAimY)
+                    Toggle("Center reticle", isOn: $reticleEnabled)
+                    LabeledContent("Duck", value: "Toggle")
+                    LabeledContent("Xbox / MFi", value: "LT aim • RT fire")
+                    Text("Left stick moves; right stick replaces the N64 C-button look controls. A/Y changes weapon, B/X acts, LB ducks, RB changes weapon, and Menu is Start.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                Section("Cheats & Testing") {
+                    Toggle("Unlock all missions", isOn: $unlockAllMissions)
+                    Text("Changes mission-select availability only. It does not mark missions complete or modify GoldenEye save data.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                Section("Runtime") {
+                    LabeledContent("Game", value: runtimeStatus)
+                    LabeledContent("Audio", value: audioStatus)
+                    LabeledContent("Controller", value: controllerName ?? "Touch")
+                }
+            }
+            .navigationTitle("GoldenPad Settings")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+private struct RecompPrototypeShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ controller: UIActivityViewController, context: Context) {}
+}
+
+private enum RecompPrototypeDiagnostics {
+    private static let sharedTailLimit = 512 * 1024
+
+    static func makeReport(
+        runtimeStatus: String,
+        audioStatus: String,
+        controllerName: String?,
+        lookSensitivity: Double,
+        aimBehavior: String,
+        controllerLookMode: String,
+        invertAimY: Bool,
+        reticleEnabled: Bool,
+        msaaEnabled: Bool,
+        resolutionMode: String,
+        threePointFiltering: Bool,
+        unlockAllMissions: Bool
+    ) -> URL {
+        let manager = FileManager.default
+        let support = manager.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("GoldenPadRecomp", isDirectory: true)
+        let logs = support.appendingPathComponent("Logs", isDirectory: true)
+        let latest = logs.appendingPathComponent("goldenpad-recomp-latest.log")
+        let previous = logs.appendingPathComponent("goldenpad-recomp-previous.log")
+        let destination = manager.temporaryDirectory
+            .appendingPathComponent("GoldenPad-Recomp-Diagnostics.txt")
+        let home = NSHomeDirectory()
+        let report = """
+        GoldenPad Recomp Diagnostics
+        ============================
+        Runtime: \(runtimeStatus)
+        Audio: \(audioStatus)
+        Input: \(controllerName ?? "Touch")
+        Look sensitivity: \(String(format: "%.2f", lookSensitivity))x
+        Aim behavior: \(aimBehavior)
+        Controller right stick: \((RecompPrototypeControllerLookMode(rawValue: controllerLookMode) ?? .analog).title)
+        Invert vertical while aiming: \(invertAimY ? "On" : "Off")
+        Center reticle: \(reticleEnabled ? "On" : "Off")
+        Unlock all missions: \(unlockAllMissions ? "On (mission select only; EEPROM unchanged)" : "Off")
+        Graphics: RT64 Metal, \((RecompPrototypeResolutionMode(rawValue: resolutionMode) ?? .automatic).title), \(msaaEnabled ? "2x MSAA" : "MSAA off"), \(threePointFiltering ? "three-point filtering" : "linear filtering"), original presentation rate
+        Device: \(UIDevice.current.model) / iOS \(UIDevice.current.systemVersion)
+
+        Previous Session
+        ----------------
+        \(tail(of: previous, home: home))
+
+        Current Session
+        ---------------
+        \(tail(of: latest, home: home))
+        """
+        try? report.write(to: destination, atomically: true, encoding: .utf8)
+        return destination
+    }
+
+    private static func tail(of url: URL, home: String) -> String {
+        guard let handle = try? FileHandle(forReadingFrom: url) else {
+            return "No log was available."
+        }
+        defer { try? handle.close() }
+        let length = (try? handle.seekToEnd()) ?? 0
+        if length > UInt64(sharedTailLimit) {
+            try? handle.seek(toOffset: length - UInt64(sharedTailLimit))
+        } else {
+            try? handle.seek(toOffset: 0)
+        }
+        guard let data = try? handle.readToEnd() else {
+            return "The log could not be read."
+        }
+        return String(decoding: data, as: UTF8.self)
+            .replacingOccurrences(of: home, with: "<HOME>")
+            .replacingOccurrences(of: NSTemporaryDirectory(), with: "<TEMP>/")
+    }
+}
+
+private struct RecompPrototypeReticle: View {
+    var body: some View {
+        ZStack {
+            Circle()
+                .stroke(.white.opacity(0.88), lineWidth: 1)
+                .frame(width: 12, height: 12)
+            Rectangle()
+                .fill(.white.opacity(0.88))
+                .frame(width: 1, height: 22)
+            Rectangle()
+                .fill(.white.opacity(0.88))
+                .frame(width: 22, height: 1)
+            Circle()
+                .fill(.white.opacity(0.92))
+                .frame(width: 2, height: 2)
+        }
+        .shadow(color: .black.opacity(0.8), radius: 1, x: 0, y: 1)
     }
 }

--- a/Sources/RecompPrototypeAudio.swift
+++ b/Sources/RecompPrototypeAudio.swift
@@ -1,0 +1,156 @@
+import AVFAudio
+import Foundation
+
+@_silgen_name("goldenpad_recomp_audio_render")
+private func goldenPadRecompAudioRender(
+    _ left: UnsafeMutablePointer<Float>?,
+    _ right: UnsafeMutablePointer<Float>?,
+    _ frames: UInt32
+) -> UInt32
+
+@_silgen_name("goldenpad_recomp_audio_stats")
+private func goldenPadRecompAudioStats(
+    _ queuedFrames: UnsafeMutablePointer<UInt64>?,
+    _ renderedFrames: UnsafeMutablePointer<UInt64>?,
+    _ nonzeroSamples: UnsafeMutablePointer<UInt64>?,
+    _ droppedFrames: UnsafeMutablePointer<UInt64>?,
+    _ underrunFrames: UnsafeMutablePointer<UInt64>?,
+    _ underrunCallbacks: UnsafeMutablePointer<UInt64>?
+)
+
+@MainActor
+final class RecompPrototypeAudio: ObservableObject {
+    @Published private(set) var status = "audio: inactive"
+
+    private let engine = AVAudioEngine()
+    private var sourceNode: AVAudioSourceNode?
+    private var observers: [NSObjectProtocol] = []
+    private var statsTimer: Timer?
+
+    init() {
+        let center = NotificationCenter.default
+        observers.append(center.addObserver(
+            forName: AVAudioSession.interruptionNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            Task { @MainActor in self?.handleInterruption(notification) }
+        })
+        observers.append(center.addObserver(
+            forName: AVAudioSession.routeChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.activate() }
+        })
+    }
+
+    deinit {
+        statsTimer?.invalidate()
+        engine.stop()
+        observers.forEach(NotificationCenter.default.removeObserver)
+    }
+
+    func activate() {
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.ambient, mode: .default)
+            try session.setActive(true)
+            try startEngine()
+            status = "audio: native PCM ready"
+            startStatsPolling()
+            print("[GoldenPadRecomp] audio: AVAudioEngine active at \(session.sampleRate) Hz")
+        } catch {
+            status = "audio: unavailable"
+            print("[GoldenPadRecomp] audio: activation failed: \(error.localizedDescription)")
+        }
+    }
+
+    func deactivate() {
+        engine.pause()
+        statsTimer?.invalidate()
+        statsTimer = nil
+        try? AVAudioSession.sharedInstance().setActive(
+            false,
+            options: .notifyOthersOnDeactivation
+        )
+        status = "audio: inactive"
+    }
+
+    private func startEngine() throws {
+        if sourceNode == nil {
+            guard let format = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: 22_050,
+                channels: 2,
+                interleaved: false
+            ) else {
+                throw NSError(domain: "GoldenPadRecomp.Audio", code: 1)
+            }
+            let source = AVAudioSourceNode(format: format) {
+                _, _, frameCount, audioBufferList -> OSStatus in
+                let buffers = UnsafeMutableAudioBufferListPointer(audioBufferList)
+                guard buffers.count >= 2,
+                      let leftData = buffers[0].mData,
+                      let rightData = buffers[1].mData else {
+                    return noErr
+                }
+                _ = goldenPadRecompAudioRender(
+                    leftData.assumingMemoryBound(to: Float.self),
+                    rightData.assumingMemoryBound(to: Float.self),
+                    UInt32(frameCount)
+                )
+                return noErr
+            }
+            engine.attach(source)
+            engine.connect(source, to: engine.mainMixerNode, format: format)
+            sourceNode = source
+            engine.prepare()
+        }
+        if !engine.isRunning {
+            try engine.start()
+        }
+    }
+
+    private func startStatsPolling() {
+        statsTimer?.invalidate()
+        statsTimer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                var queued: UInt64 = 0
+                var rendered: UInt64 = 0
+                var nonzero: UInt64 = 0
+                var dropped: UInt64 = 0
+                var underrunFrames: UInt64 = 0
+                var underrunCallbacks: UInt64 = 0
+                goldenPadRecompAudioStats(
+                    &queued, &rendered, &nonzero, &dropped,
+                    &underrunFrames, &underrunCallbacks
+                )
+                if rendered > 0 && nonzero > 0 {
+                    self.status = "audio: playing"
+                }
+                print(
+                    "[GoldenPadRecomp] audio: queued=\(queued) rendered=\(rendered) " +
+                    "nonzero=\(nonzero) dropped=\(dropped) " +
+                    "underrunFrames=\(underrunFrames) underrunCallbacks=\(underrunCallbacks)"
+                )
+            }
+        }
+    }
+
+    private func handleInterruption(_ notification: Notification) {
+        guard
+            let rawType = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+            let type = AVAudioSession.InterruptionType(rawValue: rawType)
+        else { return }
+        switch type {
+        case .began:
+            status = "audio: interrupted"
+        case .ended:
+            activate()
+        @unknown default:
+            status = "audio: interrupted"
+        }
+    }
+}

--- a/Sources/RecompPrototypeInput.swift
+++ b/Sources/RecompPrototypeInput.swift
@@ -1,0 +1,549 @@
+import Foundation
+import GameController
+import SwiftUI
+import simd
+
+@_silgen_name("goldenpad_recomp_set_controller_state")
+private func goldenPadRecompSetControllerState(
+    _ buttons: UInt32,
+    _ stickX: Int32,
+    _ stickY: Int32
+)
+
+@_silgen_name("goldenpad_recomp_set_right_analog")
+private func goldenPadRecompSetRightAnalog(_ x: Int32, _ y: Int32)
+
+@_silgen_name("goldenpad_recomp_set_controller_connected")
+private func goldenPadRecompSetControllerConnected(_ connected: Int32)
+
+@_silgen_name("goldenpad_recomp_queue_touch_look")
+private func goldenPadRecompQueueTouchLook(_ x: Int32, _ y: Int32)
+
+@_silgen_name("goldenpad_recomp_request_crouch_toggle")
+private func goldenPadRecompRequestCrouchToggle()
+
+@_silgen_name("goldenpad_recomp_set_invert_aim_y")
+private func goldenPadRecompSetInvertAimY(_ enabled: Int32)
+
+@_silgen_name("goldenpad_recomp_set_unlock_all_missions")
+private func goldenPadRecompSetUnlockAllMissions(_ enabled: Int32)
+
+enum RecompPrototypeAimBehavior: String, CaseIterable {
+    case toggle
+    case hold
+
+    var title: String {
+        switch self {
+        case .toggle: "Toggle"
+        case .hold: "Hold"
+        }
+    }
+}
+
+enum RecompPrototypeControllerLookMode: String, CaseIterable {
+    case analog
+    case classic
+    case off
+
+    var title: String {
+        switch self {
+        case .analog: "Modern analog (experimental)"
+        case .classic: "Original N64 C-buttons"
+        case .off: "Off"
+        }
+    }
+}
+
+@MainActor
+final class RecompPrototypeInput: ObservableObject {
+    private enum N64 {
+        static let a: UInt16 = 0x8000
+        static let b: UInt16 = 0x4000
+        static let z: UInt16 = 0x2000
+        static let start: UInt16 = 0x1000
+        static let dpadUp: UInt16 = 0x0800
+        static let dpadDown: UInt16 = 0x0400
+        static let dpadLeft: UInt16 = 0x0200
+        static let dpadRight: UInt16 = 0x0100
+        static let l: UInt16 = 0x0020
+        static let r: UInt16 = 0x0010
+        static let cUp: UInt16 = 0x0008
+        static let cDown: UInt16 = 0x0004
+        static let cLeft: UInt16 = 0x0002
+        static let cRight: UInt16 = 0x0001
+    }
+
+    @Published private(set) var externalControllerName: String?
+    @Published private(set) var touchAimActive = false
+    @Published private(set) var aimBehavior = RecompPrototypeAimBehavior.toggle
+    @Published private(set) var controllerLookMode = RecompPrototypeControllerLookMode.analog
+    private var touchButtons: UInt16 = 0
+    private var touchMovement = SIMD2<Float>.zero
+    private var touchLook = SIMD2<Float>.zero
+    private var touchCrouchIsPressed = false
+    private var controllerCrouchWasPressed = false
+    private var lookSensitivity: Float = 4.0
+    private var controller: GCController?
+    private var observers: [NSObjectProtocol] = []
+    private var ticker: Timer?
+
+    init() {
+        refreshController()
+        let center = NotificationCenter.default
+        observers.append(center.addObserver(forName: .GCControllerDidConnect, object: nil, queue: .main) { [weak self] _ in
+            Task { @MainActor in self?.refreshController() }
+        })
+        observers.append(center.addObserver(forName: .GCControllerDidDisconnect, object: nil, queue: .main) { [weak self] _ in
+            Task { @MainActor in self?.refreshController() }
+        })
+        ticker = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.publish() }
+        }
+        publish()
+    }
+
+    deinit {
+        ticker?.invalidate()
+        observers.forEach(NotificationCenter.default.removeObserver)
+    }
+
+    func setMovement(_ value: SIMD2<Float>) {
+        touchMovement = clamp(value)
+        publish()
+    }
+
+    func configureLookSensitivity(_ value: Double) {
+        lookSensitivity = Float(min(max(value, 0.5), 8.0))
+    }
+
+    func configureAimBehavior(_ rawValue: String) {
+        let next = RecompPrototypeAimBehavior(rawValue: rawValue) ?? .toggle
+        guard aimBehavior != next else { return }
+        aimBehavior = next
+        touchAimActive = false
+        setButton(N64.r, pressed: false)
+    }
+
+    func configureControllerLookMode(_ rawValue: String) {
+        controllerLookMode = RecompPrototypeControllerLookMode(rawValue: rawValue) ?? .analog
+        publish()
+    }
+
+    func configureInvertAimY(_ enabled: Bool) {
+        goldenPadRecompSetInvertAimY(enabled ? 1 : 0)
+    }
+
+    func configureUnlockAllMissions(_ enabled: Bool) {
+        goldenPadRecompSetUnlockAllMissions(enabled ? 1 : 0)
+    }
+
+    func setLook(_ value: SIMD2<Float>) {
+        // Preserve GoldenPad's tuned relative-look path: amplify each swipe
+        // delta by 1.5x and accumulate until the next 60 Hz publication.
+        guard value != .zero else { return }
+        touchLook = clamp(touchLook + value * 1.5)
+    }
+
+    func setCrouchPressed(_ pressed: Bool) {
+        if pressed && !touchCrouchIsPressed {
+            goldenPadRecompRequestCrouchToggle()
+        }
+        touchCrouchIsPressed = pressed
+    }
+
+    func toggleAim() {
+        touchAimActive.toggle()
+        setButton(N64.r, pressed: touchAimActive)
+    }
+
+    func setAimPressed(_ pressed: Bool) {
+        touchAimActive = pressed
+        setButton(N64.r, pressed: pressed)
+    }
+
+    func setButton(_ button: UInt16, pressed: Bool) {
+        if pressed {
+            touchButtons |= button
+        } else {
+            touchButtons &= ~button
+        }
+        publish()
+    }
+
+    func releaseTouchInput() {
+        touchButtons = 0
+        touchAimActive = false
+        touchMovement = .zero
+        touchLook = .zero
+        touchCrouchIsPressed = false
+        publish()
+    }
+
+    private func refreshController() {
+        controller = GCController.controllers().first(where: { $0.extendedGamepad != nil })
+        controllerCrouchWasPressed = false
+        externalControllerName = controller.map { $0.vendorName ?? "External controller" }
+        if controller != nil {
+            releaseTouchInput()
+        }
+        goldenPadRecompSetControllerConnected(controller == nil ? 0 : 1)
+        publish()
+    }
+
+    private func publish() {
+        var buttons = touchButtons
+        var stick = touchMovement
+        let queuedTouchLook = clamp(touchLook * lookSensitivity)
+        touchLook = .zero
+        var controllerLook = SIMD2<Float>.zero
+
+        if let gamepad = controller?.extendedGamepad {
+            stick = merge(stick, SIMD2(gamepad.leftThumbstick.xAxis.value, gamepad.leftThumbstick.yAxis.value))
+            controllerLook = SIMD2(
+                gamepad.rightThumbstick.xAxis.value,
+                gamepad.rightThumbstick.yAxis.value
+            )
+                .applyingRadialDeadZone(0.15)
+                .applyingResponseCurve(1.5)
+            if gamepad.rightTrigger.value > 0.25 { buttons |= N64.z }
+            if gamepad.leftTrigger.value > 0.25 { buttons |= N64.r }
+            if gamepad.buttonA.isPressed || gamepad.buttonY.isPressed { buttons |= N64.a }
+            if gamepad.buttonB.isPressed || gamepad.buttonX.isPressed { buttons |= N64.b }
+            if gamepad.rightShoulder.isPressed { buttons |= N64.a }
+            let controllerCrouchIsPressed = gamepad.leftShoulder.isPressed
+            if controllerCrouchIsPressed && !controllerCrouchWasPressed {
+                goldenPadRecompRequestCrouchToggle()
+            }
+            controllerCrouchWasPressed = controllerCrouchIsPressed
+            if gamepad.buttonMenu.isPressed { buttons |= N64.start }
+            if gamepad.dpad.up.isPressed { buttons |= N64.dpadUp }
+            if gamepad.dpad.down.isPressed { buttons |= N64.dpadDown }
+            if gamepad.dpad.left.isPressed { buttons |= N64.dpadLeft }
+            if gamepad.dpad.right.isPressed { buttons |= N64.dpadRight }
+        }
+
+        switch controllerLookMode {
+        case .analog:
+            break
+        case .classic:
+            let threshold: Float = 0.30
+            if controllerLook.y > threshold { buttons |= N64.cUp }
+            if controllerLook.y < -threshold { buttons |= N64.cDown }
+            if controllerLook.x < -threshold { buttons |= N64.cLeft }
+            if controllerLook.x > threshold { buttons |= N64.cRight }
+            controllerLook = .zero
+        case .off:
+            controllerLook = .zero
+        }
+
+        // The saved 4x tuning belongs to relative touch deltas. A physical
+        // right stick is an absolute value published every frame; multiplying
+        // it by 4x saturated the camera at roughly one-quarter stick travel.
+        // Keep the post-dead-zone controller value normalized instead.
+        goldenPadRecompSetControllerState(
+            UInt32(buttons),
+            Int32((clamp(stick).x * 80).rounded()),
+            Int32((clamp(stick).y * 80).rounded())
+        )
+        goldenPadRecompSetRightAnalog(
+            Int32((controllerLook.x * 32_767).rounded()),
+            Int32((controllerLook.y * 32_767).rounded())
+        )
+        if queuedTouchLook != .zero {
+            goldenPadRecompQueueTouchLook(
+                Int32((queuedTouchLook.x * 32_767).rounded()),
+                Int32((queuedTouchLook.y * 32_767).rounded())
+            )
+        }
+    }
+
+    private func merge(_ lhs: SIMD2<Float>, _ rhs: SIMD2<Float>) -> SIMD2<Float> {
+        simd_length_squared(rhs) > simd_length_squared(lhs) ? rhs : lhs
+    }
+
+    private func clamp(_ value: SIMD2<Float>) -> SIMD2<Float> {
+        let magnitude = simd_length(value)
+        return magnitude > 1 ? value / magnitude : value
+    }
+}
+
+struct RecompPrototypeTouchControls: View {
+    @ObservedObject var input: RecompPrototypeInput
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                // This is the production GoldenPad modern schema: the same
+                // movement/look zones, action rail, labels, and iPad-relative
+                // placement. Only the final N64 masks differ in this isolated
+                // runtime bridge.
+                ForEach(RecompTouchPlacement.productionSchema) { placement in
+                    control(placement, canvas: geometry.size)
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .onDisappear { input.releaseTouchInput() }
+    }
+
+    @ViewBuilder
+    private func control(_ placement: RecompTouchPlacement, canvas: CGSize) -> some View {
+        let scale = min(max(canvas.width / 720, 0.62), 1.18) * placement.scale
+        Group {
+            switch placement.id {
+            case .move:
+                RecompStick(title: placement.id.label, symbol: "figure.walk") { input.setMovement($0) }
+                    .frame(width: 300 * scale, height: 260 * scale)
+            case .look:
+                RecompLookSurface { input.setLook($0) }
+                    .frame(width: 320 * scale, height: 220 * scale)
+            case .aim:
+                if input.aimBehavior == .toggle {
+                    RecompToggleButton(
+                        title: placement.id.label,
+                        tint: placement.id.tint,
+                        activeTint: .yellow,
+                        isOn: input.touchAimActive
+                    ) {
+                        input.toggleAim()
+                    }
+                    .frame(width: 70 * scale, height: 70 * scale)
+                } else {
+                    RecompMomentaryButton(
+                        title: placement.id.label,
+                        tint: placement.id.tint,
+                        pressedTint: .yellow
+                    ) {
+                        input.setAimPressed($0)
+                    }
+                    .frame(width: 70 * scale, height: 70 * scale)
+                }
+            default:
+                RecompMomentaryButton(
+                    title: placement.id.label,
+                    tint: placement.id.tint
+                ) {
+                    if placement.id == .crouch {
+                        input.setCrouchPressed($0)
+                    } else {
+                        input.setButton(placement.id.n64Mask, pressed: $0)
+                    }
+                }
+                .frame(width: placement.id == .pause ? 64 * scale : 70 * scale,
+                       height: placement.id == .pause ? 64 * scale : 70 * scale)
+            }
+        }
+        .opacity(0.72)
+        .position(x: canvas.width * placement.x, y: canvas.height * placement.y)
+        .accessibilityLabel(placement.id.label)
+    }
+}
+
+private enum RecompTouchControlID: String {
+    case move, look, fire, aim, action, crouch, weapon, pause
+
+    var label: String {
+        switch self {
+        case .move: "MOVE"
+        case .look: "LOOK"
+        case .fire: "FIRE"
+        case .aim: "AIM"
+        case .action: "ACTION"
+        case .crouch: "DUCK"
+        case .weapon: "WEAPON"
+        case .pause: "START"
+        }
+    }
+
+    var n64Mask: UInt16 {
+        switch self {
+        case .move, .look: 0
+        case .fire: 0x2000       // Z trigger
+        case .aim: 0x0010        // R trigger
+        case .action: 0x4000     // B
+        case .crouch: 0           // Native edge-triggered crouch toggle
+        case .weapon: 0x8000     // A
+        case .pause: 0x1000      // Start
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        // GoldenEye uses Z to fire and R to aim, so those triggers stay
+        // neutral grey. The face-button actions use the N64 A/B colors.
+        case .fire: .gray
+        case .aim: .gray
+        case .weapon: .blue
+        case .action: .green
+        case .crouch: .yellow
+        case .pause: .red
+        default: .cyan
+        }
+    }
+}
+
+private extension SIMD2 where Scalar == Float {
+    func applyingRadialDeadZone(_ deadZone: Float) -> SIMD2<Float> {
+        let magnitude = simd_length(self)
+        guard magnitude > deadZone else { return .zero }
+        guard magnitude > 0 else { return .zero }
+        return (self / magnitude) * Swift.min((magnitude - deadZone) / (1 - deadZone), 1)
+    }
+
+    func applyingResponseCurve(_ exponent: Float) -> SIMD2<Float> {
+        let magnitude = simd_length(self)
+        guard magnitude > 0 else { return .zero }
+        return (self / magnitude) * pow(magnitude, exponent)
+    }
+}
+
+private struct RecompTouchPlacement: Identifiable {
+    let id: RecompTouchControlID
+    let x: CGFloat
+    let y: CGFloat
+    let scale: CGFloat
+
+    static let productionSchema: [RecompTouchPlacement] = [
+        .init(id: .move, x: 0.13, y: 0.82, scale: 1.14),
+        .init(id: .look, x: 0.78, y: 0.72, scale: 1),
+        .init(id: .fire, x: 0.91, y: 0.71, scale: 1.16),
+        .init(id: .aim, x: 0.91, y: 0.58, scale: 1),
+        .init(id: .action, x: 0.91, y: 0.84, scale: 0.94),
+        .init(id: .crouch, x: 0.81, y: 0.89, scale: 0.82),
+        .init(id: .weapon, x: 0.71, y: 0.89, scale: 0.82),
+        .init(id: .pause, x: 0.972, y: 0.14, scale: 0.78),
+    ]
+}
+
+private struct RecompStick: View {
+    let title: String
+    let symbol: String
+    let onChange: (SIMD2<Float>) -> Void
+    @State private var anchor: CGPoint?
+    @State private var value = SIMD2<Float>.zero
+
+    var body: some View {
+        GeometryReader { geometry in
+            let center = anchor ?? CGPoint(x: geometry.size.width / 2, y: geometry.size.height / 2)
+            let diameter = min(geometry.size.width, geometry.size.height) * 0.56
+            ZStack {
+                Rectangle().fill(.white.opacity(0.001))
+                Circle().fill(.black.opacity(0.33)).frame(width: diameter, height: diameter).position(center)
+                Circle().stroke(.white.opacity(0.34), lineWidth: 1).frame(width: diameter, height: diameter).position(center)
+                Circle().fill(.white.opacity(0.18)).frame(width: diameter * 0.44, height: diameter * 0.44)
+                    .overlay(Image(systemName: symbol).foregroundStyle(.white.opacity(0.8)))
+                    .position(x: center.x + CGFloat(value.x) * diameter * 0.25, y: center.y - CGFloat(value.y) * diameter * 0.25)
+                Text(title).font(.system(size: 9, weight: .bold, design: .rounded)).tracking(1).foregroundStyle(.white.opacity(0.6)).position(x: center.x, y: center.y + diameter * 0.36)
+            }
+            .contentShape(Rectangle())
+            .gesture(DragGesture(minimumDistance: 0).onChanged { gesture in
+                if anchor == nil { anchor = gesture.location }
+                let origin = anchor ?? gesture.location
+                let radius = max(diameter * 0.325, 1)
+                var next = SIMD2<Float>(Float((gesture.location.x - origin.x) / radius), Float((origin.y - gesture.location.y) / radius))
+                if simd_length(next) > 1 { next /= simd_length(next) }
+                value = next
+                onChange(next)
+            }.onEnded { _ in
+                anchor = nil
+                value = .zero
+                onChange(.zero)
+            })
+        }
+        .accessibilityLabel(title)
+    }
+}
+
+private struct RecompLookSurface: View {
+    let onChange: (SIMD2<Float>) -> Void
+    @State private var lastLocation: CGPoint?
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                RoundedRectangle(cornerRadius: 24).fill(.black.opacity(0.10))
+                RoundedRectangle(cornerRadius: 24).stroke(.white.opacity(0.14), lineWidth: 1)
+                VStack(spacing: 6) {
+                    Image(systemName: "scope").foregroundStyle(.white.opacity(0.42))
+                    Text("LOOK").font(.system(size: 9, weight: .bold, design: .rounded)).tracking(1).foregroundStyle(.white.opacity(0.42))
+                }
+            }
+            .contentShape(Rectangle())
+            .gesture(DragGesture(minimumDistance: 0).onChanged { gesture in
+                guard let previous = lastLocation else { lastLocation = gesture.location; return }
+                let scale = max(min(geometry.size.width, geometry.size.height) * 0.05, 10)
+                var next = SIMD2<Float>(Float((gesture.location.x - previous.x) / scale), Float((previous.y - gesture.location.y) / scale))
+                if simd_length(next) > 1 { next /= simd_length(next) }
+                lastLocation = gesture.location
+                onChange(next)
+            }.onEnded { _ in
+                lastLocation = nil
+                onChange(.zero)
+            })
+        }
+        .accessibilityLabel("Look")
+    }
+}
+
+private struct RecompMomentaryButton: View {
+    let title: String
+    let tint: Color
+    let pressedTint: Color
+    let onChange: (Bool) -> Void
+    @State private var pressed = false
+
+    init(
+        title: String,
+        tint: Color,
+        pressedTint: Color? = nil,
+        onChange: @escaping (Bool) -> Void
+    ) {
+        self.title = title
+        self.tint = tint
+        self.pressedTint = pressedTint ?? tint
+        self.onChange = onChange
+    }
+
+    var body: some View {
+        Text(title)
+            .font(.system(size: title == "START" ? 8 : 12, weight: .bold, design: .rounded))
+            .foregroundStyle(pressed ? .black : .white.opacity(0.96))
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(pressed ? pressedTint : tint.opacity(0.56), in: Circle())
+            .overlay(Circle().stroke(.white.opacity(0.52), lineWidth: 1))
+            .contentShape(Circle())
+            .gesture(DragGesture(minimumDistance: 0).onChanged { _ in
+                guard !pressed else { return }
+                pressed = true
+                onChange(true)
+            }.onEnded { _ in
+                pressed = false
+                onChange(false)
+            })
+            .accessibilityLabel(title)
+    }
+}
+
+private struct RecompToggleButton: View {
+    let title: String
+    let tint: Color
+    let activeTint: Color
+    let isOn: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onToggle) {
+            Text(title)
+                .font(.system(size: 12, weight: .bold, design: .rounded))
+                .foregroundStyle(isOn ? .black : .white.opacity(0.96))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(isOn ? activeTint : tint.opacity(0.56), in: Circle())
+                .overlay(Circle().stroke(.white.opacity(0.52), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .contentShape(Circle())
+        .accessibilityLabel(title)
+        .accessibilityValue(isOn ? "Locked" : "Off")
+        .accessibilityHint("Tap to lock aim so look and fire remain available")
+    }
+}

--- a/Sources/RecompPrototypeMetalCanvas.swift
+++ b/Sources/RecompPrototypeMetalCanvas.swift
@@ -10,15 +10,57 @@ private func goldenPadRecompRT64Initialize(
 @_silgen_name("goldenpad_recomp_rt64_shutdown")
 private func goldenPadRecompRT64Shutdown()
 
+@_silgen_name("goldenpad_recomp_set_msaa_enabled")
+private func goldenPadRecompSetMSAAEnabled(_ enabled: Int32)
+
+@_silgen_name("goldenpad_recomp_set_resolution_mode")
+private func goldenPadRecompSetResolutionMode(_ mode: Int32)
+
+@_silgen_name("goldenpad_recomp_set_three_point_filtering")
+private func goldenPadRecompSetThreePointFiltering(_ enabled: Int32)
+
+@_silgen_name("goldenpad_recomp_set_app_active")
+private func goldenPadRecompSetAppActive(_ active: Int32)
+
+#if GOLDENPAD_RECOMP_AOT_LINKED
+@_silgen_name("goldenpad_recomp_start_game")
+private func goldenPadRecompStartGame(
+    _ window: UnsafeMutableRawPointer,
+    _ view: UnsafeMutableRawPointer,
+    _ romPath: UnsafePointer<CChar>,
+    _ configPath: UnsafePointer<CChar>
+) -> UnsafePointer<CChar>?
+
+@_silgen_name("goldenpad_recomp_game_status")
+private func goldenPadRecompGameStatus() -> UnsafePointer<CChar>?
+#endif
+
 @MainActor
 final class RecompPrototypeSurface: ObservableObject {
     @Published private(set) var status = "RT64 prototype: preparing Metal surface"
     private weak var metalView: MTKView?
     private var commandQueue: MTLCommandQueue?
+    private var rendererInitialized = false
+    private var gameLaunchRequested = false
+    private var statusTimer: Timer?
 
     func attach(to view: MTKView) {
         metalView = view
         commandQueue = view.device?.makeCommandQueue()
+    }
+
+    func setAppActive(_ active: Bool) {
+        goldenPadRecompSetAppActive(active ? 1 : 0)
+        guard let view = metalView else { return }
+        view.isPaused = !active
+        if active {
+            view.setNeedsLayout()
+            view.draw()
+        }
+    }
+
+    private func initializeRendererIfPossible(for view: MTKView) {
+        guard !rendererInitialized else { return }
         guard let layer = view.layer as? CAMetalLayer else {
             status = "RT64 prototype: CAMetalLayer unavailable"
             return
@@ -27,20 +69,72 @@ final class RecompPrototypeSurface: ObservableObject {
         let metalLayer = Unmanaged.passUnretained(layer).toOpaque()
         if let message = goldenPadRecompRT64Initialize(window, metalLayer) {
             status = String(cString: message)
+            rendererInitialized = true
+            requestStagedGameLaunch(window: window, layer: metalLayer)
         } else {
-            status = "RT64 prototype: surface-only host; verified archives are required"
+            status = "RT64 prototype: renderer initialization pending"
+        }
+    }
+
+    private func requestStagedGameLaunch(window: UnsafeMutableRawPointer, layer: UnsafeMutableRawPointer) {
+        #if GOLDENPAD_RECOMP_AOT_LINKED
+        guard !gameLaunchRequested else { return }
+        let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let romURL = documents.appendingPathComponent("GoldenEye_TLBFREE.z64")
+        guard FileManager.default.fileExists(atPath: romURL.path) else { return }
+        let configURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("GoldenPadRecomp", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: configURL, withIntermediateDirectories: true)
+        } catch {
+            status = "AOT runtime: cannot create private support directory"
+            return
+        }
+        let launchStatus = romURL.path.withCString { romPath in
+            configURL.path.withCString { configPath in
+                goldenPadRecompStartGame(window, layer, romPath, configPath)
+            }
+        }
+        if let launchStatus {
+            status = String(cString: launchStatus)
+            gameLaunchRequested = true
+            startStatusPolling()
+        }
+        #endif
+    }
+
+    private func startStatusPolling() {
+        statusTimer?.invalidate()
+        statusTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                #if GOLDENPAD_RECOMP_AOT_LINKED
+                if let nativeStatus = goldenPadRecompGameStatus() {
+                    let nextStatus = String(cString: nativeStatus)
+                    if nextStatus != self.status {
+                        self.status = nextStatus
+                    }
+                }
+                #endif
+            }
         }
     }
 
     func detach(from view: MTKView) {
         guard metalView === view else { return }
         goldenPadRecompRT64Shutdown()
+        statusTimer?.invalidate()
+        statusTimer = nil
+        rendererInitialized = false
+        gameLaunchRequested = false
         metalView = nil
         commandQueue = nil
         status = "RT64 prototype: stopped"
     }
 
     func draw(in view: MTKView) {
+        initializeRendererIfPossible(for: view)
+        if gameLaunchRequested { return }
         guard let descriptor = view.currentRenderPassDescriptor,
               let drawable = view.currentDrawable,
               let buffer = commandQueue?.makeCommandBuffer(),
@@ -54,20 +148,41 @@ final class RecompPrototypeSurface: ObservableObject {
 
 struct RecompPrototypeMetalCanvas: UIViewRepresentable {
     let surface: RecompPrototypeSurface
+    let msaaEnabled: Bool
+    let resolutionMode: RecompPrototypeResolutionMode
+    let threePointFiltering: Bool
 
     func makeCoordinator() -> Renderer { Renderer(surface: surface) }
 
     func makeUIView(context: Context) -> MTKView {
+        goldenPadRecompSetMSAAEnabled(msaaEnabled ? 1 : 0)
+        goldenPadRecompSetResolutionMode(resolutionMode.nativeValue)
+        goldenPadRecompSetThreePointFiltering(threePointFiltering ? 1 : 0)
         let view = MTKView(frame: .zero, device: MTLCreateSystemDefaultDevice())
         view.colorPixelFormat = .bgra8Unorm
-        view.clearColor = MTLClearColor(red: 0.025, green: 0.075, blue: 0.105, alpha: 1)
+        // Keep any sub-pixel surface edge neutral. The old blue clear color
+        // made a one-pixel host seam look like part of GoldenEye's sky.
+        view.clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 1)
+        view.backgroundColor = .black
+        view.isOpaque = true
         view.preferredFramesPerSecond = 60
+        if let layer = view.layer as? CAMetalLayer {
+            // Do not let a backgrounded surface wait forever for a drawable.
+            layer.allowsNextDrawableTimeout = true
+        }
         view.delegate = context.coordinator
         surface.attach(to: view)
         return view
     }
 
-    func updateUIView(_ view: MTKView, context: Context) {}
+    func updateUIView(_ view: MTKView, context: Context) {
+        // This is consumed before RT64 starts. Changes made from Settings are
+        // persisted for the next app launch because rebuilding the live swap
+        // chain in-place is not yet a safe operation in the prototype.
+        goldenPadRecompSetMSAAEnabled(msaaEnabled ? 1 : 0)
+        goldenPadRecompSetResolutionMode(resolutionMode.nativeValue)
+        goldenPadRecompSetThreePointFiltering(threePointFiltering ? 1 : 0)
+    }
 
     static func dismantleUIView(_ view: MTKView, coordinator: Renderer) {
         coordinator.surface.detach(from: view)

--- a/Sources/RecompPrototypeMetalCanvas.swift
+++ b/Sources/RecompPrototypeMetalCanvas.swift
@@ -1,0 +1,82 @@
+import MetalKit
+import SwiftUI
+
+@_silgen_name("goldenpad_recomp_rt64_initialize")
+private func goldenPadRecompRT64Initialize(
+    _ window: UnsafeMutableRawPointer,
+    _ view: UnsafeMutableRawPointer
+) -> UnsafePointer<CChar>?
+
+@_silgen_name("goldenpad_recomp_rt64_shutdown")
+private func goldenPadRecompRT64Shutdown()
+
+@MainActor
+final class RecompPrototypeSurface: ObservableObject {
+    @Published private(set) var status = "RT64 prototype: preparing Metal surface"
+    private weak var metalView: MTKView?
+    private var commandQueue: MTLCommandQueue?
+
+    func attach(to view: MTKView) {
+        metalView = view
+        commandQueue = view.device?.makeCommandQueue()
+        guard let layer = view.layer as? CAMetalLayer else {
+            status = "RT64 prototype: CAMetalLayer unavailable"
+            return
+        }
+        let window = Unmanaged.passUnretained(view).toOpaque()
+        let metalLayer = Unmanaged.passUnretained(layer).toOpaque()
+        if let message = goldenPadRecompRT64Initialize(window, metalLayer) {
+            status = String(cString: message)
+        } else {
+            status = "RT64 prototype: surface-only host; verified archives are required"
+        }
+    }
+
+    func detach(from view: MTKView) {
+        guard metalView === view else { return }
+        goldenPadRecompRT64Shutdown()
+        metalView = nil
+        commandQueue = nil
+        status = "RT64 prototype: stopped"
+    }
+
+    func draw(in view: MTKView) {
+        guard let descriptor = view.currentRenderPassDescriptor,
+              let drawable = view.currentDrawable,
+              let buffer = commandQueue?.makeCommandBuffer(),
+              let encoder = buffer.makeRenderCommandEncoder(descriptor: descriptor)
+        else { return }
+        encoder.endEncoding()
+        buffer.present(drawable)
+        buffer.commit()
+    }
+}
+
+struct RecompPrototypeMetalCanvas: UIViewRepresentable {
+    let surface: RecompPrototypeSurface
+
+    func makeCoordinator() -> Renderer { Renderer(surface: surface) }
+
+    func makeUIView(context: Context) -> MTKView {
+        let view = MTKView(frame: .zero, device: MTLCreateSystemDefaultDevice())
+        view.colorPixelFormat = .bgra8Unorm
+        view.clearColor = MTLClearColor(red: 0.025, green: 0.075, blue: 0.105, alpha: 1)
+        view.preferredFramesPerSecond = 60
+        view.delegate = context.coordinator
+        surface.attach(to: view)
+        return view
+    }
+
+    func updateUIView(_ view: MTKView, context: Context) {}
+
+    static func dismantleUIView(_ view: MTKView, coordinator: Renderer) {
+        coordinator.surface.detach(from: view)
+    }
+
+    final class Renderer: NSObject, MTKViewDelegate {
+        let surface: RecompPrototypeSurface
+        init(surface: RecompPrototypeSurface) { self.surface = surface }
+        func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {}
+        func draw(in view: MTKView) { surface.draw(in: view) }
+    }
+}

--- a/Support/RecompPrototype/recomp_aot_link_bridge.cpp
+++ b/Support/RecompPrototype/recomp_aot_link_bridge.cpp
@@ -1,0 +1,15 @@
+#include "funcs.h"
+#include "recomp.h"
+#include "librecomp/rsp.hpp"
+
+extern RspUcodeFunc aspMain;
+gpr get_entrypoint_address();
+
+extern "C" uint32_t goldenpad_recomp_aot_entrypoint_address() {
+    const auto entrypoint = get_entrypoint_address();
+    auto *const cpu_entrypoint = &recomp_entrypoint;
+    auto *const rsp_entrypoint = &aspMain;
+    (void)cpu_entrypoint;
+    (void)rsp_entrypoint;
+    return static_cast<uint32_t>(entrypoint);
+}

--- a/Support/RecompPrototype/recomp_game_start.cpp
+++ b/Support/RecompPrototype/recomp_game_start.cpp
@@ -1,0 +1,741 @@
+#include "funcs.h"
+#include "librecomp/game.hpp"
+#include "librecomp/helpers.hpp"
+#include "librecomp/overlays.hpp"
+#include "librecomp/rsp.hpp"
+#include "ultramodern/config.hpp"
+#include "ultramodern/ultramodern.hpp"
+#include "zelda_render.h"
+
+#include <algorithm>
+#include <atomic>
+#include <array>
+#include <bit>
+#include <chrono>
+#include <cmath>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <os/log.h>
+#include <string>
+#include <thread>
+
+extern RspUcodeFunc aspMain;
+gpr get_entrypoint_address();
+
+namespace zelda64 {
+void register_overlays();
+void register_patches();
+}
+
+namespace {
+constexpr uint64_t kGoldenEyeTlbFreeHash = 0xd49fb2a8d6d3bd65ULL;
+const std::u8string kGameID = u8"ge007.us";
+
+std::atomic<bool> runtimeStarted = false;
+std::atomic<uint32_t> controllerButtons = 0;
+std::atomic<int32_t> controllerStickX = 0;
+std::atomic<int32_t> controllerStickY = 0;
+std::atomic<int32_t> controllerLookX = 0;
+std::atomic<int32_t> controllerLookY = 0;
+std::atomic<uint32_t> controllerLookSamples = 0;
+std::atomic<int32_t> queuedTouchLookX = 0;
+std::atomic<int32_t> queuedTouchLookY = 0;
+std::atomic<bool> crouchToggleRequested = false;
+std::atomic<bool> prototypeMsaaEnabled = true;
+std::atomic<int32_t> prototypeResolutionMode = 2;
+std::atomic<bool> prototypeThreePointFiltering = true;
+std::atomic<bool> invertAimY = false;
+std::atomic<bool> unlockAllMissions = false;
+std::atomic<bool> appActive = true;
+std::atomic<bool> controllerConnected = false;
+std::atomic<uint64_t> rt64DisplayListCount = 0;
+std::atomic<uint64_t> rt64ScreenUpdateCount = 0;
+std::atomic<uint64_t> rt64PresentedCount = 0;
+std::atomic<bool> controllerPortReported = false;
+std::atomic<bool> inputPollReported = false;
+std::atomic<bool> inputStateReported = false;
+std::atomic<bool> audioCallbackReported = false;
+std::atomic<bool> stateProbeStarted = false;
+std::atomic<uint8_t> invalidInputPortsReported = 0;
+std::mutex statusMutex;
+std::mutex diagnosticsMutex;
+std::string runtimeStatus = "AOT runtime: waiting for imported user ROM";
+std::filesystem::path diagnosticsLogPath;
+constexpr uintmax_t kDiagnosticsLogLimit = 4 * 1024 * 1024;
+
+// Match the working GoldenPad host: the game/audio thread is the sole producer
+// and AVAudioEngine is the sole consumer of a bounded stereo PCM ring.
+constexpr uint64_t kAudioRingFrames = 65'536;
+constexpr uint64_t kAudioPrebufferFrames = 1'024;
+constexpr uint32_t kAudioFadeFrames = 32;
+std::array<int16_t, kAudioRingFrames * 2> audioRing{};
+std::atomic<uint64_t> audioReadFrame = 0;
+std::atomic<uint64_t> audioWriteFrame = 0;
+std::atomic<uint64_t> audioDroppedFrames = 0;
+std::atomic<uint64_t> audioUnderrunFrames = 0;
+std::atomic<uint64_t> audioUnderrunCallbacks = 0;
+std::atomic<uint64_t> audioRenderedFrames = 0;
+std::atomic<uint64_t> audioNonzeroSamples = 0;
+// These fields are used only by AVAudioEngine's single render thread.
+bool audioPlaybackPrimed = false;
+uint32_t audioFadeInFramesRemaining = 0;
+float audioLastLeft = 0.0f;
+float audioLastRight = 0.0f;
+
+void logEvent(const char *event, const char *format, ...) {
+    char detail[768];
+    va_list arguments;
+    va_start(arguments, format);
+    std::vsnprintf(detail, sizeof(detail), format, arguments);
+    va_end(arguments);
+    char line[896];
+    std::snprintf(line, sizeof(line), "[GoldenPadRecomp] %s: %s", event, detail);
+    std::fprintf(stderr, "%s\n", line);
+    os_log_with_type(OS_LOG_DEFAULT, OS_LOG_TYPE_DEFAULT, "%{public}s", line);
+    std::lock_guard diagnosticsLock(diagnosticsMutex);
+    if (!diagnosticsLogPath.empty()) {
+        std::error_code error;
+        const uintmax_t size = std::filesystem::file_size(diagnosticsLogPath, error);
+        if (!error && size > kDiagnosticsLogLimit) {
+            std::ofstream reset(diagnosticsLogPath, std::ios::trunc);
+            reset << "[GoldenPadRecomp] diagnostics: earlier log text was rotated\n";
+        }
+        std::ofstream log(diagnosticsLogPath, std::ios::app);
+        log << line << '\n';
+    }
+}
+
+void configureDiagnostics(const std::filesystem::path &configPath) {
+    std::lock_guard lock(diagnosticsMutex);
+    const std::filesystem::path directory = configPath / "Logs";
+    const std::filesystem::path latest = directory / "goldenpad-recomp-latest.log";
+    const std::filesystem::path previous = directory / "goldenpad-recomp-previous.log";
+    std::error_code error;
+    std::filesystem::create_directories(directory, error);
+    std::filesystem::remove(previous, error);
+    error.clear();
+    if (std::filesystem::exists(latest, error)) {
+        std::filesystem::rename(latest, previous, error);
+    }
+    diagnosticsLogPath = latest;
+    std::ofstream log(diagnosticsLogPath, std::ios::trunc);
+    log << "[GoldenPadRecomp] diagnostics: private current-session log started\n";
+}
+
+void queueClampedAxis(std::atomic<int32_t> &axis, int32_t delta) {
+    int32_t current = axis.load(std::memory_order_relaxed);
+    while (!axis.compare_exchange_weak(
+        current,
+        std::clamp<int64_t>(static_cast<int64_t>(current) + delta, -32'767, 32'767),
+        std::memory_order_relaxed)) {}
+}
+
+void configurePrototypeGraphics() {
+    ultramodern::renderer::GraphicsConfig graphics{};
+    // Match GoldenEye64Recomp's intended remastered defaults. The zero-filled
+    // config previously selected original N64 resolution, original aspect,
+    // and no MSAA, which explains the visibly coarse physical-iPad output.
+    switch (prototypeResolutionMode.load(std::memory_order_relaxed)) {
+    case 0:
+        graphics.res_option = ultramodern::renderer::Resolution::Original;
+        break;
+    case 1:
+        graphics.res_option = ultramodern::renderer::Resolution::Original2x;
+        break;
+    default:
+        graphics.res_option = ultramodern::renderer::Resolution::Auto;
+        break;
+    }
+    graphics.wm_option = ultramodern::renderer::WindowMode::Fullscreen;
+    graphics.hr_option = ultramodern::renderer::HUDRatioMode::Clamp16x9;
+    graphics.api_option = ultramodern::renderer::GraphicsApi::Metal;
+    graphics.ar_option = ultramodern::renderer::AspectRatio::Expand;
+    const bool msaaEnabled = prototypeMsaaEnabled.load(std::memory_order_relaxed);
+    graphics.msaa_option = msaaEnabled
+        ? ultramodern::renderer::Antialiasing::MSAA2X
+        : ultramodern::renderer::Antialiasing::None;
+    // Display-rate interpolation can expose incompatible transforms as
+    // intermittent geometry shimmer. Preserve high resolution and MSAA while
+    // using the game's original presentation rate for a stable baseline.
+    graphics.rr_option = ultramodern::renderer::RefreshRate::Original;
+    graphics.hpfb_option = ultramodern::renderer::HighPrecisionFramebuffer::Auto;
+    graphics.rr_manual_value = 60;
+    graphics.ds_option = 1;
+    graphics.developer_mode = false;
+    ultramodern::renderer::set_graphics_config(graphics);
+    const char *resolution = graphics.res_option == ultramodern::renderer::Resolution::Original
+        ? "native resolution"
+        : graphics.res_option == ultramodern::renderer::Resolution::Original2x
+            ? "2x resolution"
+            : "automatic high resolution";
+    logEvent("graphics", "Metal %s, expanded aspect, %s, %s, original refresh",
+        resolution,
+        msaaEnabled ? "2x MSAA" : "MSAA off",
+        prototypeThreePointFiltering.load(std::memory_order_relaxed)
+            ? "three-point filtering" : "linear filtering");
+}
+
+void setStatus(const std::string &message) {
+    {
+        std::lock_guard lock(statusMutex);
+        runtimeStatus = message;
+    }
+    logEvent("status", "%s", message.c_str());
+}
+
+void debugMonitorStub(uint8_t *, recomp_context *ctx) {
+    ctx->r2 = 0;
+}
+
+int32_t readGameWord(uint8_t *rdram, uint32_t address) {
+    return MEM_W(0, static_cast<gpr>(static_cast<int32_t>(address)));
+}
+
+float readGameFloat(uint8_t *rdram, uint32_t address) {
+    return std::bit_cast<float>(static_cast<uint32_t>(readGameWord(rdram, address)));
+}
+
+size_t getQueuedFrames();
+
+void monitorGameState(uint8_t *rdram) {
+    int32_t previousMenu = INT32_MIN;
+    int32_t previousStage = INT32_MIN;
+    int32_t previousPendingStage = INT32_MIN;
+    uint64_t previousDisplayLists = 0;
+    uint64_t previousScreenUpdates = 0;
+    uint64_t previousPresented = 0;
+    int stalledActiveSamples = 0;
+    int heartbeat = 0;
+    while (runtimeStarted.load(std::memory_order_relaxed)) {
+        const int32_t menu = readGameWord(rdram, 0x8002A6C0);
+        const int32_t stage = readGameWord(rdram, 0x80023FA8);
+        const int32_t pendingStage = readGameWord(rdram, 0x80048164);
+        if (menu != previousMenu || stage != previousStage || pendingStage != previousPendingStage || heartbeat == 0) {
+            logEvent("game-state",
+                "menu=%d stage=%d pending=%d timer=%d update=%d firstLegal=%d firstMain=%d",
+                menu, stage, pendingStage,
+                readGameWord(rdram, 0x8002A6CC),
+                readGameWord(rdram, 0x8002A6C4),
+                readGameWord(rdram, 0x8002A72C),
+                readGameWord(rdram, 0x8002A730));
+            previousMenu = menu;
+            previousStage = stage;
+            previousPendingStage = pendingStage;
+        }
+        const uint64_t displayLists = rt64DisplayListCount.load(std::memory_order_relaxed);
+        const uint64_t screenUpdates = rt64ScreenUpdateCount.load(std::memory_order_relaxed);
+        const uint64_t presented = rt64PresentedCount.load(std::memory_order_relaxed);
+        const bool active = appActive.load(std::memory_order_relaxed);
+        if (heartbeat == 0) {
+            const uint32_t player = static_cast<uint32_t>(readGameWord(rdram, 0x80079EB0));
+            const bool playerValid = player >= 0x80000000u && player < 0xA0000000u;
+            float viewX = playerValid ? readGameFloat(rdram, player + 0x4C4) : 0.0f;
+            float viewY = playerValid ? readGameFloat(rdram, player + 0x4C8) : 0.0f;
+            float viewZ = playerValid ? readGameFloat(rdram, player + 0x4CC) : 0.0f;
+            float upX = playerValid ? readGameFloat(rdram, player + 0x4D0) : 0.0f;
+            float upY = playerValid ? readGameFloat(rdram, player + 0x4D4) : 0.0f;
+            float upZ = playerValid ? readGameFloat(rdram, player + 0x4D8) : 0.0f;
+            const float viewLengthSquared = viewX * viewX + viewY * viewY + viewZ * viewZ;
+            const float upLengthSquared = upX * upX + upY * upY + upZ * upZ;
+            const bool basisValid = stage != 90 && std::isfinite(viewLengthSquared) &&
+                std::isfinite(upLengthSquared) && viewLengthSquared > 0.25f &&
+                viewLengthSquared < 4.0f && upLengthSquared > 0.25f && upLengthSquared < 4.0f;
+            if (!basisValid) {
+                viewX = viewY = viewZ = 0.0f;
+                upX = upY = upZ = 0.0f;
+            }
+            logEvent("health",
+                "app=%s dl=%llu vi=%llu presented=%llu audioQueued=%zu audioRendered=%llu audioDropped=%llu audioUnderrunFrames=%llu audioUnderrunCallbacks=%llu controller=%s look=(%d,%d) player=0x%08X pos=(%.2f,%.2f,%.2f) model=(%.2f,%.2f,%.2f) room=(%.2f,%.2f,%.2f) yaw=%.2f pitch=%.2f basis=%s view=(%.3f,%.3f,%.3f) up=(%.3f,%.3f,%.3f)",
+                active ? "active" : "inactive",
+                static_cast<unsigned long long>(displayLists),
+                static_cast<unsigned long long>(screenUpdates),
+                static_cast<unsigned long long>(presented),
+                getQueuedFrames(),
+                static_cast<unsigned long long>(audioRenderedFrames.load(std::memory_order_relaxed)),
+                static_cast<unsigned long long>(audioDroppedFrames.load(std::memory_order_relaxed)),
+                static_cast<unsigned long long>(audioUnderrunFrames.load(std::memory_order_relaxed)),
+                static_cast<unsigned long long>(audioUnderrunCallbacks.load(std::memory_order_relaxed)),
+                controllerConnected.load(std::memory_order_relaxed) ? "external" : "touch",
+                controllerLookX.load(std::memory_order_relaxed),
+                controllerLookY.load(std::memory_order_relaxed),
+                player,
+                playerValid ? readGameFloat(rdram, player + 0x04) : 0.0f,
+                playerValid ? readGameFloat(rdram, player + 0x08) : 0.0f,
+                playerValid ? readGameFloat(rdram, player + 0x0C) : 0.0f,
+                playerValid ? readGameFloat(rdram, player + 0x38) : 0.0f,
+                playerValid ? readGameFloat(rdram, player + 0x3C) : 0.0f,
+                playerValid ? readGameFloat(rdram, player + 0x40) : 0.0f,
+                playerValid ? readGameFloat(rdram, player + 0x50) : 0.0f,
+                playerValid ? readGameFloat(rdram, player + 0x54) : 0.0f,
+                playerValid ? readGameFloat(rdram, player + 0x58) : 0.0f,
+                playerValid ? readGameFloat(rdram, player + 0x148) : 0.0f,
+                playerValid ? readGameFloat(rdram, player + 0x158) : 0.0f,
+                basisValid ? "valid" : "unavailable",
+                viewX, viewY, viewZ, upX, upY, upZ);
+        }
+        const bool rendererHadStarted = displayLists != 0 || screenUpdates != 0;
+        const bool rendererAdvanced = displayLists != previousDisplayLists ||
+            screenUpdates != previousScreenUpdates || presented != previousPresented;
+        if (active && rendererHadStarted && !rendererAdvanced) {
+            ++stalledActiveSamples;
+            if (stalledActiveSamples == 5) {
+                logEvent("watchdog",
+                    "RT64 made no progress for 10 seconds while active (dl=%llu vi=%llu presented=%llu)",
+                    static_cast<unsigned long long>(displayLists),
+                    static_cast<unsigned long long>(screenUpdates),
+                    static_cast<unsigned long long>(presented));
+            }
+        } else {
+            stalledActiveSamples = 0;
+        }
+        previousDisplayLists = displayLists;
+        previousScreenUpdates = screenUpdates;
+        previousPresented = presented;
+        heartbeat = (heartbeat + 1) % 5;
+        std::this_thread::sleep_for(std::chrono::seconds(2));
+    }
+}
+
+void installGoldenEyeRuntimeStubs(uint8_t *rdram, recomp_context *) {
+    // Overlay initialization clears its dynamic dispatch map immediately before
+    // the game threads begin. Install GoldenEye's unused rmon monitor stubs at
+    // thread creation so indirect calls see them after that reset.
+    constexpr uint32_t monitorStubs[] = {
+        0x8000CCA0, 0x8000CCA8, 0x8000CCB0, 0x8000CCB8,
+        0x8000CCC0, 0x8000CCC8, 0x8000CCD0, 0x8000CCD8,
+        0x8000CCE0,
+    };
+    for (const uint32_t address : monitorStubs) {
+        recomp::overlays::add_loaded_function(static_cast<int32_t>(address), debugMonitorStub);
+    }
+    if (!stateProbeStarted.exchange(true, std::memory_order_relaxed)) {
+        std::thread(monitorGameState, rdram).detach();
+    }
+}
+
+RspUcodeFunc *getRspMicrocode(const OSTask *task) {
+    return task->t.type == M_AUDTASK ? aspMain : nullptr;
+}
+
+void queueSamples(int16_t *samples, size_t sampleCount) {
+    if (!audioCallbackReported.exchange(true)) {
+        logEvent("audio", "game submitted audio to the GoldenPad PCM ring");
+    }
+    if (samples == nullptr || sampleCount < 2) {
+        return;
+    }
+    uint64_t incomingFrames = sampleCount / 2;
+    if (incomingFrames > kAudioRingFrames) {
+        samples += (incomingFrames - kAudioRingFrames) * 2;
+        incomingFrames = kAudioRingFrames;
+    }
+
+    const uint64_t readFrame = audioReadFrame.load(std::memory_order_acquire);
+    uint64_t writeFrame = audioWriteFrame.load(std::memory_order_relaxed);
+    const uint64_t queuedFrames = std::min(writeFrame - std::min(writeFrame, readFrame), kAudioRingFrames);
+    const uint64_t availableFrames = kAudioRingFrames - queuedFrames;
+    if (incomingFrames > availableFrames) {
+        const uint64_t discard = incomingFrames - availableFrames;
+        samples += discard * 2;
+        incomingFrames -= discard;
+        audioDroppedFrames.fetch_add(discard, std::memory_order_relaxed);
+    }
+    for (uint64_t frame = 0; frame < incomingFrames; ++frame) {
+        const uint64_t destination = ((writeFrame + frame) % kAudioRingFrames) * 2;
+        // Match GoldenEye64Recomp's reference host: N64ModernRuntime's RDRAM
+        // address XOR leaves each interleaved stereo pair in reversed order.
+        audioRing[destination] = samples[frame * 2 + 1];
+        audioRing[destination + 1] = samples[frame * 2];
+    }
+    audioWriteFrame.store(writeFrame + incomingFrames, std::memory_order_release);
+}
+size_t getQueuedFrames() {
+    const uint64_t readFrame = audioReadFrame.load(std::memory_order_acquire);
+    const uint64_t writeFrame = audioWriteFrame.load(std::memory_order_acquire);
+    return static_cast<size_t>(std::min(writeFrame - std::min(writeFrame, readFrame), kAudioRingFrames));
+}
+size_t getFramesRemaining() {
+    // AVAudioSourceNode can pull a larger resampled block than the game's
+    // per-VI producer chunk. Keep a small host reserve out of the value the
+    // game sees so its next audio task is scheduled before that pull arrives.
+    const size_t queued = getQueuedFrames();
+    return queued > kAudioPrebufferFrames ? queued - kAudioPrebufferFrames : 0;
+}
+void setFrequency(uint32_t frequency) {
+    logEvent("audio", "game requested %u Hz output", frequency);
+}
+void pollInput() {
+    if (!inputPollReported.exchange(true)) {
+        logEvent("input", "game began polling the prototype controller bridge");
+    }
+}
+bool getInput(int controllerNum, uint16_t *buttons, float *x, float *y) {
+    if (controllerNum != 0 || buttons == nullptr || x == nullptr || y == nullptr) {
+        const uint8_t reportBit = controllerNum >= 0 && controllerNum < 4
+            ? static_cast<uint8_t>(1u << controllerNum)
+            : static_cast<uint8_t>(1u << 4);
+        if ((invalidInputPortsReported.fetch_or(reportBit) & reportBit) == 0) {
+            logEvent("input", "controller port %d has no prototype input source", controllerNum + 1);
+        }
+        return false;
+    }
+    *buttons = static_cast<uint16_t>(controllerButtons.load(std::memory_order_relaxed));
+    *x = static_cast<float>(controllerStickX.load(std::memory_order_relaxed)) / 80.0f;
+    *y = static_cast<float>(controllerStickY.load(std::memory_order_relaxed)) / 80.0f;
+    if (!inputStateReported.exchange(true)) {
+        logEvent("input", "controller 1 state is available (touch and GameController map)");
+    }
+    return true;
+}
+void setRumble(int controllerNum, bool enabled) {
+    if (controllerNum == 0) {
+        logEvent("input", "controller 1 rumble %s (not implemented in prototype)", enabled ? "requested" : "stopped");
+    }
+}
+ultramodern::input::connected_device_info_t getConnectedDeviceInfo(int controllerNum) {
+    if (controllerNum == 0) {
+        if (!controllerPortReported.exchange(true)) {
+            logEvent("input", "advertising a normal controller in port 1");
+        }
+        return {ultramodern::input::Device::Controller, ultramodern::input::Pak::None};
+    }
+    return {ultramodern::input::Device::None, ultramodern::input::Pak::None};
+}
+void reportRuntimeError(const char *message) {
+    setStatus(std::string("AOT runtime error: ") + message);
+    logEvent("error", "%s", message);
+}
+std::string gameThreadName(const OSThread *) { return "GE game"; }
+
+void runRuntime(ultramodern::renderer::WindowHandle window, std::filesystem::path romPath, std::filesystem::path configPath) {
+    try {
+        configureDiagnostics(configPath);
+        logEvent("runtime", "worker started");
+        std::filesystem::create_directories(configPath);
+        recomp::register_config_path(std::move(configPath));
+        configurePrototypeGraphics();
+
+        recomp::GameEntry game{};
+        game.rom_hash = kGoldenEyeTlbFreeHash;
+        game.internal_name = "GOLDENEYE";
+        game.game_id = kGameID;
+        game.save_type = recomp::SaveType::Eep4k;
+        game.is_enabled = true;
+        game.entrypoint_address = get_entrypoint_address();
+        game.entrypoint = recomp_entrypoint;
+        game.thread_create_callback = installGoldenEyeRuntimeStubs;
+        recomp::register_game(game);
+        zelda64::register_overlays();
+        zelda64::register_patches();
+        logEvent("runtime", "registered GoldenEye game, overlays, and upstream recomp patches");
+
+        std::u8string gameID = kGameID;
+        if (recomp::select_rom(romPath, gameID) != recomp::RomValidationError::Good) {
+            setStatus("AOT runtime: the imported ROM is not the expected GoldenEye NTSC-U TLBFREE input");
+            logEvent("runtime", "ROM validation failed");
+            runtimeStarted = false;
+            return;
+        }
+        logEvent("runtime", "ROM validation passed");
+
+        recomp::rsp::callbacks_t rspCallbacks{.get_rsp_microcode = getRspMicrocode};
+        ultramodern::renderer::callbacks_t rendererCallbacks{.create_render_context = zelda64::renderer::create_render_context};
+        ultramodern::audio_callbacks_t audioCallbacks{
+            .queue_samples = queueSamples,
+            .get_frames_remaining = getFramesRemaining,
+            .set_frequency = setFrequency,
+        };
+        ultramodern::input::callbacks_t inputCallbacks{
+            .poll_input = pollInput,
+            .get_input = getInput,
+            .set_rumble = setRumble,
+            .get_connected_device_info = getConnectedDeviceInfo,
+        };
+        ultramodern::gfx_callbacks_t gfxCallbacks{};
+        ultramodern::events::callbacks_t eventCallbacks{};
+        ultramodern::error_handling::callbacks_t errorCallbacks{.message_box = reportRuntimeError};
+        ultramodern::threads::callbacks_t threadCallbacks{.get_game_thread_name = gameThreadName};
+
+        setStatus("AOT runtime: starting GoldenEye game thread");
+        logEvent("runtime", "starting GoldenEye runtime");
+        recomp::start_game(kGameID);
+        setStatus("AOT runtime: GoldenEye loop active");
+        recomp::start({0, 0, 1, "-prototype"}, window, rspCallbacks, rendererCallbacks,
+            audioCallbacks, inputCallbacks, gfxCallbacks, eventCallbacks, errorCallbacks, threadCallbacks);
+        setStatus("AOT runtime: stopped");
+    } catch (const std::exception &error) {
+        reportRuntimeError(error.what());
+    }
+    logEvent("runtime", "worker stopped");
+    runtimeStarted = false;
+}
+}
+
+extern "C" void goldenpad_recomp_set_msaa_enabled(int32_t enabled) {
+    if (!runtimeStarted.load(std::memory_order_relaxed)) {
+        prototypeMsaaEnabled.store(enabled != 0, std::memory_order_relaxed);
+    }
+}
+
+extern "C" void goldenpad_recomp_set_resolution_mode(int32_t mode) {
+    if (!runtimeStarted.load(std::memory_order_relaxed)) {
+        prototypeResolutionMode.store(std::clamp(mode, 0, 2), std::memory_order_relaxed);
+    }
+}
+
+extern "C" void goldenpad_recomp_set_three_point_filtering(int32_t enabled) {
+    if (!runtimeStarted.load(std::memory_order_relaxed)) {
+        prototypeThreePointFiltering.store(enabled != 0, std::memory_order_relaxed);
+    }
+}
+
+extern "C" int32_t goldenpad_recomp_three_point_filtering_enabled() {
+    return prototypeThreePointFiltering.load(std::memory_order_relaxed) ? 1 : 0;
+}
+
+extern "C" const char *goldenpad_recomp_start_game(void *window, void *view, const char *romPath, const char *configPath) {
+    if (window == nullptr || view == nullptr || romPath == nullptr || configPath == nullptr) {
+        logEvent("launch", "rejected incomplete launch arguments");
+        return "AOT runtime: missing launch input";
+    }
+    if (runtimeStarted.exchange(true)) {
+        logEvent("launch", "ignored duplicate launch request");
+        return "AOT runtime: already running";
+    }
+    setStatus("AOT runtime: validating imported user ROM");
+    std::thread(runRuntime, ultramodern::renderer::WindowHandle{window, view},
+        std::filesystem::path(romPath), std::filesystem::path(configPath)).detach();
+    return "AOT runtime: launch requested";
+}
+
+extern "C" const char *goldenpad_recomp_game_status() {
+    thread_local std::string statusSnapshot;
+    std::lock_guard lock(statusMutex);
+    statusSnapshot = runtimeStatus;
+    return statusSnapshot.c_str();
+}
+
+extern "C" void goldenpad_recomp_set_controller_state(uint32_t buttons, int32_t stickX, int32_t stickY) {
+    const uint32_t normalizedButtons = buttons & 0xFFFFu;
+    const uint32_t previousButtons = controllerButtons.exchange(normalizedButtons, std::memory_order_relaxed);
+    if (previousButtons != normalizedButtons) {
+        logEvent("input", "published controller 1 buttons 0x%04X", normalizedButtons);
+    }
+    controllerStickX.store(std::clamp(stickX, -80, 80), std::memory_order_relaxed);
+    controllerStickY.store(std::clamp(stickY, -80, 80), std::memory_order_relaxed);
+}
+
+extern "C" void goldenpad_recomp_set_right_analog(int32_t lookX, int32_t lookY) {
+    const int32_t normalizedX = std::clamp(lookX, -32'767, 32'767);
+    const int32_t normalizedY = std::clamp(lookY, -32'767, 32'767);
+    const int32_t previousX = controllerLookX.exchange(normalizedX, std::memory_order_relaxed);
+    const int32_t previousY = controllerLookY.exchange(normalizedY, std::memory_order_relaxed);
+    const bool wasActive = std::abs(previousX) > 2'048 || std::abs(previousY) > 2'048;
+    const bool isActive = std::abs(normalizedX) > 2'048 || std::abs(normalizedY) > 2'048;
+    if (wasActive != isActive) {
+        logEvent("input", "controller right stick %s at (%d,%d)",
+            isActive ? "active" : "neutral", normalizedX, normalizedY);
+    }
+    const uint32_t sample = controllerLookSamples.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (isActive && sample % 30 == 1) {
+        logEvent("input", "controller right stick sample (%d,%d)", normalizedX, normalizedY);
+    }
+}
+
+extern "C" void goldenpad_recomp_set_controller_connected(int32_t connected) {
+    const bool next = connected != 0;
+    const bool previous = controllerConnected.exchange(next, std::memory_order_relaxed);
+    if (previous != next) {
+        logEvent("input", "external controller %s; touch overlay %s",
+            next ? "connected" : "disconnected", next ? "hidden" : "restored");
+    }
+}
+
+extern "C" void goldenpad_recomp_set_app_active(int32_t active) {
+    const bool next = active != 0;
+    const bool previous = appActive.exchange(next, std::memory_order_relaxed);
+    if (previous != next) {
+        uint64_t discardedAudioFrames = 0;
+        if (next) {
+            const uint64_t writeFrame = audioWriteFrame.load(std::memory_order_acquire);
+            const uint64_t readFrame = audioReadFrame.exchange(writeFrame, std::memory_order_acq_rel);
+            discardedAudioFrames = writeFrame - std::min(writeFrame, readFrame);
+            audioPlaybackPrimed = false;
+            audioFadeInFramesRemaining = 0;
+            audioLastLeft = 0.0f;
+            audioLastRight = 0.0f;
+        }
+        logEvent("lifecycle", "host became %s; RT64 presentation %s",
+            next ? "active" : "inactive", next ? "resumed" : "suspended");
+        if (discardedAudioFrames != 0) {
+            logEvent("audio", "discarded %llu stale queued frames after foregrounding",
+                static_cast<unsigned long long>(discardedAudioFrames));
+        }
+    }
+}
+
+extern "C" int32_t goldenpad_recomp_is_app_active() {
+    return appActive.load(std::memory_order_relaxed) ? 1 : 0;
+}
+
+extern "C" void goldenpad_recomp_note_display_list(uint64_t count) {
+    rt64DisplayListCount.store(count, std::memory_order_relaxed);
+}
+
+extern "C" void goldenpad_recomp_note_screen_progress(uint64_t updates, uint64_t presented) {
+    rt64ScreenUpdateCount.store(updates, std::memory_order_relaxed);
+    rt64PresentedCount.store(presented, std::memory_order_relaxed);
+}
+
+extern "C" void goldenpad_recomp_queue_touch_look(int32_t lookX, int32_t lookY) {
+    queueClampedAxis(queuedTouchLookX, lookX);
+    queueClampedAxis(queuedTouchLookY, lookY);
+}
+
+extern "C" void goldenpad_recomp_request_crouch_toggle() {
+    crouchToggleRequested.store(true, std::memory_order_release);
+}
+
+extern "C" void goldenpad_recomp_set_invert_aim_y(int32_t enabled) {
+    invertAimY.store(enabled != 0, std::memory_order_relaxed);
+}
+
+extern "C" void goldenpad_recomp_set_unlock_all_missions(int32_t enabled) {
+    const bool next = enabled != 0;
+    const bool previous = unlockAllMissions.exchange(next, std::memory_order_relaxed);
+    if (previous != next) {
+        logEvent("progression", "unlock all missions %s; EEPROM unchanged", next ? "enabled" : "disabled");
+    }
+}
+
+extern "C" void recomp_get_camera_inputs(uint8_t *rdram, recomp_context *ctx) {
+    float *xOut = _arg<0, float *>(rdram, ctx);
+    float *yOut = _arg<1, float *>(rdram, ctx);
+    const bool aiming = (controllerButtons.load(std::memory_order_relaxed) & 0x0010u) != 0;
+    // Port the working MGB64 controller rate exactly while leaving the tuned
+    // relative-touch path unchanged. MGB64 resolves to 1.2 degrees/frame at
+    // full hip-fire deflection and about 0.133 degrees/frame while aiming;
+    // the recomp gameplay patch applies 3 and 1 degrees respectively.
+    const float controllerScale = aiming ? (0.13333334f / 1.0f) : (1.2f / 3.0f);
+    float x = static_cast<float>(controllerLookX.load(std::memory_order_relaxed)) /
+            32'767.0f * controllerScale +
+        static_cast<float>(queuedTouchLookX.exchange(0, std::memory_order_acq_rel)) / 32'767.0f;
+    float y = static_cast<float>(controllerLookY.load(std::memory_order_relaxed)) /
+            32'767.0f * controllerScale +
+        static_cast<float>(queuedTouchLookY.exchange(0, std::memory_order_acq_rel)) / 32'767.0f;
+    x = std::clamp(x, -1.0f, 1.0f);
+    y = std::clamp(y, -1.0f, 1.0f);
+    // GoldenEye's sight-aim camera applies the opposite vertical convention
+    // from normal free look. Normalize that by default, while retaining an
+    // explicit setting for players who prefer inverted aiming.
+    if (aiming && !invertAimY.load(std::memory_order_relaxed)) {
+        y = -y;
+    }
+    *xOut = x;
+    *yOut = y;
+}
+
+extern "C" void goldenpad_recomp_consume_crouch_toggle(uint8_t *, recomp_context *ctx) {
+    ctx->r2 = crouchToggleRequested.exchange(false, std::memory_order_acq_rel) ? 1 : 0;
+}
+
+extern "C" void goldenpad_recomp_unlock_all_missions_enabled(uint8_t *, recomp_context *ctx) {
+    ctx->r2 = unlockAllMissions.load(std::memory_order_relaxed) ? 1 : 0;
+}
+
+extern "C" uint32_t goldenpad_recomp_audio_render(float *left, float *right, uint32_t frames) {
+    if (left == nullptr || right == nullptr) {
+        return 0;
+    }
+    const uint64_t readFrame = audioReadFrame.load(std::memory_order_relaxed);
+    const uint64_t writeFrame = audioWriteFrame.load(std::memory_order_acquire);
+    const uint64_t queued = std::min(
+        writeFrame - std::min(writeFrame, readFrame), kAudioRingFrames);
+    if (!audioPlaybackPrimed) {
+        if (queued < kAudioPrebufferFrames) {
+            std::fill(left, left + frames, 0.0f);
+            std::fill(right, right + frames, 0.0f);
+            return 0;
+        }
+        audioPlaybackPrimed = true;
+        audioFadeInFramesRemaining = kAudioFadeFrames;
+    }
+
+    if (queued < frames) {
+        const uint64_t renderedBefore = audioRenderedFrames.load(std::memory_order_relaxed);
+        if (renderedBefore > 0) {
+            audioUnderrunFrames.fetch_add(frames - queued, std::memory_order_relaxed);
+            audioUnderrunCallbacks.fetch_add(1, std::memory_order_relaxed);
+        }
+        const uint32_t fadeFrames = std::min(frames, kAudioFadeFrames);
+        for (uint32_t frame = 0; frame < fadeFrames; ++frame) {
+            const float gain = 1.0f - static_cast<float>(frame + 1) / static_cast<float>(fadeFrames);
+            left[frame] = audioLastLeft * gain;
+            right[frame] = audioLastRight * gain;
+        }
+        std::fill(left + fadeFrames, left + frames, 0.0f);
+        std::fill(right + fadeFrames, right + frames, 0.0f);
+        audioLastLeft = 0.0f;
+        audioLastRight = 0.0f;
+        audioPlaybackPrimed = false;
+        return 0;
+    }
+
+    const uint32_t produced = frames;
+    uint64_t nonzero = 0;
+    for (uint32_t frame = 0; frame < produced; ++frame) {
+        const uint64_t source = ((readFrame + frame) % kAudioRingFrames) * 2;
+        float gain = 1.0f;
+        if (audioFadeInFramesRemaining > 0) {
+            gain = 1.0f - static_cast<float>(audioFadeInFramesRemaining) /
+                static_cast<float>(kAudioFadeFrames);
+            --audioFadeInFramesRemaining;
+        }
+        left[frame] = static_cast<float>(audioRing[source]) / 32768.0f * gain;
+        right[frame] = static_cast<float>(audioRing[source + 1]) / 32768.0f * gain;
+        nonzero += audioRing[source] != 0;
+        nonzero += audioRing[source + 1] != 0;
+    }
+    audioLastLeft = left[produced - 1];
+    audioLastRight = right[produced - 1];
+    audioReadFrame.store(readFrame + produced, std::memory_order_release);
+    audioRenderedFrames.fetch_add(produced, std::memory_order_relaxed);
+    audioNonzeroSamples.fetch_add(nonzero, std::memory_order_relaxed);
+    return produced;
+}
+
+extern "C" void goldenpad_recomp_audio_stats(
+    uint64_t *queuedFrames, uint64_t *renderedFrames,
+    uint64_t *nonzeroSamples, uint64_t *droppedFrames,
+    uint64_t *underrunFrames, uint64_t *underrunCallbacks) {
+    if (queuedFrames != nullptr) {
+        *queuedFrames = getQueuedFrames();
+    }
+    if (renderedFrames != nullptr) {
+        *renderedFrames = audioRenderedFrames.load(std::memory_order_relaxed);
+    }
+    if (nonzeroSamples != nullptr) {
+        *nonzeroSamples = audioNonzeroSamples.load(std::memory_order_relaxed);
+    }
+    if (droppedFrames != nullptr) {
+        *droppedFrames = audioDroppedFrames.load(std::memory_order_relaxed);
+    }
+    if (underrunFrames != nullptr) {
+        *underrunFrames = audioUnderrunFrames.load(std::memory_order_relaxed);
+    }
+    if (underrunCallbacks != nullptr) {
+        *underrunCallbacks = audioUnderrunCallbacks.load(std::memory_order_relaxed);
+    }
+}
+
+extern "C" void goldenpad_recomp_stop_game() {
+    if (runtimeStarted.load()) {
+        logEvent("runtime", "stop requested by UIKit host");
+        ultramodern::quit();
+    }
+}

--- a/Support/RecompPrototype/recomp_register_overlays.cpp
+++ b/Support/RecompPrototype/recomp_register_overlays.cpp
@@ -1,0 +1,19 @@
+#include "librecomp/overlays.hpp"
+
+#include "recomp_overlays.inl"
+
+namespace zelda64 {
+void register_overlays() {
+    recomp::overlays::overlay_section_table_data_t sections{
+        .code_sections = section_table,
+        .num_code_sections = ARRLEN(section_table),
+        .total_num_sections = num_sections,
+    };
+    recomp::overlays::overlays_by_index_t overlays{
+        .table = overlay_sections_by_index,
+        .len = ARRLEN(overlay_sections_by_index),
+    };
+    recomp::overlays::register_overlays(sections, overlays);
+
+}
+}

--- a/Support/RecompPrototype/recomp_rt64_surface_bridge.cpp
+++ b/Support/RecompPrototype/recomp_rt64_surface_bridge.cpp
@@ -1,0 +1,49 @@
+#include "plume_render_interface.h"
+
+#include <memory>
+#include <string>
+
+namespace plume {
+std::unique_ptr<RenderInterface> CreateMetalInterface();
+}
+
+namespace {
+struct MetalContext {
+    std::unique_ptr<plume::RenderInterface> renderInterface;
+    std::unique_ptr<plume::RenderDevice> device;
+    std::unique_ptr<plume::RenderCommandQueue> commandQueue;
+    std::unique_ptr<plume::RenderSwapChain> swapChain;
+    std::string status;
+};
+
+std::unique_ptr<MetalContext> context;
+}
+
+extern "C" const char *goldenpad_recomp_rt64_initialize(void *window, void *view) {
+    if (window == nullptr || view == nullptr) {
+        return nullptr;
+    }
+    auto candidate = std::make_unique<MetalContext>();
+    candidate->renderInterface = plume::CreateMetalInterface();
+    if (candidate->renderInterface == nullptr) {
+        return nullptr;
+    }
+    candidate->device = candidate->renderInterface->createDevice();
+    candidate->commandQueue = candidate->device->createCommandQueue(plume::RenderCommandListType::DIRECT);
+    const plume::RenderWindow renderWindow = {window, view};
+    candidate->swapChain = candidate->commandQueue->createSwapChain(
+        plume::RenderSwapChainDesc(renderWindow, plume::RenderFormat::B8G8R8A8_UNORM, 3));
+    if (candidate->swapChain == nullptr || !candidate->swapChain->resize()) {
+        return nullptr;
+    }
+    candidate->status = "RT64 prototype: Metal " + candidate->device->getDescription().name +
+        " " + std::to_string(candidate->swapChain->getWidth()) + "x" +
+        std::to_string(candidate->swapChain->getHeight()) +
+        "; awaiting private AOT GoldenEye output";
+    context = std::move(candidate);
+    return context->status.c_str();
+}
+
+extern "C" void goldenpad_recomp_rt64_shutdown() {
+    context.reset();
+}

--- a/Support/RecompPrototype/recomp_rt64_surface_bridge.cpp
+++ b/Support/RecompPrototype/recomp_rt64_surface_bridge.cpp
@@ -1,45 +1,39 @@
-#include "plume_render_interface.h"
-
 #include <memory>
 #include <string>
 
-namespace plume {
-std::unique_ptr<RenderInterface> CreateMetalInterface();
-}
+#if defined(GOLDENPAD_RECOMP_AOT_LINKED)
+extern "C" uint32_t goldenpad_recomp_aot_entrypoint_address();
+#endif
 
 namespace {
 struct MetalContext {
-    std::unique_ptr<plume::RenderInterface> renderInterface;
-    std::unique_ptr<plume::RenderDevice> device;
-    std::unique_ptr<plume::RenderCommandQueue> commandQueue;
-    std::unique_ptr<plume::RenderSwapChain> swapChain;
     std::string status;
 };
 
 std::unique_ptr<MetalContext> context;
+std::string failureStatus;
+
+const char *fail(const char *stage) {
+    failureStatus = "RT64 prototype: Metal initialization failed at ";
+    failureStatus += stage;
+    return failureStatus.c_str();
+}
 }
 
 extern "C" const char *goldenpad_recomp_rt64_initialize(void *window, void *view) {
     if (window == nullptr || view == nullptr) {
-        return nullptr;
+        return fail("window handle");
     }
     auto candidate = std::make_unique<MetalContext>();
-    candidate->renderInterface = plume::CreateMetalInterface();
-    if (candidate->renderInterface == nullptr) {
-        return nullptr;
-    }
-    candidate->device = candidate->renderInterface->createDevice();
-    candidate->commandQueue = candidate->device->createCommandQueue(plume::RenderCommandListType::DIRECT);
-    const plume::RenderWindow renderWindow = {window, view};
-    candidate->swapChain = candidate->commandQueue->createSwapChain(
-        plume::RenderSwapChainDesc(renderWindow, plume::RenderFormat::B8G8R8A8_UNORM, 3));
-    if (candidate->swapChain == nullptr || !candidate->swapChain->resize()) {
-        return nullptr;
-    }
-    candidate->status = "RT64 prototype: Metal " + candidate->device->getDescription().name +
-        " " + std::to_string(candidate->swapChain->getWidth()) + "x" +
-        std::to_string(candidate->swapChain->getHeight()) +
-        "; awaiting private AOT GoldenEye output";
+    // GoldenPad's working mobile renderer has one owner for each CAMetalLayer.
+    // RT64 creates the actual device/queue/swap chain after the AOT game starts,
+    // so this bridge must only validate the host surface, never claim it first.
+    candidate->status = "RT64 prototype: host Metal surface ready";
+#if defined(GOLDENPAD_RECOMP_AOT_LINKED)
+    candidate->status += "; AOT entry 0x" + std::to_string(goldenpad_recomp_aot_entrypoint_address());
+#else
+    candidate->status += "; awaiting private AOT GoldenEye output";
+#endif
     context = std::move(candidate);
     return context->status.c_str();
 }

--- a/Support/RecompPrototype/recomp_rt64_surface_stub.cpp
+++ b/Support/RecompPrototype/recomp_rt64_surface_stub.cpp
@@ -1,0 +1,7 @@
+extern "C" const char *goldenpad_recomp_rt64_initialize(void *window, void *view) {
+    (void)window;
+    (void)view;
+    return nullptr;
+}
+
+extern "C" void goldenpad_recomp_rt64_shutdown() {}

--- a/Support/RecompPrototype/recomp_rt64_surface_stub.cpp
+++ b/Support/RecompPrototype/recomp_rt64_surface_stub.cpp
@@ -1,3 +1,6 @@
+#include <algorithm>
+#include <cstdint>
+
 extern "C" const char *goldenpad_recomp_rt64_initialize(void *window, void *view) {
     (void)window;
     (void)view;
@@ -5,3 +8,41 @@ extern "C" const char *goldenpad_recomp_rt64_initialize(void *window, void *view
 }
 
 extern "C" void goldenpad_recomp_rt64_shutdown() {}
+
+extern "C" void goldenpad_recomp_set_msaa_enabled(int32_t) {}
+extern "C" void goldenpad_recomp_set_resolution_mode(int32_t) {}
+extern "C" void goldenpad_recomp_set_three_point_filtering(int32_t) {}
+extern "C" void goldenpad_recomp_set_controller_state(uint32_t, int32_t, int32_t) {}
+extern "C" void goldenpad_recomp_set_right_analog(int32_t, int32_t) {}
+extern "C" void goldenpad_recomp_set_controller_connected(int32_t) {}
+extern "C" void goldenpad_recomp_set_app_active(int32_t) {}
+extern "C" void goldenpad_recomp_queue_touch_look(int32_t, int32_t) {}
+extern "C" void goldenpad_recomp_request_crouch_toggle() {}
+extern "C" void goldenpad_recomp_set_invert_aim_y(int32_t) {}
+extern "C" void goldenpad_recomp_set_unlock_all_missions(int32_t) {}
+
+extern "C" uint32_t goldenpad_recomp_audio_render(
+    float *left, float *right, uint32_t frames) {
+    if (left != nullptr) {
+        std::fill(left, left + frames, 0.0f);
+    }
+    if (right != nullptr) {
+        std::fill(right, right + frames, 0.0f);
+    }
+    return 0;
+}
+
+extern "C" void goldenpad_recomp_audio_stats(
+    uint64_t *queuedFrames, uint64_t *renderedFrames,
+    uint64_t *nonzeroSamples, uint64_t *droppedFrames,
+    uint64_t *underrunFrames, uint64_t *underrunCallbacks) {
+    uint64_t *outputs[] = {
+        queuedFrames, renderedFrames, nonzeroSamples,
+        droppedFrames, underrunFrames, underrunCallbacks,
+    };
+    for (uint64_t *output : outputs) {
+        if (output != nullptr) {
+            *output = 0;
+        }
+    }
+}

--- a/Support/RecompPrototype/recomp_ui.h
+++ b/Support/RecompPrototype/recomp_ui.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace recompui {
+void set_render_hooks();
+}

--- a/Support/RecompPrototype/recomp_ui_stub.cpp
+++ b/Support/RecompPrototype/recomp_ui_stub.cpp
@@ -1,0 +1,3 @@
+namespace recompui {
+void set_render_hooks() {}
+}

--- a/Support/RecompPrototype/recomp_ultra_shims.cpp
+++ b/Support/RecompPrototype/recomp_ultra_shims.cpp
@@ -1,0 +1,73 @@
+#include "recomp.h"
+#include "librecomp/addresses.hpp"
+#include "librecomp/game.hpp"
+#include "librecomp/overlays.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+
+extern "C" void boot_osPiRawStartDma(uint8_t *rdram, recomp_context *ctx) {
+    // The TLBFREE boot patch only performs synchronous ROM reads.
+    if (static_cast<uint32_t>(ctx->r4) == 0) {
+        recomp::do_rom_read(
+            rdram,
+            ctx->r6,
+            static_cast<uint32_t>(ctx->r5) + recomp::rom_base,
+            static_cast<uint32_t>(ctx->r7));
+    }
+}
+
+extern "C" void recomp_load_overlays(uint8_t *, recomp_context *ctx) {
+    load_overlays(
+        static_cast<uint32_t>(ctx->r4),
+        static_cast<int32_t>(ctx->r5),
+        static_cast<uint32_t>(ctx->r6));
+}
+
+extern "C" void recomp_puts(uint8_t *rdram, recomp_context *ctx) {
+    static std::atomic<uint32_t> loggedBytes = 0;
+    static std::atomic<bool> reportedSuppression = false;
+    const gpr stringAddress = ctx->r4;
+    const uint32_t length = static_cast<uint32_t>(ctx->r5);
+    constexpr uint32_t kPatchLogLimit = 4096;
+    const uint32_t previousBytes = loggedBytes.fetch_add(length, std::memory_order_relaxed);
+    if (previousBytes >= kPatchLogLimit) {
+        if (!reportedSuppression.exchange(true, std::memory_order_relaxed)) {
+            std::fputs(
+                "[GoldenPadRecomp] patch-log: suppressed high-frequency legacy scheduler trace\n",
+                stderr);
+        }
+        return;
+    }
+    const uint32_t printableLength = std::min(length, kPatchLogLimit - previousBytes);
+    for (uint32_t index = 0; index < printableLength; ++index) {
+        std::fputc(MEM_B(index, stringAddress), stdout);
+    }
+}
+
+extern "C" void osDpGetCounters_recomp(uint8_t *, recomp_context *) {}
+extern "C" void osPiReadIo_recomp(uint8_t *, recomp_context *) {}
+
+extern "C" void osPfsInit_recomp(uint8_t *, recomp_context *ctx) {
+    // GoldenEye treats an unavailable Controller Pak as non-fatal.
+    ctx->r2 = 1;
+}
+
+extern "C" void osUnmapTLB_recomp(uint8_t *, recomp_context *) {}
+extern "C" void __osGetTLBHi_recomp(uint8_t *, recomp_context *ctx) {
+    ctx->r2 = 0;
+}
+
+extern "C" void __f_to_ll_recomp(uint8_t *, recomp_context *ctx) {
+    const int64_t value = static_cast<int64_t>(ctx->f12.fl);
+    ctx->r2 = static_cast<uint32_t>(value >> 32);
+    ctx->r3 = static_cast<uint32_t>(value);
+}
+
+extern "C" void __ll_to_d_recomp(uint8_t *, recomp_context *ctx) {
+    const int64_t value = (static_cast<int64_t>(static_cast<int32_t>(ctx->r4)) << 32) |
+        static_cast<uint32_t>(ctx->r5);
+    ctx->f0.d = static_cast<double>(value);
+}

--- a/Support/RecompPrototype/rt64_namespace_compat.hpp
+++ b/Support/RecompPrototype/rt64_namespace_compat.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "plume_render_interface_types.h"
+
+namespace RT64 {
+using RenderFormat = plume::RenderFormat;
+using RenderSampleCounts = plume::RenderSampleCounts;
+namespace RenderSampleCount = plume::RenderSampleCount;
+}

--- a/docs/RT64_N64RECOMP_MORNING_HANDOFF_2026-08-21.md
+++ b/docs/RT64_N64RECOMP_MORNING_HANDOFF_2026-08-21.md
@@ -1,0 +1,81 @@
+# GoldenPad recomp morning handoff — 2026-08-21
+
+## Accepted baseline
+
+The installed `GoldenPadRecompPrototype` build is the accepted mainline
+baseline. The 2026-08-21 physical-iPad test successfully selected and launched
+multiple missions, including Bunker, and sustained normal gameplay. The Xbox/
+MFi controller mapping felt responsive for movement, looking, aiming and
+firing. The former right-edge blue line and the severe Bunker blue-void
+rendering failure were not visible in the final run. High-resolution RT64 output
+looked substantially better than the earlier MGB64 baseline.
+
+The accepted installed/local app executable SHA-256 is
+`addd13724a405237585aa3835000a220283996bc83c980b6263ea5c3735a4826`.
+
+This acceptance is intentionally scoped. A few intermittent map glitches were
+still observed, multiplayer was not exercised, and the lifecycle failure below
+ended the run. Keep the former MGB64 app as a deprecated fallback while this
+recomp build becomes GoldenPad's main development baseline.
+
+## Morning worklist
+
+1. **Screenshot/background return can freeze gameplay.** During a mission, the
+   tester took an iPad screenshot, returned to GoldenPad, and found gameplay
+   completely frozen. The app process remained alive. Persistent diagnostics
+   recorded `host became inactive`, `host became active`, a stale-audio discard,
+   and then a watchdog with RT64 counters fixed at `dl=11144`, `vi=11143`, and
+   `presented=11051`. There was no new GoldenPad `.ips` crash report at 1:00 AM.
+   Treat this as a lifecycle hang, not a confirmed process crash. Reproduce and
+   diagnose it tomorrow; do not fold a speculative fix into tonight's baseline.
+2. **The optional center reticle is misplaced.** Enabling it placed the reticle
+   at the extreme top-right beside the three-dot button rather than at the
+   center of the rendered game viewport. The 1:00 AM screenshot records the
+   bad placement.
+3. **Add `Return to Main Menu` to the three-dot menu.** Start opens GoldenEye's
+   watch, but the tester could not find a reliable route from an active mission
+   back to mission select/title. This should be an explicit host-menu action,
+   with a confirmation if it discards mission progress.
+4. **Make graphics-setting application clear.** Toggling N64 three-point
+   filtering, 2x MSAA, and Native N64 versus Automatic high resolution produced
+   no obvious immediate visual change. Establish whether each setting is live
+   or restart-only, then communicate that in the UI. If a restart is required,
+   provide an explicit restart/apply flow instead of leaving the result
+   ambiguous.
+5. **Exercise multiplayer with multiple physical controllers.** Do not assume
+   multiplayer becomes available merely because another controller connects.
+   Verify controller enumeration, player-port assignment, touch-overlay
+   behavior and an actual multiplayer match with at least two controllers.
+6. **Record intermittent map glitches by stage and location.** The final missions
+   were overwhelmingly stable, but the tester still saw occasional geometry or
+   map glitches. Capture stage, room, camera angle and diagnostics when one is
+   reproduced. Do not reopen the rejected camera-basis experiment, which made
+   gameplay unplayably slow.
+7. **Retest physical-speaker audio.** Runtime counters showed no drops or
+   underruns in the accepted run, but occasional static was reported in earlier
+   physical listening. Keep this as a listening gate rather than treating queue
+   health alone as final audio acceptance.
+
+## Preserved evidence
+
+- User screenshot: `Screenshot 2026-08-21 at 1.00.22 AM.png` (kept outside the
+  repository because it is a private gameplay capture).
+- Current and previous bounded application logs were copied from
+  `Library/Application Support/GoldenPadRecomp/Logs` before relaunching or
+  rebuilding.
+- The current log SHA-256 is
+  `8996f3cc5936f5d12d424b336365f9cdca490810d6a34c6f878924d2b1aecd7a`.
+- The previous log SHA-256 is
+  `c1a3e2d7d498515a25e062662cde57854292d4cb98116d3f3487136fa6aa6fbf`.
+- The most recent pre-existing CPU-resource report was also copied for later
+  comparison; its SHA-256 is
+  `b5d17d962435f86dd054b7faeac7976842fc2b905dfb7522d866fe29637f0f73`.
+- Raw logs, `.ips` files, ROM data, saves and gameplay captures remain private
+  local evidence and are not committed.
+
+## Release boundary
+
+The final run is strong physical evidence for a public tech-demo baseline, not
+proof that every mission, multiplayer, screenshot/resume path or audio route is
+release-complete. Tomorrow's first gate is the screenshot/background-return
+freeze; the other work should remain small and independently verifiable.

--- a/docs/RT64_N64RECOMP_PROTOTYPE.md
+++ b/docs/RT64_N64RECOMP_PROTOTYPE.md
@@ -1,5 +1,9 @@
 # RT64 + N64Recomp prototype
 
+The accepted physical-iPad baseline and its bounded next-day worklist are
+recorded in
+[`RT64_N64RECOMP_MORNING_HANDOFF_2026-08-21.md`](RT64_N64RECOMP_MORNING_HANDOFF_2026-08-21.md).
+
 ## Objective and isolation
 
 This branch evaluates a **separate**, non-production `GoldenPadRecompPrototype`
@@ -7,7 +11,7 @@ iOS/iPadOS app for the original Nintendo 64 release of GoldenEye 007. It does
 not alter the `GoldenPad` MGB64 target, bundle identifier, container, saves, or
 renderer. The prototype identifier is
 `com.chrissotraidis.goldenpad.recomp-prototype`, so it can coexist with
-production in a Simulator.
+production in Simulator or on hardware.
 
 The intended execution route is AOT/static N64Recomp output from a user-owned
 US retail ROM, N64ModernRuntime's libultra replacement, and RT64's Metal
@@ -47,37 +51,39 @@ GoldenEye64Recomp's local, pinned `vanilla_to_tlbfree.xdelta` input and writes
 only outside the repository. N64Recomp then consumes the private TLB-free ROM
 and `us.toml`; the generated `RecompiledFuncs/` directory remains private.
 
-No retail ROM was located in the project workspace during this audit, so this
-branch has not generated or inspected game-derived code.
+A user-supplied ROM was later imported into private local build and app-container
+storage for validation. The repository still contains no retail ROM, generated
+game functions, extracted assets, saves or captures.
 
 ## AOT iOS finding
 
-N64ModernRuntime currently unconditionally builds N64Recomp's `LiveRecomp`
+N64ModernRuntime upstream unconditionally builds N64Recomp's `LiveRecomp`
 target. It failed for ARM64 iOS Simulator in SLJIT's Apple executable allocator,
 which is expected for an iOS AOT path and is not a source failure. The narrow
 patch [`patches/n64modernruntime-ios-aot.patch`](../patches/n64modernruntime-ios-aot.patch)
 skips that live-recompiler dependency when the runtime is only used with static
 generated C/C++. It applies and reverses cleanly against the exact ignored
-checkout, and produced ARM64 Simulator `libultramodern.a` and `liblibrecomp.a`.
-It has not yet been integrated into the app target.
+checkout, and produced ARM64 Simulator and iPhoneOS `libultramodern.a` and
+`liblibrecomp.a`. The private AOT build now uses those archives in the
+isolated prototype target.
 
 ## RT64/UIKit host
 
 `GoldenPadRecompPrototype` is an independent CMake/Xcode target. Its SwiftUI
 host owns an `MTKView`/`CAMetalLayer` and uses its own C++ bridge to create
-RT64's Plume Metal interface and swapchain. The initial ARM64 Simulator host
-build passed with the unique bundle identifier and contains neither `bossEntry`
-nor `goldenpad_mgb64_*` symbols. This is host/surface evidence only; it does
-not submit a colored triangle or a synthetic display list and does **not** count
-as RT64 GoldenEye rendering.
+RT64's Plume Metal interface and swapchain. The ARM64 Simulator and iPhoneOS
+builds use the unique bundle identifier and contain neither production MGB64
+runtime nor production app state. The target now submits the recompiled game's
+real display lists to RT64; synthetic render tests are not used as gameplay
+evidence.
 
 ## Required game path and carried fixes
 
-The next integration stage must register a UIKit-native N64ModernRuntime
-renderer context and call RT64's `loadUCodeGBI` plus `processDisplayLists` with
-the actual `OSTask` RSP/DP data and RDRAM from the recompiled game. It must also
-adapt production's AVAudioEngine, GameController/touch snapshots, atomic save
-root and scene lifecycle rather than transplanting the macOS AppKit/SDL host.
+The prototype registers a UIKit-native N64ModernRuntime renderer context and
+calls RT64's `loadUCodeGBI` plus `processDisplayLists` with actual `OSTask`
+RSP/DP data and RDRAM from the recompiled game. It also has prototype-local
+AVAudioEngine, GameController/touch snapshots, private config/log storage and
+scene lifecycle rather than transplanting the macOS AppKit/SDL host.
 
 The following changes are required before considering a frame valid:
 
@@ -94,7 +100,7 @@ The following changes are required before considering a frame valid:
    fixes are absent from the static generator route rather than applying them
    blindly.
 
-## Rendering validation and known blocker
+## Rendering validation
 
 The rendering order is intro logos/gunbarrel, main menu/briefings, then Dam.
 For every checkpoint, capture a private deterministic frame and record display
@@ -102,20 +108,17 @@ list submissions, texture-cache hits/misses, TMEM upload bytes, pipeline
 creation, frame time and FPS. Compare equal internal/output resolution against
 production MGB64; Simulator results are not iPhone/iPad performance claims.
 
-GoldenEye64Recomp currently reports black skyboxes and flat water because their
-custom command path is not represented by RT64. The completed GoldenEye decomp
-builds the sky/water from projected vertices (`skyRenderTri`/`skyRenderFull`),
-and Perfect Dark's non-N64 port converts the equivalent projected vertices into
-ordinary allocated vertices before submitting display-list triangles. The first
-candidate fix is therefore a small GoldenEye-specific conversion of those
-computed vertices into ordinary RT64-supported triangles (or documented RT64
-extended commands), preserving texture coordinates and vertex color. A flat
-clear color is unacceptable as a final result. Framebuffer-dependent glass,
-monitors and blending remain separate validation gates after base geometry.
+The current hardware build renders the intro, menus and playable stages through
+RT64 at automatic high resolution, expanded aspect and optional 2x MSAA. It uses
+the original presentation rate because display-rate interpolation exposed
+intermittent geometry shimmer. Sky, water, framebuffer-dependent glass,
+monitors, blending, camera near-plane behavior and later-stage effects remain
+separate validation gates; a correct Dam frame is not proof that every effect
+or mission is correct.
 
 ## Build and Simulator instructions
 
-Build the current ROM-free host:
+Build the ROM-free host checks:
 
 ```sh
 ./scripts/verify-recomp-prototype-host.sh
@@ -127,27 +130,126 @@ with `GOLDENPAD_RECOMP_RT64_ARCHIVE_DIR` and
 `GOLDENPAD_RECOMP_RT64_SOURCE_DIR`. The subsequent AOT integration will add the
 ignored N64ModernRuntime checkout and private generated output explicitly.
 
-On the current host, `verify-rt64-ios-static.sh` reaches RT64's generated MSL
-compile and stops because `xcrun -sdk macosx metal` reports a missing Metal
-Toolchain. Xcode 26.6's `xcodebuild -downloadComponent MetalToolchain` completed
-successfully, but the command still reports the component unavailable. This is
-a host-toolchain registration blocker, not an RT64 source or iOS patch failure;
-the patches apply/reverse cleanly. Do not treat the surface-only host as a
-linked RT64 renderer until this command succeeds and the four verified archives
-exist.
+The static-archive verifier uses the installed Metal toolchain via
+`TOOLCHAINS=metal-2600.50.6.1` and
+`GOLDENPAD_METAL_TOOLCHAIN=metal-2600.50.6.1`. Private generated game output
+and runtime build directories remain explicit local inputs and are not
+committed.
 
 After a supported private ROM is supplied, build/install/launch evidence must
 be separate from game-frame evidence. It must install via `simctl` without
 removing `com.chrissotraidis.goldenpad`; capture intro, menu and Dam privately;
 and retain console/PID/liveness logs independently.
 
+## Current AOT result — 2026-08-20
+
+The isolated target now links private generated AOT sources, the AOT-only
+N64ModernRuntime archives and RT64. With the user-supplied ROM staged only in
+the prototype container, the process reaches real GoldenEye PI DMA, scheduler,
+RSP and DP completion work. This is execution evidence, not a rendered-frame
+claim. ROM derivatives, generated sources, saves and captures remain ignored
+private state and are never committed.
+
+The original Simulator failure was RT64's flat common-set ABI: it requested 52
+buffers and 18 samplers where the Simulator permits 31 and 16. The private,
+Simulator-only static archive now removes unused extended/ray-tracing bindings,
+aliases the remaining samplers, and bypasses unavailable counter sampling. It
+renders real GoldenEye frames from the user-supplied input. Hardware validation
+has since advanced through intro, menus and playable stages. This remains a
+private prototype result, not a claim that every stage or effect is complete.
+
+The prototype has independent input plumbing using the production GoldenPad
+touch placement and tuning: move, relative look, fire, aim, action, duck,
+weapon and Start. AIM supports toggle or hold and has a distinct yellow active
+state; DUCK is a yellow C-button-style action. Look uses the production 1.5x
+swipe accumulation, 4x default sensitivity and one-third-speed precision while
+aiming. Settings include aim behavior, optional aim-only vertical inversion,
+an optional centered reticle and persisted 2x MSAA. A prototype-only
+`Unlock all missions` setting uses GoldenEye's existing mission-availability
+predicate without marking missions complete or writing EEPROM. It is intended
+for later-stage rendering tests and leaves the user's real save progression
+unchanged. Its
+N64ModernRuntime bridge explicitly advertises a normal controller in port 1,
+matching the reference implementation; it previously reported `Device::None`,
+which caused GoldenEye's controller-socket error. A Simulator UI gesture on A
+was verified in the native log as button bit `0x8000` followed by release. The
+bridge is prototype-local and does not use or change the production MGB64 input
+system.
+
+The native GameController map supports Xbox/MFi-style hardware: left stick
+moves, right stick supplies modern analog look, LT aims, RT fires, A/Y changes
+weapon, B/X acts, LB toggles duck, RB changes weapon, Menu is Start and the
+d-pad maps directly. Code-path and connection reporting are verified; a full
+physical Bluetooth controller playthrough is still an acceptance gate.
+
+Patch regeneration produces a matched `RecompiledPatches/patches.c` and
+embedded `patches_bin.c`; rebuilding or installing with only one half updated
+is an invalid black-screen artifact and must fail the display-list liveness
+gate. A later experiment that rebuilt `field_488.applied_view` after modern
+look was also rejected: it reduced physical-iPad gameplay presentation to about
+17-18 frames per second and made controller input feel sluggish.
+
+The bridge writes bounded `[GoldenPadRecomp]` unified-log events for ROM
+validation, runtime/overlay setup, the active game loop, controller presence,
+first polling/input state, button transitions, audio submission, rumble
+requests, stop, and errors. It intentionally emits no per-frame port warnings.
+Audio is consumed by a 22,050 Hz stereo `AVAudioSourceNode` and converted by
+AVAudioEngine to the current device route. Diagnostics separately report the
+real queued, rendered, non-zero, producer-dropped and consumer-underrun frame
+counts. Physical logging identified the reported static as consumer cadence
+jitter rather than a sample-rate mismatch: the game and engine averaged the
+same rate, but larger AVAudioEngine pulls occasionally arrived just before the
+next per-VI game chunk. The host now keeps a 1,024-frame scheduling reserve,
+prebuffers about 46 ms and uses 32-frame fades only when rebuffering. The final
+hardware soak rendered more than 2.3 million frames with zero underrun frames,
+zero underrun callbacks and zero producer drops. Physical-speaker listening
+remains the final audio acceptance gate. The iOS ring now also matches the
+reference GoldenEye64Recomp host's stereo-pair swap required by
+N64ModernRuntime's RDRAM address ordering; queue health alone could not detect
+that channel-order defect.
+
+For runtime diagnosis, the prototype also applies a temporary,
+reversible trace at the reference RT64 render-context seam. It reports the
+first display list and every 300 thereafter, alongside the equivalent VI
+presentation count. Physical soaks have reached tens of thousands of processed
+display lists and VI updates. A pre-fix hardware run rendered more than 15.5
+million audio frames without reproducing the former
+`alAuxBusPull`/`alEnvmixerPull` crash. Those faults were traced to 32-bit N64
+KSEG addresses losing sign extension across nested recompiled audio calls; the
+AOT runtime patch now canonicalizes all RDRAM accesses to the 29-bit physical
+address range.
+
+The host explicitly fills and clips the Metal surface over an edge-to-edge
+black background. A former two-physical-pixel blue strip at the right edge is
+no longer visible in the latest QuickTime hardware frame. This is visible-seam
+evidence, not yet a claim that every UIKit/CAMetalLayer drawable dimension has
+been proven across all device sizes and orientations.
+
+An in-place hardware update on 2026-08-20 preserved prototype database UUID
+`D2F4E1F3-F310-4A01-8ED7-65B907FAA17B`. A subsequent 34.7-second QuickTime
+capture showed playable full-frame RT64 output with no visible right-edge blue
+strip. During the same title/demo progression, native counters exceeded four
+thousand display-list/VI updates and two million rendered audio frames with no
+consumer underruns or producer drops. The capture contained a 48 kHz mono
+audio track but at an extremely low recorded level, so it is not used as a
+physical-speaker static acceptance result.
+
+When rebuilding the AOT target, temporarily apply and reverse the existing
+RT64 iOS SDK, embedded-host and Plume patches around the Xcode build: the
+external RT64 render-context source otherwise includes the desktop SDL path.
+The RT64 static-archive verifier works with the downloaded Metal component via
+`TOOLCHAINS=metal-2600.50.6.1` and
+`GOLDENPAD_METAL_TOOLCHAIN=metal-2600.50.6.1`.
+
 ## Migration gates and current recommendation
 
-Do not migrate production based on the current host build. Continue MGB64 while
-the prototype advances. Migration requires all of the following: AOT game
-execution, real intro/menu/Dam RT64 frames, correct textures/core geometry,
-audio plus touch or controller, confirmed or specifically reproduced sky/water
-state, framebuffer effects, an equivalent-settings comparison, and a clean
-ROM/generated-code audit. Until then, the recommendation is **continue both
-temporarily**: production MGB64 remains the playable baseline and this isolated
-prototype is the RT64 investigation path.
+Do not replace production based on build/install/liveness evidence alone. The
+prototype now has AOT game execution, real intro/menu/gameplay RT64 frames,
+native audio and the production touch schema, so it is the stronger path for
+high-resolution rendering and continued stabilization. Migration still
+requires physical controller acceptance, physical-speaker audio acceptance,
+longer mission/lifecycle soaks, later-stage/effect comparison, save
+compatibility and a clean ROM/generated-code audit. Until those pass, the
+recommendation remains **continue both temporarily**: production MGB64 is the
+known fallback while the isolated recomp prototype is brought to replacement
+quality.

--- a/docs/RT64_N64RECOMP_PROTOTYPE.md
+++ b/docs/RT64_N64RECOMP_PROTOTYPE.md
@@ -1,0 +1,144 @@
+# RT64 + N64Recomp prototype
+
+## Objective and isolation
+
+This branch evaluates a **separate**, non-production `GoldenPadRecompPrototype`
+iOS/iPadOS app for the original Nintendo 64 release of GoldenEye 007. It does
+not alter the `GoldenPad` MGB64 target, bundle identifier, container, saves, or
+renderer. The prototype identifier is
+`com.chrissotraidis.goldenpad.recomp-prototype`, so it can coexist with
+production in a Simulator.
+
+The intended execution route is AOT/static N64Recomp output from a user-owned
+US retail ROM, N64ModernRuntime's libultra replacement, and RT64's Metal
+renderer. No live JIT or executable-memory allocation is permitted in the iOS
+route. The current target is a buildable UIKit/CAMetalLayer host only; it never
+claims to render a game frame until private AOT output drives real RSP/RDP tasks.
+
+## Dependency record and license boundary
+
+Verified on 2026-08-20 using public primary repositories:
+
+| Dependency | Commit | License/status | Prototype use |
+| --- | --- | --- | --- |
+| `n64decomp/007` | `c4356466796c697dfd298010b9bed261f9ed8c6a` | No top-level license found; original-game rights remain unresolved | Behavioral/oracle reference only |
+| `cblock85/GoldenEye64Recomp` | `a787fe0d95e8278fcba5ba2d768fa6a606e75f55` | GPL-3.0 | Static configuration, conversion and fix reference; isolate any reuse |
+| `kholdfuzion/GoldenRecomp` | `f31b5d1e214f57c9ddb3dc598daa688bccffdd4f` | GPL-3.0 | Historical/static-recomp reference only |
+| `N64Recomp/N64Recomp` | `ffb39cdad1da5de07eaaa48bd1db4a89a7986771` | MIT | Static generator/tooling |
+| `N64Recomp/N64ModernRuntime` | `589bbf018a3e6d3646ddf7de1e7919f1b7e99bb1` | GPL-3.0 | Runtime, input/audio/queues/saves |
+| `rt64/rt64` | `5473732a822a4423b5696e7cb18fecc425a59875` | MIT | RDP renderer; Plume submodule `d890ac899e505fb30040e037a4037cdeca68f033` |
+| `Kenix3/libultraship` | `7eb555d06656271556efc9cb9b23fc39b31b9aef` | MIT | Fast3D design reference only |
+| `perfect-dark-pc-port/perfect_dark` | `32a1cb9f268dd3ac73016801025c6bbbfa20130f` | MIT | Sky conversion reference only |
+
+Linking N64ModernRuntime or GoldenEye64Recomp-derived code creates a GPL-3.0
+prototype distribution obligation. Therefore it must remain a separately
+documented target and cannot be folded into production MGB64 without a separate
+licensing and migration decision. The N64 decomp's public readability does not
+place game code or assets in the public domain.
+
+## ROM and generated-code boundary
+
+Only the normalized US retail dump with SHA-1
+`abe01e4aeb033b6c0836819f549c791b26cfde83` is in scope. Retail ROM bytes,
+TLB-free converted ROM bytes, extracted assets, AOT-generated game functions,
+RSP output, saves and captures stay in ignored local storage. They must never
+be committed, packaged or cited in public evidence. The planned conversion uses
+GoldenEye64Recomp's local, pinned `vanilla_to_tlbfree.xdelta` input and writes
+only outside the repository. N64Recomp then consumes the private TLB-free ROM
+and `us.toml`; the generated `RecompiledFuncs/` directory remains private.
+
+No retail ROM was located in the project workspace during this audit, so this
+branch has not generated or inspected game-derived code.
+
+## AOT iOS finding
+
+N64ModernRuntime currently unconditionally builds N64Recomp's `LiveRecomp`
+target. It failed for ARM64 iOS Simulator in SLJIT's Apple executable allocator,
+which is expected for an iOS AOT path and is not a source failure. The narrow
+patch [`patches/n64modernruntime-ios-aot.patch`](../patches/n64modernruntime-ios-aot.patch)
+skips that live-recompiler dependency when the runtime is only used with static
+generated C/C++. It applies and reverses cleanly against the exact ignored
+checkout, and produced ARM64 Simulator `libultramodern.a` and `liblibrecomp.a`.
+It has not yet been integrated into the app target.
+
+## RT64/UIKit host
+
+`GoldenPadRecompPrototype` is an independent CMake/Xcode target. Its SwiftUI
+host owns an `MTKView`/`CAMetalLayer` and uses its own C++ bridge to create
+RT64's Plume Metal interface and swapchain. The initial ARM64 Simulator host
+build passed with the unique bundle identifier and contains neither `bossEntry`
+nor `goldenpad_mgb64_*` symbols. This is host/surface evidence only; it does
+not submit a colored triangle or a synthetic display list and does **not** count
+as RT64 GoldenEye rendering.
+
+## Required game path and carried fixes
+
+The next integration stage must register a UIKit-native N64ModernRuntime
+renderer context and call RT64's `loadUCodeGBI` plus `processDisplayLists` with
+the actual `OSTask` RSP/DP data and RDRAM from the recompiled game. It must also
+adapt production's AVAudioEngine, GameController/touch snapshots, atomic save
+root and scene lifecycle rather than transplanting the macOS AppKit/SDL host.
+
+The following changes are required before considering a frame valid:
+
+1. Preserve SP/DP completion messages with a FIFO pending queue when the game
+   scheduler queue is full; upstream current drops them.
+2. Force RT64's ubershader route on Metal until the specialized shader issue is
+   reproduced as fixed; otherwise character, weapon and logo geometry may be
+   absent.
+3. Guard interpolation for incompatible/teleport rotations and clamp the
+   angular `acos` input.
+4. Patch the static `cosf` fallthrough into `sinf` in the private generated
+   function output; no live-recompiler-only fix belongs in the AOT target.
+5. Verify that live-only odd-FPR, `mtc1` width and cross-section jump-table
+   fixes are absent from the static generator route rather than applying them
+   blindly.
+
+## Rendering validation and known blocker
+
+The rendering order is intro logos/gunbarrel, main menu/briefings, then Dam.
+For every checkpoint, capture a private deterministic frame and record display
+list submissions, texture-cache hits/misses, TMEM upload bytes, pipeline
+creation, frame time and FPS. Compare equal internal/output resolution against
+production MGB64; Simulator results are not iPhone/iPad performance claims.
+
+GoldenEye64Recomp currently reports black skyboxes and flat water because their
+custom command path is not represented by RT64. The completed GoldenEye decomp
+builds the sky/water from projected vertices (`skyRenderTri`/`skyRenderFull`),
+and Perfect Dark's non-N64 port converts the equivalent projected vertices into
+ordinary allocated vertices before submitting display-list triangles. The first
+candidate fix is therefore a small GoldenEye-specific conversion of those
+computed vertices into ordinary RT64-supported triangles (or documented RT64
+extended commands), preserving texture coordinates and vertex color. A flat
+clear color is unacceptable as a final result. Framebuffer-dependent glass,
+monitors and blending remain separate validation gates after base geometry.
+
+## Build and Simulator instructions
+
+Build the current ROM-free host:
+
+```sh
+./scripts/verify-recomp-prototype-host.sh
+```
+
+To link the already verified RT64 static archives, first produce them with
+`GOLDENPAD_RT64_ARTIFACT_DIR` using `verify-rt64-ios-static.sh`, then configure
+with `GOLDENPAD_RECOMP_RT64_ARCHIVE_DIR` and
+`GOLDENPAD_RECOMP_RT64_SOURCE_DIR`. The subsequent AOT integration will add the
+ignored N64ModernRuntime checkout and private generated output explicitly.
+
+After a supported private ROM is supplied, build/install/launch evidence must
+be separate from game-frame evidence. It must install via `simctl` without
+removing `com.chrissotraidis.goldenpad`; capture intro, menu and Dam privately;
+and retain console/PID/liveness logs independently.
+
+## Migration gates and current recommendation
+
+Do not migrate production based on the current host build. Continue MGB64 while
+the prototype advances. Migration requires all of the following: AOT game
+execution, real intro/menu/Dam RT64 frames, correct textures/core geometry,
+audio plus touch or controller, confirmed or specifically reproduced sky/water
+state, framebuffer effects, an equivalent-settings comparison, and a clean
+ROM/generated-code audit. Until then, the recommendation is **continue both
+temporarily**: production MGB64 remains the playable baseline and this isolated
+prototype is the RT64 investigation path.

--- a/docs/RT64_N64RECOMP_PROTOTYPE.md
+++ b/docs/RT64_N64RECOMP_PROTOTYPE.md
@@ -127,6 +127,15 @@ with `GOLDENPAD_RECOMP_RT64_ARCHIVE_DIR` and
 `GOLDENPAD_RECOMP_RT64_SOURCE_DIR`. The subsequent AOT integration will add the
 ignored N64ModernRuntime checkout and private generated output explicitly.
 
+On the current host, `verify-rt64-ios-static.sh` reaches RT64's generated MSL
+compile and stops because `xcrun -sdk macosx metal` reports a missing Metal
+Toolchain. Xcode 26.6's `xcodebuild -downloadComponent MetalToolchain` completed
+successfully, but the command still reports the component unavailable. This is
+a host-toolchain registration blocker, not an RT64 source or iOS patch failure;
+the patches apply/reverse cleanly. Do not treat the surface-only host as a
+linked RT64 renderer until this command succeeds and the four verified archives
+exist.
+
 After a supported private ROM is supplied, build/install/launch evidence must
 be separate from game-frame evidence. It must install via `simctl` without
 removing `com.chrissotraidis.goldenpad`; capture intro, menu and Dam privately;

--- a/patches/goldeneye64recomp-ios-modern-controls.patch
+++ b/patches/goldeneye64recomp-ios-modern-controls.patch
@@ -1,0 +1,113 @@
+diff --git a/patches/externs.h b/patches/externs.h
+index 609e348..a6dfd75 100644
+--- a/patches/externs.h
++++ b/patches/externs.h
+@@ -406,6 +406,7 @@ extern f32 titleTransitionX;
+ extern Mtxf dword_CODE_bss_80079E98;
+ extern f32 g_SkyCloudOffset;
+ extern struct player* g_CurrentPlayer;
++void bondviewApplyVertaTheta(void);
+ extern s32 cameraFrameCounter1;
+ extern s32 cameraFrameCounter2;
+ extern s32 cameraBufferToggle;
+diff --git a/patches/patches.h b/patches/patches.h
+index 77b502e..c55b224 100644
+--- a/patches/patches.h
++++ b/patches/patches.h
+@@ -117,6 +117,9 @@ int recomp_printf(const char* fmt, ...);
+     extern u8 identifier[]
+ 
+ float recomp_get_aspect_ratio(float);
++void recomp_get_camera_inputs(float* x, float* y);
++s32 goldenpad_recomp_consume_crouch_toggle(void);
++s32 goldenpad_recomp_unlock_all_missions_enabled(void);
+ void recomp_crash(const char* err);
+ 
+ #endif
+diff --git a/patches/syms.ld b/patches/syms.ld
+index 31e51b1..8aec43d 100644
+--- a/patches/syms.ld
++++ b/patches/syms.ld
+@@ -76,4 +76,6 @@ boot_osPiRawStartDma = 0x8F000100;
+ osGetCount_recomp = 0x8F000104;
+ sprintf_recomp = 0x8F000108;
+ osPfsInit_recomp = 0x8F00010C;
+-osMotorInit_recomp = 0x8F000110;
+\ No newline at end of file
++osMotorInit_recomp = 0x8F000110;
++goldenpad_recomp_consume_crouch_toggle = 0x8F000114;
++goldenpad_recomp_unlock_all_missions_enabled = 0x8F000118;
+diff --git a/patches/workbench_theboy.c b/patches/workbench_theboy.c
+index d4424c7..bf55d78 100644
+--- a/patches/workbench_theboy.c
++++ b/patches/workbench_theboy.c
+@@ -473,6 +473,61 @@ void InitFrameRateControl(void)
+ extern s32 g_DebugMode;
+ extern s32 g_DebugHighlightedOption;
+ 
++RECOMP_PATCH s32 get_debug_enable_all_levels_flag(void)
++{
++    return goldenpad_recomp_unlock_all_missions_enabled();
++}
++
++static void goldenpadApplyModernTouchControls(void)
++{
++    static s32 crouched = FALSE;
++    f32 lookX = 0.0f;
++    f32 lookY = 0.0f;
++    f32 degreesPerFrame;
++
++    if (g_StageNum == LEVELID_TITLE || g_CurrentPlayer == NULL ||
++        g_CurrentPlayer->prop == NULL || g_CurrentPlayer->bonddead) {
++        crouched = FALSE;
++        goldenpad_recomp_consume_crouch_toggle();
++        return;
++    }
++
++    recomp_get_camera_inputs(&lookX, &lookY);
++    if (lookX != 0.0f || lookY != 0.0f) {
++        /* GoldenPad's tuned MGB64 path resolves to 3 degrees per frame at
++         * full deflection, and one third of that while aiming. */
++        degreesPerFrame = g_CurrentPlayer->insightaimmode ? 1.0f : 3.0f;
++        g_CurrentPlayer->vv_theta += lookX * degreesPerFrame;
++        g_CurrentPlayer->vv_verta += lookY * degreesPerFrame;
++
++        while (g_CurrentPlayer->vv_theta < 0.0f) {
++            g_CurrentPlayer->vv_theta += 360.0f;
++        }
++        while (g_CurrentPlayer->vv_theta >= 360.0f) {
++            g_CurrentPlayer->vv_theta -= 360.0f;
++        }
++        if (g_CurrentPlayer->vv_verta > 90.0f) {
++            g_CurrentPlayer->vv_verta = 90.0f;
++        }
++        if (g_CurrentPlayer->vv_verta < -90.0f) {
++            g_CurrentPlayer->vv_verta = -90.0f;
++        }
++        g_CurrentPlayer->vv_verta360 = g_CurrentPlayer->vv_verta;
++        if (g_CurrentPlayer->vv_verta360 < 0.0f) {
++            g_CurrentPlayer->vv_verta360 += 360.0f;
++        }
++        g_CurrentPlayer->speedtheta = 0.0f;
++        g_CurrentPlayer->speedverta = 0.0f;
++        bondviewApplyVertaTheta();
++    }
++
++    if (goldenpad_recomp_consume_crouch_toggle()) {
++        crouched = !crouched;
++        /* GoldenEye's native crouch enum is squat=0, half=1, stand=2. */
++        g_CurrentPlayer->crouchpos = crouched ? 0 : 2;
++    }
++}
++
+ RECOMP_PATCH void bossMainloop(void) {
+     // declarations
+ 
+@@ -702,6 +757,7 @@ RECOMP_PATCH void bossMainloop(void) {
+                                     viSetViewPosition(localPlayer->viewleft, localPlayer->viewtop);
+ 
+                                     lvlViewMoveTick();
++                                    goldenpadApplyModernTouchControls();
+                                 }
+                             }
+ 

--- a/patches/goldeneye64recomp-ios-prototype-render-trace.patch
+++ b/patches/goldeneye64recomp-ios-prototype-render-trace.patch
@@ -1,0 +1,107 @@
+--- a/src/main/rt64_render_context.cpp
++++ b/src/main/rt64_render_context.cpp
+@@ -1,5 +1,11 @@
+ #include <memory>
++#include <atomic>
++#include <cstdlib>
+ #include <cstring>
++#include <filesystem>
++#if __has_include(<TargetConditionals.h>)
++#include <TargetConditionals.h>
++#endif
+ 
+ // Undefine problematic X11 macros before including RT64 headers
+ #ifdef None
+@@ -22,4 +23,9 @@
+ #include "ultramodern/ultramodern.hpp"
+ #include "ultramodern/config.hpp"
+ 
++#ifdef MIN
++#undef MIN
++#endif
++#include <os/log.h>
++
+ #include "zelda_render.h"
+@@ -30,6 +32,13 @@
+ static uint8_t DMEM[0x1000];
+ static uint8_t IMEM[0x1000];
+ 
++static std::atomic<uint64_t> goldenpad_display_list_count = 0;
++static std::atomic<uint64_t> goldenpad_screen_update_count = 0;
++static std::atomic<uint64_t> goldenpad_presented_count = 0;
++extern "C" int32_t goldenpad_recomp_is_app_active();
++extern "C" int32_t goldenpad_recomp_three_point_filtering_enabled();
++extern "C" void goldenpad_recomp_note_display_list(uint64_t count);
++extern "C" void goldenpad_recomp_note_screen_progress(uint64_t updates, uint64_t presented);
+ unsigned int MI_INTR_REG = 0;
+ 
+ unsigned int DPC_START_REG = 0;
+@@ -249,5 +262,11 @@
+     // Set up the RT64 application configuration fields.
+     RT64::ApplicationConfiguration appConfig;
+     appConfig.useConfigurationFile = false;
++#if TARGET_OS_IPHONE
++    // The data-container root is not writable on physical iPadOS devices.
++    // Keep RT64's private artifacts in the app's writable support directory.
++    appConfig.detectDataPath = false;
++    appConfig.dataPath = std::filesystem::path(std::getenv("HOME")) / "Library/Application Support/GoldenPadRecompRT64";
++#endif
+ 
+     // Create the RT64 application.
+@@ -256,4 +280,5 @@
+     // Set initial user config settings based on the current settings.
+     auto& cur_config = ultramodern::renderer::get_graphics_config();
+     set_application_user_config(app.get(), cur_config);
++    app->userConfig.threePointFiltering = goldenpad_recomp_three_point_filtering_enabled() != 0;
+     app->userConfig.developerMode = debug;
+@@ -280,10 +301,11 @@ zelda64::renderer::RT64Context::RT64Context(uint8_t* rdram, ultramodern::renderer::WindowHandle window_handle, bool debug) {
+     // Set up the RT64 application.
+     uint32_t thread_id = 0;
+ #ifdef _WIN32
+     thread_id = window_handle.thread_id;
+ #endif
+     setup_result = map_setup_result(app->setup(thread_id));
++    fprintf(stderr, "[GoldenPadRecomp] render: RT64 setup %s\n", setup_result == ultramodern::renderer::SetupResult::Success ? "ready" : "failed");
+     if (setup_result != ultramodern::renderer::SetupResult::Success) {
+         app = nullptr;
+         return;
+     }
+@@ -313,5 +339,14 @@
+ 
+ void zelda64::renderer::RT64Context::send_dl(const OSTask* task) {
++    const uint64_t count = goldenpad_display_list_count.fetch_add(1) + 1;
++    goldenpad_recomp_note_display_list(count);
++    if (count == 1 || count % 300 == 0) {
++        fprintf(stderr, "[GoldenPadRecomp] render: processed %llu display lists\n",
++            static_cast<unsigned long long>(count));
++        os_log_with_type(OS_LOG_DEFAULT, OS_LOG_TYPE_DEFAULT,
++            "[GoldenPadRecomp] render: processed %{public}llu display lists",
++            static_cast<unsigned long long>(count));
++    }
+     app->state->rsp->reset();
+     app->interpreter->loadUCodeGBI(task->t.ucode & 0x3FFFFFF, task->t.ucode_data & 0x3FFFFFF, true);
+     app->processDisplayLists(app->core.RDRAM, task->t.data_ptr & 0x3FFFFFF, 0, true);
+@@ -319,5 +354,23 @@
+ void zelda64::renderer::RT64Context::update_screen(uint32_t vi_origin) {
++    const uint64_t count = goldenpad_screen_update_count.fetch_add(1) + 1;
++    uint64_t presented = goldenpad_presented_count.load();
++    goldenpad_recomp_note_screen_progress(count, presented);
++    if (count == 1 || count % 300 == 0) {
++        fprintf(stderr, "[GoldenPadRecomp] render: presented %llu VI updates\n",
++            static_cast<unsigned long long>(count));
++        os_log_with_type(OS_LOG_DEFAULT, OS_LOG_TYPE_DEFAULT,
++            "[GoldenPadRecomp] render: presented %{public}llu VI updates",
++            static_cast<unsigned long long>(count));
++    }
+     VI_ORIGIN_REG = vi_origin;
+ 
++    // UIKit can temporarily make CAMetalLayer drawables unavailable while the
++    // app is backgrounded. Avoid entering RT64's presentation path until the
++    // host is active again; the next VI resumes from the current game state.
++    if (!goldenpad_recomp_is_app_active()) {
++        return;
++    }
+     app->updateScreen();
++    presented = goldenpad_presented_count.fetch_add(1) + 1;
++    goldenpad_recomp_note_screen_progress(count, presented);
+ }

--- a/patches/n64modernruntime-ios-aot.patch
+++ b/patches/n64modernruntime-ios-aot.patch
@@ -1,51 +1,215 @@
 diff --git a/N64Recomp/CMakeLists.txt b/N64Recomp/CMakeLists.txt
-index 34dc7e8..0000000 100644
 --- a/N64Recomp/CMakeLists.txt
 +++ b/N64Recomp/CMakeLists.txt
-@@ -180,28 +180,30 @@ target_link_libraries(RecompModMerger N64Recomp)
+@@ -167,5 +167,6 @@ target_link_libraries(OfflineModRecomp fmt rabbitizer tomlplusplus::tomlplusplu
+ 
  # Live recompiler
 +if (N64RECOMP_ENABLE_LIVE_RECOMP)
  project(LiveRecomp)
  add_library(LiveRecomp)
  
- target_sources(LiveRecomp PRIVATE
-     ${CMAKE_CURRENT_SOURCE_DIR}/LiveRecomp/live_generator.cpp
-     ${CMAKE_CURRENT_SOURCE_DIR}/lib/sljit/sljit_src/sljitLir.c
- )
- 
- target_include_directories(LiveRecomp PRIVATE
-     ${CMAKE_CURRENT_SOURCE_DIR}/lib/sljit/sljit_src
- )
- 
- target_link_libraries(LiveRecomp N64Recomp)
- 
- # Live recompiler test
- project(LiveRecompTest)
- add_executable(LiveRecompTest)
- 
- target_sources(LiveRecompTest PRIVATE
-     ${CMAKE_CURRENT_SOURCE_DIR}/LiveRecomp/live_recompiler_test.cpp
- )
- 
- target_include_directories(LiveRecompTest PRIVATE
-     ${CMAKE_CURRENT_SOURCE_DIR}/lib/sljit/sljit_src
+@@ -193,3 +194,8 @@ target_include_directories(LiveRecompTest PRIVATE
  )
  
  target_link_libraries(LiveRecompTest LiveRecomp)
++else()
++target_sources(N64Recomp PRIVATE
++    ${CMAKE_CURRENT_SOURCE_DIR}/LiveRecomp/shim_function_aot.cpp
++)
 +endif()
+diff --git a/N64Recomp/LiveRecomp/shim_function_aot.cpp b/N64Recomp/LiveRecomp/shim_function_aot.cpp
+new file mode 100644
+--- /dev/null
++++ b/N64Recomp/LiveRecomp/shim_function_aot.cpp
+@@ -0,0 +1,25 @@
++#include "recompiler/live_recompiler.h"
++
++N64Recomp::ShimFunction::ShimFunction(recomp_func_ext_t* to_shim, uintptr_t value)
++    : code(nullptr), func(nullptr) {
++    (void)to_shim;
++    (void)value;
++}
++
++N64Recomp::ShimFunction::~ShimFunction() = default;
++
++void N64Recomp::live_recompiler_init() {}
++
++N64Recomp::LiveGeneratorOutput::~LiveGeneratorOutput() = default;
++
++size_t N64Recomp::LiveGeneratorOutput::num_reference_symbol_jumps() const {
++    return 0;
++}
++
++void N64Recomp::LiveGeneratorOutput::set_reference_symbol_jump(size_t, recomp_func_t*) {}
++
++N64Recomp::ReferenceJumpDetails N64Recomp::LiveGeneratorOutput::get_reference_symbol_jump_details(size_t) {
++    return {};
++}
++
++void N64Recomp::LiveGeneratorOutput::populate_import_symbol_jumps(size_t, recomp_func_t*) {}
+diff --git a/N64Recomp/include/recomp.h b/N64Recomp/include/recomp.h
+--- a/N64Recomp/include/recomp.h
++++ b/N64Recomp/include/recomp.h
+@@ -92,22 +92,25 @@ typedef uint64_t gpr;
+ #define SUB32(a, b) \
+     ((gpr)(int32_t)((a) - (b)))
+ 
++#define RDRAM_OFFSET(offset, reg) \
++    ((uint32_t)((reg) + (offset)) & 0x1FFFFFFFu)
++
+ #define MEM_W(offset, reg) \
+-    (*(int32_t*)(rdram + ((((reg) + (offset))) - 0xFFFFFFFF80000000)))
++    (*(int32_t*)(rdram + RDRAM_OFFSET((offset), (reg))))
+ 
+ #define MEM_H(offset, reg) \
+-    (*(int16_t*)(rdram + ((((reg) + (offset)) ^ 2) - 0xFFFFFFFF80000000)))
++    (*(int16_t*)(rdram + (RDRAM_OFFSET((offset), (reg)) ^ 2)))
+ 
+ #define MEM_B(offset, reg) \
+-    (*(int8_t*)(rdram + ((((reg) + (offset)) ^ 3) - 0xFFFFFFFF80000000)))
++    (*(int8_t*)(rdram + (RDRAM_OFFSET((offset), (reg)) ^ 3)))
+ 
+ #define MEM_HU(offset, reg) \
+-    (*(uint16_t*)(rdram + ((((reg) + (offset)) ^ 2) - 0xFFFFFFFF80000000)))
++    (*(uint16_t*)(rdram + (RDRAM_OFFSET((offset), (reg)) ^ 2)))
+ 
+ #define MEM_BU(offset, reg) \
+-    (*(uint8_t*)(rdram + ((((reg) + (offset)) ^ 3) - 0xFFFFFFFF80000000)))
++    (*(uint8_t*)(rdram + (RDRAM_OFFSET((offset), (reg)) ^ 3)))
+ 
+ #define SD(val, offset, reg) { \
+-    *(uint32_t*)(rdram + ((((reg) + (offset) + 4)) - 0xFFFFFFFF80000000)) = (uint32_t)((gpr)(val) >> 0); \
+-    *(uint32_t*)(rdram + ((((reg) + (offset) + 0)) - 0xFFFFFFFF80000000)) = (uint32_t)((gpr)(val) >> 32); \
++    *(uint32_t*)(rdram + RDRAM_OFFSET((offset) + 4, (reg))) = (uint32_t)((gpr)(val) >> 0); \
++    *(uint32_t*)(rdram + RDRAM_OFFSET((offset) + 0, (reg))) = (uint32_t)((gpr)(val) >> 32); \
+ }
 diff --git a/librecomp/CMakeLists.txt b/librecomp/CMakeLists.txt
-index 7df8b08..0000000 100644
 --- a/librecomp/CMakeLists.txt
 +++ b/librecomp/CMakeLists.txt
-@@ -63,5 +63,10 @@ endif()
+@@ -57,7 +57,16 @@ if (WIN32)
+ endif()
+ 
  add_subdirectory(${PROJECT_SOURCE_DIR}/../thirdparty/miniz ${CMAKE_CURRENT_BINARY_DIR}/miniz)
 +set(N64RECOMP_ENABLE_LIVE_RECOMP ${N64MODERNRUNTIME_ENABLE_LIVE_RECOMP} CACHE BOOL
 +    "Build N64Recomp's SLJIT live-recompiler path")
  add_subdirectory(${PROJECT_SOURCE_DIR}/../N64Recomp ${CMAKE_CURRENT_BINARY_DIR}/N64Recomp EXCLUDE_FROM_ALL)
  
 -target_link_libraries(librecomp PRIVATE ultramodern N64Recomp LiveRecomp)
++target_compile_definitions(librecomp PRIVATE
++    N64RECOMP_ENABLE_LIVE_RECOMP=$<BOOL:${N64MODERNRUNTIME_ENABLE_LIVE_RECOMP}>
++)
++
 +target_link_libraries(librecomp PRIVATE ultramodern N64Recomp)
 +if (N64MODERNRUNTIME_ENABLE_LIVE_RECOMP)
 +    target_link_libraries(librecomp PRIVATE LiveRecomp)
 +endif()
  target_link_libraries(librecomp PUBLIC miniz)
+diff --git a/librecomp/src/mods.cpp b/librecomp/src/mods.cpp
+--- a/librecomp/src/mods.cpp
++++ b/librecomp/src/mods.cpp
+@@ -473,6 +473,7 @@ recomp::mods::CodeModLoadError recomp::mods::DynamicLibraryCodeHandle::populate_
+     return CodeModLoadError::Good;
+ }
+ 
++#if N64RECOMP_ENABLE_LIVE_RECOMP
+ recomp::mods::LiveRecompilerCodeHandle::LiveRecompilerCodeHandle(
+     const N64Recomp::Context& context, const ModCodeHandleInputs& inputs,
+     std::unordered_map<size_t, size_t>&& entry_func_hooks, std::unordered_map<size_t, size_t>&& return_func_hooks, std::vector<size_t>&& original_section_indices, bool regenerated)
+@@ -550,6 +551,28 @@ recomp::mods::GenericFunction recomp::mods::LiveRecompilerCodeHandle::get_functi
+     return GenericFunction{ recompiler_output->functions[func_index] };
+ }
+ 
++#else
++
++// Static iOS builds must not request executable memory. Keep the mod ABI intact,
++// but report live code modules as unavailable instead of pulling in SLJIT.
++recomp::mods::LiveRecompilerCodeHandle::LiveRecompilerCodeHandle(
++    const N64Recomp::Context&, const ModCodeHandleInputs& inputs,
++    std::unordered_map<size_t, size_t>&&, std::unordered_map<size_t, size_t>&&, std::vector<size_t>&&, bool)
++    : base_event_index(inputs.base_event_index) {}
++
++void recomp::mods::LiveRecompilerCodeHandle::set_imported_function(size_t, GenericFunction) {}
++
++recomp::mods::CodeModLoadError recomp::mods::LiveRecompilerCodeHandle::populate_reference_symbols(
++    const N64Recomp::Context&, std::string&) {
++    return CodeModLoadError::Good;
++}
++
++recomp::mods::GenericFunction recomp::mods::LiveRecompilerCodeHandle::get_function_handle(size_t) {
++    return GenericFunction{ static_cast<recomp_func_t*>(nullptr) };
++}
++
++#endif
++
+ void patch_func(recomp_func_t* target_func, recomp::mods::GenericFunction replacement_func) {
+     uint8_t* target_func_u8 = reinterpret_cast<uint8_t*>(target_func);
+     size_t offset = 0;
+diff --git a/librecomp/src/pi.cpp b/librecomp/src/pi.cpp
+--- a/librecomp/src/pi.cpp
++++ b/librecomp/src/pi.cpp
+@@ -366,20 +366,19 @@ extern "C" void osPiGetStatus_recomp(RDRAM_ARG recomp_context * ctx) {
+ }
+ 
+ extern "C" void osPiRawStartDma_recomp(RDRAM_ARG recomp_context * ctx) {
+-    ultramodern::error_handling::message_box(
+-        "Stub `osPiRawStartDma_recomp` function called!\n"
+-        "Most games do not call this function directly, which means the libultra function\n"
+-        "that uses this function was not properly named.\n"
+-        "\n"
+-        "If you triggered this message, please make sure you have properly identified\n"
+-        "every libultra function on your recompiled game. If you are sure every libultra\n"
+-        "function has been identified and you still get this problem then open an issue on\n"
+-        "the N64ModernRuntime Github repository mentioning the game you are trying to\n"
+-        "recompile and steps to reproduce the issue.\n"
+-        "\n"
+-        "The application will close now, bye and good luck!"
+-    );
+-    ULTRAMODERN_QUICK_EXIT();
++    const uint32_t direction = ctx->r4;
++    const uint32_t device_address = ctx->r5;
++    const gpr rdram_address = ctx->r6;
++    const uint32_t size = ctx->r7;
++
++    if (direction != 0) {
++        throw std::runtime_error("PI raw DMA writes are unsupported");
++    }
++
++    // Some N64 boot code calls raw PI DMA directly. It is synchronous on the
++    // recompiled host because the caller immediately waits for completion.
++    recomp::do_rom_read(rdram, rdram_address, device_address + recomp::rom_base, size);
++    ctx->r2 = 0;
+ }
+ 
+ extern "C" void osEPiRawStartDma_recomp(RDRAM_ARG recomp_context * ctx) {
+diff --git a/ultramodern/include/ultramodern/ultramodern.hpp b/ultramodern/include/ultramodern/ultramodern.hpp
+--- a/ultramodern/include/ultramodern/ultramodern.hpp
++++ b/ultramodern/include/ultramodern/ultramodern.hpp
+@@ -152,6 +152,9 @@ void set_callbacks(
+ #define MIN(a, b) ((a) < (b) ? (a) : (b))
+ 
+-//#define debug_printf(...)
+-#define debug_printf(...) printf(__VA_ARGS__);
++#if defined(N64MODERNRUNTIME_VERBOSE_LOGGING)
++#define debug_printf(...) printf(__VA_ARGS__)
++#else
++#define debug_printf(...) ((void)0)
++#endif
+ 
+ #endif
+diff --git a/ultramodern/src/events.cpp b/ultramodern/src/events.cpp
+--- a/ultramodern/src/events.cpp
++++ b/ultramodern/src/events.cpp
+@@ -202,4 +202,6 @@ static void send_complete_retry(PTR(OSMesgQueue) mq, OSMesg msg) {
+ 
+ void sp_complete() {
++#if defined(N64MODERNRUNTIME_VERBOSE_LOGGING)
+     fprintf(stderr, "[complete] SP -> mq %08X msg %08X\n", (uint32_t)events_context.sp.mq, (uint32_t)events_context.sp.msg);
++#endif
+     send_complete_retry(events_context.sp.mq, events_context.sp.msg);
+@@ -207,4 +209,6 @@ void sp_complete() {
+ 
+ void dp_complete() {
++#if defined(N64MODERNRUNTIME_VERBOSE_LOGGING)
+     fprintf(stderr, "[complete] DP -> mq %08X msg %08X\n", (uint32_t)events_context.dp.mq, (uint32_t)events_context.dp.msg);
++#endif
+     send_complete_retry(events_context.dp.mq, events_context.dp.msg);

--- a/patches/n64modernruntime-ios-aot.patch
+++ b/patches/n64modernruntime-ios-aot.patch
@@ -1,0 +1,51 @@
+diff --git a/N64Recomp/CMakeLists.txt b/N64Recomp/CMakeLists.txt
+index 34dc7e8..0000000 100644
+--- a/N64Recomp/CMakeLists.txt
++++ b/N64Recomp/CMakeLists.txt
+@@ -180,28 +180,30 @@ target_link_libraries(RecompModMerger N64Recomp)
+ # Live recompiler
++if (N64RECOMP_ENABLE_LIVE_RECOMP)
+ project(LiveRecomp)
+ add_library(LiveRecomp)
+ 
+ target_sources(LiveRecomp PRIVATE
+     ${CMAKE_CURRENT_SOURCE_DIR}/LiveRecomp/live_generator.cpp
+     ${CMAKE_CURRENT_SOURCE_DIR}/lib/sljit/sljit_src/sljitLir.c
+ )
+ 
+ target_include_directories(LiveRecomp PRIVATE
+     ${CMAKE_CURRENT_SOURCE_DIR}/lib/sljit/sljit_src
+ )
+ 
+ target_link_libraries(LiveRecomp N64Recomp)
+ 
+ # Live recompiler test
+ project(LiveRecompTest)
+ add_executable(LiveRecompTest)
+ 
+ target_sources(LiveRecompTest PRIVATE
+     ${CMAKE_CURRENT_SOURCE_DIR}/LiveRecomp/live_recompiler_test.cpp
+ )
+ 
+ target_include_directories(LiveRecompTest PRIVATE
+     ${CMAKE_CURRENT_SOURCE_DIR}/lib/sljit/sljit_src
+ )
+ 
+ target_link_libraries(LiveRecompTest LiveRecomp)
++endif()
+diff --git a/librecomp/CMakeLists.txt b/librecomp/CMakeLists.txt
+index 7df8b08..0000000 100644
+--- a/librecomp/CMakeLists.txt
++++ b/librecomp/CMakeLists.txt
+@@ -63,5 +63,10 @@ endif()
+ add_subdirectory(${PROJECT_SOURCE_DIR}/../thirdparty/miniz ${CMAKE_CURRENT_BINARY_DIR}/miniz)
++set(N64RECOMP_ENABLE_LIVE_RECOMP ${N64MODERNRUNTIME_ENABLE_LIVE_RECOMP} CACHE BOOL
++    "Build N64Recomp's SLJIT live-recompiler path")
+ add_subdirectory(${PROJECT_SOURCE_DIR}/../N64Recomp ${CMAKE_CURRENT_BINARY_DIR}/N64Recomp EXCLUDE_FROM_ALL)
+ 
+-target_link_libraries(librecomp PRIVATE ultramodern N64Recomp LiveRecomp)
++target_link_libraries(librecomp PRIVATE ultramodern N64Recomp)
++if (N64MODERNRUNTIME_ENABLE_LIVE_RECOMP)
++    target_link_libraries(librecomp PRIVATE LiveRecomp)
++endif()
+ target_link_libraries(librecomp PUBLIC miniz)

--- a/patches/plume-ios-metal.patch
+++ b/patches/plume-ios-metal.patch
@@ -202,7 +202,22 @@ diff --git a/plume_metal.cpp b/plume_metal.cpp
 index 373c87e..0c24a02 100644
 --- a/plume_metal.cpp
 +++ b/plume_metal.cpp
-@@ -2022,12 +2022,20 @@ namespace plume {
+@@ -1959,8 +1959,14 @@ namespace plume {
+         // According to Apple, presenting via scheduled handler is more performant than using the presentDrawable method.
+         // We grab the underlying drawable because we might've acquired a new one by now and the old one would have been released.
+         CA::MetalDrawable *drawableMtl = drawable.mtl->retain();
++#if TARGET_OS_IPHONE
++        // On iPadOS the command buffer owns presentation. Calling present on
++        // a scheduled handler leaves the host CAMetalLayer black.
++        presentBuffer->presentDrawable(drawableMtl);
++#else
+         presentBuffer->addScheduledHandler([drawableMtl](MTL::CommandBuffer* cmdBuffer) {
+             drawableMtl->present();
+         });
++#endif
+ 
+         presentBuffer->addCompletedHandler([drawableMtl, presentId, this](MTL::CommandBuffer* cmdBuffer) {
+@@ -2022,12 +2028,20 @@ namespace plume {
 
      void MetalSwapChain::setVsyncEnabled(const bool vsyncEnabled) {
          MetalAutoreleasePool releasePool;
@@ -253,10 +268,12 @@ index 373c87e..0c24a02 100644
 
          const std::string deviceName(mtl->name()->utf8String());
          description.name = deviceName;
-@@ -3797,6 +3809,10 @@ namespace plume {
+@@ -3797,9 +3809,19 @@ namespace plume {
          const std::string deviceName(mtl->name()->utf8String());
          description.name = deviceName;
-+#if TARGET_OS_SIMULATOR
++#if TARGET_OS_IPHONE
++        // MTLDevice.location is a macOS-only selector. Physical Apple GPUs
++        // expose AGX device objects without it, just like the Simulator.
 +        description.type = RenderDeviceType::VIRTUAL;
 +#else
          description.type = mapDeviceType(mtl->location());
@@ -264,6 +281,14 @@ index 373c87e..0c24a02 100644
          description.driverVersion = 1; // Unavailable
          description.vendor = mtl->supportsFamily(MTL::GPUFamilyApple1) ? RenderDeviceVendor::APPLE : getRenderDeviceVendor(mtl->registryID());
          description.dedicatedVideoMemory = mtl->recommendedMaxWorkingSetSize();
+ 
+-        timestampCounterSet = findTimestampCounterSet();
++#if TARGET_OS_SIMULATOR
++        timestampCounterSet = nullptr;
++#else
++        timestampCounterSet = findTimestampCounterSet();
++#endif
+         if (timestampCounterSet != nullptr) {
 @@ -4193,10 +4209,16 @@ namespace plume {
          capabilities.shaderFormat = RenderShaderFormat::METAL;
 
@@ -284,3 +309,4 @@ index 373c87e..0c24a02 100644
 +            device->release();
          }
      }
+ 

--- a/patches/plume-ios-simulator-query.patch
+++ b/patches/plume-ios-simulator-query.patch
@@ -1,0 +1,57 @@
+diff --git a/plume_metal.cpp b/plume_metal.cpp
+index 373c87e..bccca2d 100644
+--- a/plume_metal.cpp
++++ b/plume_metal.cpp
+@@ -2200,25 +2200,34 @@ namespace plume {
+         MetalAutoreleasePool releasePool;
+         this->device = device;
+ 
+-        MTL::CounterSampleBufferDescriptor *sampleBufferDesc = MTL::CounterSampleBufferDescriptor::alloc()->init();
+-        sampleBufferDesc->setCounterSet(device->timestampCounterSet);
+-        sampleBufferDesc->setStorageMode(MTL::StorageModeShared);
+-        sampleBufferDesc->setSampleCount(queryCount);
+-        sampleBuffer = device->mtl->newCounterSampleBuffer(sampleBufferDesc, nullptr);
+-        sampleBufferDesc->release();
++        if (device->timestampCounterSet != nullptr) {
++            MTL::CounterSampleBufferDescriptor *sampleBufferDesc = MTL::CounterSampleBufferDescriptor::alloc()->init();
++            sampleBufferDesc->setCounterSet(device->timestampCounterSet);
++            sampleBufferDesc->setStorageMode(MTL::StorageModeShared);
++            sampleBufferDesc->setSampleCount(queryCount);
++            sampleBuffer = device->mtl->newCounterSampleBuffer(sampleBufferDesc, nullptr);
++            sampleBufferDesc->release();
++        }
+ 
+         results.resize(queryCount, 0);
+     }
+ 
+     MetalQueryPool::~MetalQueryPool() {
+         MetalAutoreleasePool releasePool;
+-        sampleBuffer->release();
++        if (sampleBuffer != nullptr) {
++            sampleBuffer->release();
++        }
+     }
+ 
+     void MetalQueryPool::queryResults() {
+         MetalAutoreleasePool releasePool;
++        if (sampleBuffer == nullptr) {
++            return;
++        }
+         const NS::Data* data = sampleBuffer->resolveCounterRange(NS::Range(0, results.size()));
+-        std::memcpy(results.data(), data->mutableBytes(), results.size() * sizeof(uint64_t));
++        if (data != nullptr) {
++            std::memcpy(results.data(), data->mutableBytes(), results.size() * sizeof(uint64_t));
++        }
+     }
+ 
+     const uint64_t *MetalQueryPool::getResults() const {
+@@ -3204,6 +3213,9 @@ namespace plume {
+         MetalAutoreleasePool releasePool;
+         const MetalQueryPool *interfaceQueryPool = static_cast<const MetalQueryPool *>(queryPool);
+ 
++        if (interfaceQueryPool->sampleBuffer == nullptr) {
++            return;
++        }
+         MTL::ComputeCommandEncoder *computeEncoder = activeComputeEncoder != nullptr ? activeComputeEncoder : activeResolveComputeEncoder;
+         if (computeEncoder != nullptr && device->mtl->supportsCounterSampling(MTL::CounterSamplingPointAtDispatchBoundary)) {
+             computeEncoder->sampleCountersInBuffer(interfaceQueryPool->sampleBuffer, queryIndex, true);

--- a/patches/rt64-ios-simulator-resource-limits.patch
+++ b/patches/rt64-ios-simulator-resource-limits.patch
@@ -1,0 +1,139 @@
+diff --git a/src/render/rt64_descriptor_sets.h b/src/render/rt64_descriptor_sets.h
+index 69a82ac..a2715f5 100644
+--- a/src/render/rt64_descriptor_sets.h
++++ b/src/render/rt64_descriptor_sets.h
+@@ -237,51 +237,6 @@ namespace RT64 {
+             gNearestMirrorMirrorSampler = builder.addImmutableSampler(20, samplerLibrary.nearest.mirrorMirror.get());
+             gNearestMirrorClampSampler = builder.addImmutableSampler(21, samplerLibrary.nearest.mirrorClamp.get());
+             gNearestClampWrapSampler = builder.addImmutableSampler(22, samplerLibrary.nearest.clampWrap.get());
+-            gNearestClampMirrorSampler = builder.addImmutableSampler(23, samplerLibrary.nearest.clampMirror.get());
+-            gNearestClampClampSampler = builder.addImmutableSampler(24, samplerLibrary.nearest.clampClamp.get());
+-            RtParams = builder.addConstantBuffer(25);
+-            SceneBVH = raytracing ? builder.addAccelerationStructure(26) : 0;
+-            posBuffer = builder.addByteAddressBuffer(27);
+-            normBuffer = builder.addByteAddressBuffer(28);
+-            velBuffer = builder.addByteAddressBuffer(29);
+-            genTexCoordBuffer = builder.addByteAddressBuffer(30);
+-            shadedColBuffer = builder.addByteAddressBuffer(31);
+-            srcFogIndices = builder.addByteAddressBuffer(32);
+-            srcLightIndices = builder.addByteAddressBuffer(33);
+-            srcLightCounts = builder.addByteAddressBuffer(34);
+-            indexBuffer = builder.addByteAddressBuffer(35);
+-            RSPFogVector = builder.addStructuredBuffer(36);
+-            RSPLightVector = builder.addStructuredBuffer(37);
+-            instanceExtraParams = builder.addStructuredBuffer(38);
+-            SceneLights = builder.addStructuredBuffer(39);
+-            interleavedRasters = builder.addStructuredBuffer(40);
+-            gHitVelocityDistance = builder.addReadWriteFormattedBuffer(41);
+-            gHitColor = builder.addReadWriteFormattedBuffer(42);
+-            gHitNormalFog = builder.addReadWriteFormattedBuffer(43);
+-            gHitInstanceId = builder.addReadWriteFormattedBuffer(44);
+-            gViewDirection = builder.addReadWriteTexture(45);
+-            gShadingPosition = builder.addReadWriteTexture(46);
+-            gShadingNormal = builder.addReadWriteTexture(47);
+-            gShadingSpecular = builder.addReadWriteTexture(48);
+-            gDiffuse = builder.addReadWriteTexture(49);
+-            gInstanceId = builder.addReadWriteTexture(50);
+-            gDirectLightAccum = builder.addReadWriteTexture(51);
+-            gIndirectLightAccum = builder.addReadWriteTexture(52);
+-            gReflection = builder.addReadWriteTexture(53);
+-            gRefraction = builder.addReadWriteTexture(54);
+-            gTransparent = builder.addReadWriteTexture(55);
+-            gFlow = builder.addReadWriteTexture(56);
+-            gReactiveMask = builder.addReadWriteTexture(57);
+-            gLockMask = builder.addReadWriteTexture(58);
+-            gNormalRoughness = builder.addReadWriteTexture(59);
+-            gDepth = builder.addReadWriteTexture(60);
+-            gPrevNormalRoughness = builder.addReadWriteTexture(61);
+-            gPrevDepth = builder.addReadWriteTexture(62);
+-            gPrevDirectLightAccum = builder.addReadWriteTexture(63);
+-            gPrevIndirectLightAccum = builder.addReadWriteTexture(64);
+-            gFilteredDirectLight = builder.addReadWriteTexture(65);
+-            gFilteredIndirectLight = builder.addReadWriteTexture(66);
+-            gBlueNoise = builder.addTexture(67);
+             builder.end();
+ 
+             if (device != nullptr) {
+diff --git a/src/shaders/FbRendererCommon.hlsli b/src/shaders/FbRendererCommon.hlsli
+index bc250a2..1df00ed 100644
+--- a/src/shaders/FbRendererCommon.hlsli
++++ b/src/shaders/FbRendererCommon.hlsli
+@@ -36,8 +36,6 @@ SamplerState gNearestMirrorWrapSampler : register(s19, space0);
+ SamplerState gNearestMirrorMirrorSampler : register(s20, space0);
+ SamplerState gNearestMirrorClampSampler : register(s21, space0);
+ SamplerState gNearestClampWrapSampler : register(s22, space0);
+-SamplerState gNearestClampMirrorSampler : register(s23, space0);
+-SamplerState gNearestClampClampSampler : register(s24, space0);
+ 
+ // Set 1 - RGBA32 texture cache.
+ Texture2D<float4> gTextures[8192] : register(t0, space1);
+diff --git a/src/shaders/TextureSampler.hlsli b/src/shaders/TextureSampler.hlsli
+index 1ceb2ce..70cd890 100644
+--- a/src/shaders/TextureSampler.hlsli
++++ b/src/shaders/TextureSampler.hlsli
+@@ -132,10 +132,10 @@ float4 sampleTextureNative(Texture2D texture, uint nativeSampler, int2 texelBase
+         case NATIVE_SAMPLER_CLAMP_WRAP:
+             return texture.SampleLevel(gNearestClampWrapSampler, nativeUVCoord, 0.0f);
+         case NATIVE_SAMPLER_CLAMP_MIRROR:
+-            return texture.SampleLevel(gNearestClampMirrorSampler, nativeUVCoord, 0.0f);
++            return texture.SampleLevel(gNearestClampWrapSampler, nativeUVCoord, 0.0f);
+         case NATIVE_SAMPLER_CLAMP_CLAMP:
+         default:
+-            return texture.SampleLevel(gNearestClampClampSampler, nativeUVCoord, 0.0f);
++            return texture.SampleLevel(gNearestClampWrapSampler, nativeUVCoord, 0.0f);
+     }
+ }
+ 
+@@ -309,10 +309,10 @@ float4 sampleTexture(OtherMode otherMode, RenderFlags renderFlags, float2 inputU
+                 case NATIVE_SAMPLER_CLAMP_WRAP:
+                     return texture.SampleGrad(gLinearClampWrapSampler, nativeUVCoord, ddxUVNorm, ddyUVNorm);
+                 case NATIVE_SAMPLER_CLAMP_MIRROR:
+-                    return texture.SampleGrad(gLinearClampMirrorSampler, nativeUVCoord, ddxUVNorm, ddyUVNorm);
++                    return texture.SampleGrad(gLinearClampWrapSampler, nativeUVCoord, ddxUVNorm, ddyUVNorm);
+                 case NATIVE_SAMPLER_CLAMP_CLAMP:
+                 default:
+-                    return texture.SampleGrad(gLinearClampClampSampler, nativeUVCoord, ddxUVNorm, ddyUVNorm);
++                    return texture.SampleGrad(gLinearClampWrapSampler, nativeUVCoord, ddxUVNorm, ddyUVNorm);
+             }
+         }
+     }
+@@ -356,4 +356,4 @@ float4 sampleTexture(OtherMode otherMode, RenderFlags renderFlags, float2 inputU
+     }
+     
+     return textureColor;
+-}
+\ No newline at end of file
++}
+diff --git a/src/render/rt64_shader_library.cpp b/src/render/rt64_shader_library.cpp
+index 7ee856d..e7bbec8 100644
+--- a/src/render/rt64_shader_library.cpp
++++ b/src/render/rt64_shader_library.cpp
+@@ -853,28 +853,5 @@ namespace RT64 {
+         }
+         
+         // Raytracing debug.
+-        {
+-            FramebufferRendererDescriptorCommonSet descriptorCommonSet(samplerLibrary, deviceCapabilities.raytracing);
+-            FramebufferRendererDescriptorTextureSet descriptorTextureSet;
+-            FramebufferRendererDescriptorFramebufferSet descriptorFramebufferSet;
+-            layoutBuilder.begin();
+-            layoutBuilder.addDescriptorSet(descriptorCommonSet);
+-            layoutBuilder.addDescriptorSet(descriptorTextureSet);
+-            layoutBuilder.addDescriptorSet(descriptorTextureSet);
+-            layoutBuilder.addDescriptorSet(descriptorFramebufferSet);
+-            layoutBuilder.end();
+-            debug.pipelineLayout = layoutBuilder.create(device);
+-
+-            std::unique_ptr<RenderShader> pixelShader = device->createShader(CREATE_SHADER_INPUTS(DebugPSBlobDXIL, DebugPSBlobSPIRV, DebugPSBlobMSL, "PSMain", shaderFormat));
+-            RenderGraphicsPipelineDesc pipelineDesc;
+-            pipelineDesc.pipelineLayout = debug.pipelineLayout.get();
+-            pipelineDesc.renderTargetBlend[0] = RenderBlendDesc::AlphaBlend();
+-            pipelineDesc.renderTargetFormat[0] = RenderTarget::colorBufferFormat(usesHDR);
+-            pipelineDesc.renderTargetCount = 1;
+-            pipelineDesc.vertexShader = fullScreenVertexShader.get();
+-            pipelineDesc.pixelShader = pixelShader.get();
+-            pipelineDesc.multisampling = multisampling;
+-            debug.pipeline = device->createGraphicsPipeline(pipelineDesc);
+-        }
+
+         // RSP Vertex Test Z.

--- a/scripts/verify-recomp-prototype-host.sh
+++ b/scripts/verify-recomp-prototype-host.sh
@@ -4,13 +4,22 @@ set -eu
 repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 build_dir=${GOLDENPAD_RECOMP_BUILD_DIR:-"$repo_root/build-recomp-prototype-simulator"}
 bundle_identifier=${GOLDENPAD_RECOMP_BUNDLE_IDENTIFIER:-com.chrissotraidis.goldenpad.recomp-prototype}
+rt64_archive_dir=${GOLDENPAD_RECOMP_RT64_ARCHIVE_DIR:-}
+rt64_source_dir=${GOLDENPAD_RECOMP_RT64_SOURCE_DIR:-}
+
+if [ -n "$rt64_archive_dir" ] && [ -z "$rt64_source_dir" ]; then
+    echo "GOLDENPAD_RECOMP_RT64_SOURCE_DIR is required with prototype RT64 archives." >&2
+    exit 1
+fi
 
 cmake -S "$repo_root" -B "$build_dir" -G Xcode \
     -DCMAKE_SYSTEM_NAME=iOS \
     -DCMAKE_OSX_SYSROOT=iphonesimulator \
     -DCMAKE_OSX_ARCHITECTURES=arm64 \
     -DGOLDENPAD_RECOMP_PROTOTYPE=ON \
-    -DGOLDENPAD_RECOMP_BUNDLE_IDENTIFIER="$bundle_identifier"
+    -DGOLDENPAD_RECOMP_BUNDLE_IDENTIFIER="$bundle_identifier" \
+    -DGOLDENPAD_RECOMP_RT64_ARCHIVE_DIR="$rt64_archive_dir" \
+    -DGOLDENPAD_RECOMP_RT64_SOURCE_DIR="$rt64_source_dir"
 
 xcodebuild -quiet -project "$build_dir/GoldenPad.xcodeproj" \
     -target GoldenPadRecompPrototype -configuration Release -sdk iphonesimulator \
@@ -23,8 +32,12 @@ file "$binary" | grep -q 'Mach-O 64-bit executable arm64'
 test "$(plutil -extract CFBundleIdentifier raw -o - "$app/Info.plist")" = "$bundle_identifier"
 nm -gU "$binary" | grep -q _goldenpad_recomp_rt64_initialize
 nm -gU "$binary" | grep -q _goldenpad_recomp_rt64_shutdown
-if nm -gU "$binary" | grep -Eq '_bossEntry|_goldenpad_mgb64_'; then
+if nm -gU "$binary" | grep -q '_goldenpad_mgb64_'; then
     echo "Production MGB64 symbols entered the isolated prototype." >&2
+    exit 1
+fi
+if [ -n "$rt64_archive_dir" ] && ! nm -gU "$binary" | grep -q _goldenpad_recomp_rt64_initialize; then
+    echo "The configured RT64 bridge did not enter the prototype binary." >&2
     exit 1
 fi
 

--- a/scripts/verify-recomp-prototype-host.sh
+++ b/scripts/verify-recomp-prototype-host.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+build_dir=${GOLDENPAD_RECOMP_BUILD_DIR:-"$repo_root/build-recomp-prototype-simulator"}
+bundle_identifier=${GOLDENPAD_RECOMP_BUNDLE_IDENTIFIER:-com.chrissotraidis.goldenpad.recomp-prototype}
+
+cmake -S "$repo_root" -B "$build_dir" -G Xcode \
+    -DCMAKE_SYSTEM_NAME=iOS \
+    -DCMAKE_OSX_SYSROOT=iphonesimulator \
+    -DCMAKE_OSX_ARCHITECTURES=arm64 \
+    -DGOLDENPAD_RECOMP_PROTOTYPE=ON \
+    -DGOLDENPAD_RECOMP_BUNDLE_IDENTIFIER="$bundle_identifier"
+
+xcodebuild -quiet -project "$build_dir/GoldenPad.xcodeproj" \
+    -target GoldenPadRecompPrototype -configuration Release -sdk iphonesimulator \
+    CODE_SIGNING_ALLOWED=NO build
+
+app="$build_dir/Release-iphonesimulator/GoldenPadRecompPrototype.app"
+binary="$app/GoldenPadRecompPrototype"
+test -f "$binary"
+file "$binary" | grep -q 'Mach-O 64-bit executable arm64'
+test "$(plutil -extract CFBundleIdentifier raw -o - "$app/Info.plist")" = "$bundle_identifier"
+nm -gU "$binary" | grep -q _goldenpad_recomp_rt64_initialize
+nm -gU "$binary" | grep -q _goldenpad_recomp_rt64_shutdown
+if nm -gU "$binary" | grep -Eq '_bossEntry|_goldenpad_mgb64_'; then
+    echo "Production MGB64 symbols entered the isolated prototype." >&2
+    exit 1
+fi
+
+echo "GoldenPadRecompPrototype host passed (ARM64 Simulator, $bundle_identifier)."

--- a/scripts/verify-rt64-ios-metal.sh
+++ b/scripts/verify-rt64-ios-metal.sh
@@ -8,6 +8,11 @@ rt64_patch="$repo_root/patches/rt64-ios-sdk.patch"
 plume_patch="$repo_root/patches/plume-ios-metal.patch"
 expected_rt64=5473732a822a4423b5696e7cb18fecc425a59875
 expected_plume=d890ac899e505fb30040e037a4037cdeca68f033
+metal_toolchain=${GOLDENPAD_METAL_TOOLCHAIN:-}
+metal_toolchain_args=()
+if [ -n "$metal_toolchain" ]; then
+    metal_toolchain_args=(--toolchain "$metal_toolchain")
+fi
 
 if [ ! -d "$rt64_path/.git" ] || [ ! -f "$plume_path/plume_metal.cpp" ]; then
     echo "Expected the pinned RT64 checkout at: $rt64_path" >&2
@@ -87,8 +92,8 @@ for sdk in iphoneos iphonesimulator; do
     while IFS= read -r target; do
         name=${target#src/shaders/}
         source="$build_path/src/shaders/$name"
-        xcrun -sdk "$sdk" metal -c "$source" -o "$sdk_output/shaders/$name.air"
-        xcrun -sdk "$sdk" metallib \
+        xcrun "${metal_toolchain_args[@]}" -sdk "$sdk" metal -c "$source" -o "$sdk_output/shaders/$name.air"
+        xcrun "${metal_toolchain_args[@]}" -sdk "$sdk" metallib \
             "$sdk_output/shaders/$name.air" \
             -o "$sdk_output/shaders/$name.metallib"
     done < "$target_list"

--- a/scripts/verify-rt64-ios-static.sh
+++ b/scripts/verify-rt64-ios-static.sh
@@ -7,6 +7,8 @@ plume_path="$rt64_path/src/contrib/plume"
 rt64_sdk_patch="$repo_root/patches/rt64-ios-sdk.patch"
 rt64_embedded_patch="$repo_root/patches/rt64-ios-embedded.patch"
 plume_patch="$repo_root/patches/plume-ios-metal.patch"
+plume_query_patch="$repo_root/patches/plume-ios-simulator-query.patch"
+simulator_resource_patch="$repo_root/patches/rt64-ios-simulator-resource-limits.patch"
 shim_path="$repo_root/Support/RT64"
 link_probe="$shim_path/rt64_link_probe.cpp"
 expected_rt64=5473732a822a4423b5696e7cb18fecc425a59875
@@ -16,6 +18,12 @@ expected_metal_shaders=56
 expected_rt64_members=210
 expected_closure_members=246
 artifact_root=${GOLDENPAD_RT64_ARTIFACT_DIR:-}
+simulator_resource_limits=${GOLDENPAD_RT64_SIMULATOR_RESOURCE_LIMITS:-OFF}
+metal_toolchain=${GOLDENPAD_METAL_TOOLCHAIN:-}
+metal_toolchain_args=()
+if [ -n "$metal_toolchain" ]; then
+    metal_toolchain_args=(--toolchain "$metal_toolchain")
+fi
 
 if [ ! -d "$rt64_path/.git" ] || [ ! -f "$plume_path/plume_metal.cpp" ]; then
     echo "Expected the pinned RT64 checkout at: $rt64_path" >&2
@@ -49,12 +57,25 @@ if ! git -C "$plume_path" diff --quiet -- plume_apple.mm plume_metal.cpp; then
     exit 1
 fi
 
+if [ "$simulator_resource_limits" = "ON" ] && ! git -C "$rt64_path" diff --quiet -- src/render/rt64_descriptor_sets.h src/render/rt64_shader_library.cpp src/shaders/FbRendererCommon.hlsli src/shaders/TextureSampler.hlsli; then
+    echo "RT64 Simulator resource-limit sources have local changes; refusing to patch them." >&2
+    exit 1
+fi
+
 probe_root=$(mktemp -d "${TMPDIR:-/tmp}/goldenpad-rt64-static.XXXXXX")
 rt64_sdk_patch_applied=0
 rt64_embedded_patch_applied=0
 plume_patch_applied=0
+plume_query_patch_applied=0
+simulator_resource_patch_applied=0
 
 cleanup() {
+    if [ "$simulator_resource_patch_applied" -eq 1 ]; then
+        git -C "$rt64_path" apply --reverse "$simulator_resource_patch" >/dev/null
+    fi
+    if [ "$plume_query_patch_applied" -eq 1 ]; then
+        patch -R -p1 -l --batch -d "$plume_path" < "$plume_query_patch" >/dev/null
+    fi
     if [ "$plume_patch_applied" -eq 1 ]; then
         patch -R -p1 -l --batch -d "$plume_path" < "$plume_patch" >/dev/null
     fi
@@ -74,6 +95,12 @@ patch -p1 -l --batch -d "$rt64_path" < "$rt64_embedded_patch" >/dev/null
 rt64_embedded_patch_applied=1
 patch -p1 -l --batch -d "$plume_path" < "$plume_patch" >/dev/null
 plume_patch_applied=1
+patch -p1 -l --batch -d "$plume_path" < "$plume_query_patch" >/dev/null
+plume_query_patch_applied=1
+if [ "$simulator_resource_limits" = "ON" ]; then
+    git -C "$rt64_path" apply "$simulator_resource_patch"
+    simulator_resource_patch_applied=1
+fi
 
 host_build="$probe_root/host"
 cmake -S "$rt64_path" -B "$host_build" -G Ninja \
@@ -133,8 +160,8 @@ for sdk in iphoneos iphonesimulator; do
             echo "Could not read the generated array name from: $host_blob_c" >&2
             exit 1
         fi
-        xcrun -sdk "$sdk" metal -c "$source" -o "$output_base.air"
-        xcrun -sdk "$sdk" metallib "$output_base.air" -o "$output_base.metallib"
+        xcrun "${metal_toolchain_args[@]}" -sdk "$sdk" metal -c "$source" -o "$output_base.air"
+        xcrun "${metal_toolchain_args[@]}" -sdk "$sdk" metallib "$output_base.air" -o "$output_base.metallib"
         "$file_to_c" "$output_base.metallib" "$array_name" \
             "$output_base.c" "$output_base.h"
     done < "$metal_sources"


### PR DESCRIPTION
## Summary
- promote the isolated RT64/N64Recomp iPad prototype as GoldenPad's accepted main development baseline
- include native audio, production-tuned touch controls, Xbox/MFi controller input, settings, diagnostics, high-resolution RT64 Metal rendering, and bounded runtime telemetry
- document the 2026-08-21 physical-iPad acceptance run and morning worklist

## Physical acceptance
- multiple missions launched and played normally on the iPad
- controller movement, look, aim, and fire felt responsive
- former right-edge blue line and Bunker blue-void failure were not observed
- installed/local executable SHA-256: addd13724a405237585aa3835000a220283996bc83c980b6263ea5c3735a4826

## Known follow-up
- screenshot/background return can leave the live process frozen
- optional reticle is misplaced at the top-right
- add an explicit Return to Main Menu action
- clarify restart/apply behavior for resolution, MSAA, and filtering settings
- multiplayer and physical-speaker audio remain acceptance gates

## Verification
- ARM64 Simulator host verification passed
- RT64 iPhoneOS and iPhoneSimulator static archive/link verification passed
- GoldenEye controls and render-trace patches dry-run cleanly
- ROMs, generated AOT code, saves, logs, crash reports, and captures are excluded