### PR TITLE
docs: track sidestep control template debt

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,11 +299,12 @@ remove that container, so preserve your own source and saves before uninstalling
 
 ## Touch controls
 
-GoldenPad defaults to a modern dual-stick FPS layout:
+GoldenPad defaults to its current touch template, combining the original
+GoldenEye movement semantics with modern relative look:
 
 | Control | Behavior |
 |---|---|
-| **MOVE** | Large left virtual stick |
+| **MOVE** | Large left virtual stick; forward/back and turn, with no sidestep in the current template |
 | **LOOK** | Relative right-thumb swipe region; movement stops when the swipe stops |
 | **FIRE** | N64 Z / primary fire |
 | **AIM** | N64 R; Toggle by default, with Hold available |
@@ -323,6 +324,12 @@ Touch Controls also contains:
 - Toggle or Hold aim behavior;
 - the current iPhone or iPad touch layout.
 
+The current touch template does not expose GoldenEye's native C-left/C-right
+sidestep inputs. A future sidestep-capable touch template or control submenu is
+tracked in [issue #8](https://github.com/chrissotraidis/goldenpad/issues/8). The
+accepted iPhone and iPad layouts remain unchanged while that design and its
+physical-device behavior are evaluated.
+
 In edit mode, drag a control directly over the running game. The selected
 control receives a yellow outline and the always-visible top slider resizes it
 from 55–160%; the opacity slider adjusts that selected control from 20–100%.
@@ -341,7 +348,10 @@ accepted tablet profile.
 The primary build automatically uses the first Xbox/MFi extended gamepad for
 Player 1 and hides the touch overlay while it is connected. Movement, modern
 right-stick look, aim, fire, action, weapon, crouch and Start are physically
-accepted. **Settings → Controller → Button mapping** can reassign the face
+accepted. **Settings → Controller → Right stick → Original N64 C-buttons**
+restores GoldenEye's native C-left/C-right sidestep input, but replaces modern
+analog right-stick look with the original C-button behavior. **Settings →
+Controller → Button mapping** can reassign the face
 buttons, bumpers, and triggers; sticks, D-pad, and Menu/Start retain their
 standard roles. For hardware-limited testing, **Cheats & Testing → Two-player input
 test** keeps the attached controller as Player 1 and exposes touch controls as

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -33,6 +33,26 @@ Do not regress the accepted single-player speed, high-resolution renderer,
 touch tuning, controller mapping, save compatibility, or clean-install defaults
 while addressing that debt.
 
+## Touch sidestep and control-template debt — 2026-08-22
+
+[Issue #8](https://github.com/chrissotraidis/goldenpad/issues/8) records a real
+gap between GoldenPad's current input configurations. The accepted iPhone/iPad
+touch template combines GoldenEye's original analog-stick movement with
+GoldenPad's relative LOOK surface. Horizontal MOVE input therefore retains the
+original turn behavior and does not expose native sidestepping.
+
+Physical controllers have a separate **Original N64 C-buttons** right-stick
+configuration. It emits C-left/C-right and restores GoldenEye's native
+sidestepping, but it replaces the modern analog right-stick look path. Touch has
+no corresponding C-button or sidestep-capable template today.
+
+This remains design debt, not an approved control rewrite. A future pass should
+evaluate multiple named templates or a dedicated controls submenu that can add
+a sidestep-capable touch option while preserving the current accepted template.
+Any candidate must keep menu navigation unchanged, preserve independent
+movement and look, avoid silently changing existing saved preferences, and pass
+hands-on iPhone, iPad and physical-controller testing before becoming a default.
+
 ## macOS alpha disposition — 2026-08-21
 
 The native Apple-Silicon Mac product is retained as an **alpha**, one quality


### PR DESCRIPTION
## Summary
- document the current touch template's lack of sidestep input
- explain the controller C-button alternative and its look tradeoff
- track a future touch template or submenu under issue #8 without changing accepted controls

## Validation
- git diff --check
- focused two-file staged diff