### PR TITLE
Preview 4: repair shared controls and tank input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,9 @@ if(goldenpad_apple_platform STREQUAL "mac")
             "recomp_get_camera_inputs"
             "goldenpad_recomp_consume_crouch_toggle"
             "goldenpad_recomp_consume_inventory_slot"
-            "goldenpad_recomp_consume_reload")
+            "goldenpad_recomp_consume_reload"
+            "goldenpad_recomp_fire_rate_player_sample"
+            "goldenpad_recomp_fire_rate_guard_sample")
         string(FIND "${goldenpad_mac_patches_text}"
             "${required_bridge}" goldenpad_mac_bridge_offset)
         if(goldenpad_mac_bridge_offset EQUAL -1)
@@ -104,6 +106,34 @@ if(goldenpad_apple_platform STREQUAL "mac")
                 "Generated Mac patches.c is missing ${required_bridge}; regenerate the modern-controls patch pair before building GoldenPad.")
         endif()
     endforeach()
+    foreach(required_tank_marker IN ITEMS
+            "MEM_W(ctx->r1, 0X6248)"
+            "MEM_W(ctx->r23, 0X6250)"
+            "MEM_W(0X6284"
+            "MEM_W(0X6274"
+            "MEM_W(0X6278"
+            "MEM_W(ctx->r1, -0X6848)")
+        string(FIND "${goldenpad_mac_patches_text}"
+            "${required_tank_marker}" goldenpad_mac_tank_marker_offset)
+        if(goldenpad_mac_tank_marker_offset EQUAL -1)
+            message(FATAL_ERROR
+                "Generated Mac patches.c is missing mounted-turret marker ${required_tank_marker}; apply the tracked modern-controls patch and regenerate patches.c plus patches_bin.c together.")
+        endif()
+    endforeach()
+    set(goldenpad_mac_patch_source
+        "${GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR}/patches/workbench_theboy.c")
+    set(goldenpad_mac_patch_binary
+        "${GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR}/patches/patches.bin")
+    if("${goldenpad_mac_patch_source}" IS_NEWER_THAN
+            "${GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR}/RecompiledPatches/patches.c")
+        message(FATAL_ERROR
+            "GoldenEye64Recomp Mac patches.c is stale. Regenerate the matched patch outputs before building GoldenPad.")
+    endif()
+    if("${goldenpad_mac_patch_binary}" IS_NEWER_THAN
+            "${GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR}/RecompiledPatches/patches_bin.c")
+        message(FATAL_ERROR
+            "GoldenEye64Recomp Mac patches_bin.c is stale. Regenerate the matched patch outputs before building GoldenPad.")
+    endif()
 
     set(goldenpad_mac_runtime_archives
         "${GOLDENPAD_RECOMP_RUNTIME_ARCHIVE_DIR}/ultramodern/libultramodern.a"
@@ -128,6 +158,7 @@ if(goldenpad_apple_platform STREQUAL "mac")
         Config/ThirdPartyNotices.txt
         Sources/Mac/GoldenPadMacApp.swift
         Sources/Mac/RecompMacAudio.swift
+        Sources/RecompControlMapping.swift
         Sources/Mac/RecompMacDiagnostics.swift
         Sources/Mac/RecompMacInput.swift
         Sources/Mac/RecompMacMetalCanvas.swift
@@ -293,7 +324,11 @@ if(GOLDENPAD_RECOMP_PROTOTYPE)
             goldenpad_recomp_patches_text)
         foreach(required_bridge IN ITEMS
                 "recomp_get_camera_inputs"
-                "goldenpad_recomp_consume_crouch_toggle")
+                "goldenpad_recomp_consume_crouch_toggle"
+                "goldenpad_recomp_consume_inventory_slot"
+                "goldenpad_recomp_consume_reload"
+                "goldenpad_recomp_fire_rate_player_sample"
+                "goldenpad_recomp_fire_rate_guard_sample")
             string(FIND "${goldenpad_recomp_patches_text}"
                 "${required_bridge}" goldenpad_recomp_bridge_offset)
             if(goldenpad_recomp_bridge_offset EQUAL -1)
@@ -310,6 +345,20 @@ if(GOLDENPAD_RECOMP_PROTOTYPE)
             if(goldenpad_recomp_multiplayer_patch_offset EQUAL -1)
                 message(FATAL_ERROR
                     "Generated RecompiledPatches/patches.c is missing the Preview 2 depth-alias repair marker ${required_multiplayer_patch}. Regenerate patches.c plus patches_bin.c from the patched GoldenEye64Recomp source before building mobile GoldenPad.")
+            endif()
+        endforeach()
+        foreach(required_tank_marker IN ITEMS
+                "MEM_W(ctx->r1, 0X6248)"
+                "MEM_W(ctx->r23, 0X6250)"
+                "MEM_W(0X6284"
+                "MEM_W(0X6274"
+                "MEM_W(0X6278"
+                "MEM_W(ctx->r1, -0X6848)")
+            string(FIND "${goldenpad_recomp_patches_text}"
+                "${required_tank_marker}" goldenpad_recomp_tank_marker_offset)
+            if(goldenpad_recomp_tank_marker_offset EQUAL -1)
+                message(FATAL_ERROR
+                    "Generated RecompiledPatches/patches.c is missing mounted-turret marker ${required_tank_marker}. Apply the tracked modern-controls patch and regenerate both embedded patch halves.")
             endif()
         endforeach()
         set(goldenpad_recomp_patch_source
@@ -386,6 +435,7 @@ if(GOLDENPAD_RECOMP_PROTOTYPE)
         Config/ThirdPartyNotices.txt
         Sources/RecompPrototypeApp.swift
         Sources/RecompPrototypeAudio.swift
+        Sources/RecompControlMapping.swift
         Sources/RecompPrototypeInput.swift
         Sources/RecompPrototypeMetalCanvas.swift
         Sources/RecompPrototypeROMStore.swift
@@ -399,7 +449,7 @@ if(GOLDENPAD_RECOMP_PROTOTYPE)
         MACOSX_BUNDLE_BUNDLE_NAME "GoldenPad"
         MACOSX_BUNDLE_GUI_IDENTIFIER "${GOLDENPAD_RECOMP_BUNDLE_IDENTIFIER}"
         MACOSX_BUNDLE_SHORT_VERSION_STRING "0.1.0"
-        MACOSX_BUNDLE_BUNDLE_VERSION "3"
+        MACOSX_BUNDLE_BUNDLE_VERSION "4"
         MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Config/RecompPrototypeInfo.plist.in"
         XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "${goldenpad_recomp_code_signing_allowed}"
         XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "${goldenpad_recomp_code_signing_required}"
@@ -407,6 +457,7 @@ if(GOLDENPAD_RECOMP_PROTOTYPE)
         XCODE_ATTRIBUTE_DEVELOPMENT_TEAM "${GOLDENPAD_DEVELOPMENT_TEAM}"
         XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon"
         XCODE_ATTRIBUTE_GENERATE_INFOPLIST_FILE "NO"
+        XCODE_ATTRIBUTE_GOLDENPAD_RECOMP_DISPLAY_NAME "GoldenPad"
         XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "17.0"
         XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${GOLDENPAD_RECOMP_BUNDLE_IDENTIFIER}"
         XCODE_ATTRIBUTE_SUPPORTED_PLATFORMS "iphoneos iphonesimulator"

--- a/Config/RecompPrototypeInfo.plist.in
+++ b/Config/RecompPrototypeInfo.plist.in
@@ -5,7 +5,7 @@
     <key>CFBundleDevelopmentRegion</key>
     <string>$(DEVELOPMENT_LANGUAGE)</string>
     <key>CFBundleDisplayName</key>
-    <string>GoldenPad</string>
+    <string>$(GOLDENPAD_RECOMP_DISPLAY_NAME)</string>
     <key>CFBundleExecutable</key>
     <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundleIdentifier</key>
@@ -34,7 +34,7 @@
     <key>CFBundleShortVersionString</key>
     <string>0.1.0</string>
     <key>CFBundleVersion</key>
-    <string>3</string>
+    <string>4</string>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.games</string>
     <key>LSRequiresIPhoneOS</key>

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You need an iPhone or iPad running iOS/iPadOS 17 or later, a Mac or Windows
 computer, an Apple ID, and your own original US GoldenEye 007 Nintendo 64 ROM.
 
 > **No jailbreak or JIT is required. Do not search for a TLB-free ROM.**
-> Preview 3 accepts your ordinary `.z64`, `.v64`, `.n64`, or `.rom` dump and
+> Preview 4 accepts your ordinary `.z64`, `.v64`, `.n64`, or `.rom` dump and
 > prepares the required private runtime copy automatically on the device.
 
 1. Install **AltStore Classic** by following its official
@@ -63,7 +63,7 @@ computer, an Apple ID, and your own original US GoldenEye 007 Nintendo 64 ROM.
    Use AltStore Classic with AltServer, not AltStore PAL. PAL cannot install an
    arbitrary unsigned `.ipa` downloaded from GitHub.
 2. Download
-   [`GoldenPad-0.1.0-preview.3-unsigned.ipa`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.3/GoldenPad-0.1.0-preview.3-unsigned.ipa).
+   [`GoldenPad-0.1.0-preview.4-unsigned.ipa`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.4/GoldenPad-0.1.0-preview.4-unsigned.ipa).
    This is the iPhone/iPad app. Do not download the separate Mac `.zip`.
 3. Open AltStore Classic on the device, go to **My Apps**, tap **+**, and choose
    the downloaded GoldenPad `.ipa` from Files. Follow iOS's prompts to trust
@@ -113,17 +113,18 @@ the repository or application package.
 | Option | Status | What to do |
 |---|---|---|
 | Local Simulator build | **Verified** | Build with the complete verifier below, then run from Xcode or `simctl`. |
-| Local iPhone/iPad build | **Physically approved Preview 3** | Build 3 was installed in place with ROMs, saves and preferences preserved; the user accepted the final controls release for publication. |
-| Native Apple-Silicon Mac build | **Preview 3 Alpha** | GoldenPad officially supports Apple Silicon Macs in Alpha status. [Download the separate arm64 Mac Alpha](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.3/GoldenPad-0.1.0-preview.3-macos-arm64-alpha.zip); the thin far-right blue edge and broader sustained-performance coverage remain open. |
-| Unsigned `.ipa` | **Audited Preview 3** | Follow [Play on iPhone or iPad](#play-on-iphone-or-ipad) to install the public unsigned IPA with AltStore Classic. |
-| GitHub release | **Preview 3** | [Release notes, downloads and SHA-256](https://github.com/chrissotraidis/goldenpad/releases/tag/v0.1.0-preview.3). |
+| Local iPhone/iPad build | **Preview 4 controls accepted** | The user accepted menu, on-foot Aim, Runway tank drive/turn/turret/weapon behavior, exit/re-entry, and a Facility regression pass on physical iPad. The final requested 20% right-stick increase is build and matrix verified. |
+| Native Apple-Silicon Mac build | **Preview 4 Alpha** | GoldenPad officially supports Apple Silicon Macs in Alpha status. [Download the separate arm64 Mac Alpha](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.4/GoldenPad-0.1.0-preview.4-macos-arm64-alpha.zip); issue #17 reporter verification, the thin far-right blue edge, and broader sustained-performance coverage remain open. |
+| Unsigned `.ipa` | **Audited Preview 4** | Follow [Play on iPhone or iPad](#play-on-iphone-or-ipad) to install the public unsigned IPA with AltStore Classic. |
+| GitHub release | **Preview 4** | [Release notes, downloads and SHA-256](https://github.com/chrissotraidis/goldenpad/releases/tag/v0.1.0-preview.4). |
 | App Store / TestFlight | **Not announced** | Store distribution requires separate rights, signing, review, and device acceptance. |
 
 The mobile baseline was accepted through normal single-player gameplay on a
 physical iPhone and iPad, including the editable touch layout and Xbox/MFi
-controller path. Preview 3 retains the bounded in-app ROM importer and frozen
-experimental multiplayer render repair, adds an opt-in Honey sidestep adapter,
-and ships the accepted Mac keyboard/mouse controls. Longer thermal/route sweeps
+controller path. Preview 4 retains the bounded in-app ROM importer and frozen
+experimental multiplayer render repair, automatically follows GoldenEye's
+active 1.1 through 1.4 control style, and repairs the Runway/Streets tank path.
+Longer thermal/route sweeps
 and complete multiplayer acceptance remain open. This developer preview must
 not be described as App Store-ready.
 
@@ -136,7 +137,7 @@ mobile-parity or notarized Mac release.
 |---|---|
 | Native runtime | Statically recompiled game code runs as Apple ARM64; no JIT or emulator wrapper |
 | Rendering | RT64 presents high-resolution Metal output on physical iPad hardware |
-| Setup | Preview 3 imports the user's original NTSC-U retail dump from Files and converts it privately on device; no game data is included |
+| Setup | Preview 4 imports the user's original NTSC-U retail dump from Files and converts it privately on device; no game data is included |
 | Gameplay | Original front end and live Dam/Facility gameplay render and accept normal input |
 | Touch | Tuned GoldenPad move and relative-look zones plus aim, fire, action, weapon, duck, and Start controls |
 | Customization | Separate persisted iPhone/iPad layouts with per-control drag, resize, opacity and reset, plus look sensitivity and hold/toggle aim |
@@ -167,10 +168,10 @@ emulator. Another N64 game or GoldenEye revision cannot be substituted.
 
 ## Release files and advanced setup
 
-### Preview 3 downloads
+### Preview 4 downloads
 
 Download
-[`GoldenPad-0.1.0-preview.3-unsigned.ipa`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.3/GoldenPad-0.1.0-preview.3-unsigned.ipa)
+[`GoldenPad-0.1.0-preview.4-unsigned.ipa`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.4/GoldenPad-0.1.0-preview.4-unsigned.ipa)
 and its adjacent `.sha256` file. The IPA is intentionally unsigned. Follow
 [Play on iPhone or iPad](#play-on-iphone-or-ipad) for the supported AltStore
 Classic installation path.
@@ -181,10 +182,10 @@ the required TLB-free transformation privately on the device, verifies the
 exact output, and starts the native runtime automatically. A valid Preview 1
 `GoldenEye_TLBFREE.z64` is reused unchanged during an in-place update. See the
 [Preview 2 ROM import design and acceptance record](docs/PREVIEW_2_ROM_IMPORT.md),
-which Preview 3 retains unchanged.
+which Preview 4 retains unchanged.
 
 The separate Apple-Silicon Mac Alpha is
-[`GoldenPad-0.1.0-preview.3-macos-arm64-alpha.zip`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.3/GoldenPad-0.1.0-preview.3-macos-arm64-alpha.zip).
+[`GoldenPad-0.1.0-preview.4-macos-arm64-alpha.zip`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.4/GoldenPad-0.1.0-preview.4-macos-arm64-alpha.zip).
 It is an ad-hoc-signed, non-notarized arm64 app and remains below mobile release
 quality. It uses the same user-supplied-data boundary and must not be described
 as mobile parity.
@@ -192,7 +193,7 @@ as mobile parity.
 <details>
 <summary><strong>Preview 1 manual setup (legacy only)</strong></summary>
 
-> **Preview 2 and Preview 3 users do not need these steps or a prebuilt TLB-free ROM.** This
+> **Preview 2, Preview 3, and Preview 4 users do not need these steps or a prebuilt TLB-free ROM.** This
 > section is retained only for people intentionally running the older Preview 1
 > artifact.
 
@@ -222,7 +223,7 @@ resident in Expansion Pak memory and stores the original compressed data segment
 uncompressed in the layout expected by the recompiled code. The unmodified retail
 ROM has a different layout, so Preview 1 cannot read it directly. This is a
 technical limitation of the current build, not a DRM check. Preview 2 and
-Preview 3 perform this same private conversion inside GoldenPad so users can
+Preview 3 and Preview 4 perform this same private conversion inside GoldenPad so users can
 select their ordinary retail dump directly; Preview 1 still needs the manual
 process below.
 
@@ -267,7 +268,7 @@ retail input and generated output remain yours and must not be redistributed.
 > currently be reproduced from the public checkout alone because its generated
 > game-code inputs are private and intentionally untracked. The public build
 > commands below produce the older `GoldenPad Legacy` fallback. To use the
-> current primary release, follow **Preview 3** and **First launch** instead.
+> current primary release, follow **Preview 4** and **First launch** instead.
 
 You need:
 
@@ -330,7 +331,7 @@ reference path.
 
 GoldenPad never downloads or bundles game data.
 
-1. Install the unsigned Preview 3 IPA by following
+1. Install the unsigned Preview 4 IPA by following
    [Play on iPhone or iPad](#play-on-iphone-or-ipad).
 2. Launch GoldenPad and choose your own supported original NTSC-U retail ROM
    from Files. The importer accepts `.z64`, `.v64`, `.n64`, and `.rom` byte
@@ -367,7 +368,7 @@ the game runtime are separate stages with different fixes.
   PAL, Japanese, modified, overdumped, and other revisions are rejected.
 - `.z64`, `.v64`, `.n64`, and `.rom` are accepted. Renaming another file or ROM
   does not change its contents and will not pass validation.
-- Preview 3 performs the TLB-free conversion itself. Do not download, request,
+- Preview 4 performs the TLB-free conversion itself. Do not download, request,
   or manually create a TLB-free ROM for the current release.
 - If GoldenPad cannot read a valid file from a cloud or third-party provider,
   copy it into **On My iPhone** or **On My iPad** in Files and try again.
@@ -495,10 +496,11 @@ MGB64 symbols. The older MGB64 IPA workflow remains a fallback only.
 - Automatic player/guard weapon cadence is not yet timing-authentic at the
   primary runtime's native 60 Hz. A deterministic measurement gate is required
   before changing the accepted combat feel.
-- Preview 3 adds an opt-in **Sidestep with left/right** movement adapter for
-  live single-player 1.1 Honey gameplay on touch and connected controllers.
-  Preview 2 movement remains the default, and issue #8 remains open until the
-  reporter confirms both paths ([issue #8](https://github.com/chrissotraidis/goldenpad/issues/8)).
+- Preview 4 replaces the separate movement adapter with one shared mapping that
+  follows GoldenEye's active 1.1 through 1.4 control style. Physical iPad
+  testing accepted normal movement, native left-stick Aim, and Runway tank
+  controls. Issue #17 remains open until the Mac reporter confirms the release
+  ([issue #17](https://github.com/chrissotraidis/goldenpad/issues/17)).
 - A deterministic first-frame RT64/Metal crash is reported on an A12X iPad Pro
   with Preview 1. A12-family hardware is not yet validated; the compatibility
   fix or minimum GPU policy remains open ([issue #9](https://github.com/chrissotraidis/goldenpad/issues/9)).
@@ -506,7 +508,7 @@ MGB64 symbols. The older MGB64 IPA workflow remains a fallback only.
   Slight lighting flicker and real three/four-controller routing remain open.
 - Peer-to-peer, LAN, internet, relay, and rollback multiplayer are not
   implemented.
-- Preview 3 retains Preview 2's complete, package-audited in-app retail-ROM conversion.
+- Preview 4 retains Preview 2's complete, package-audited in-app retail-ROM conversion.
   A clean physical-iPhone installation has reached the empty-container setup
   screen; fresh real-ROM import, wrong-ROM, cancellation and low-storage
   coverage remains open in the focused importer acceptance record.
@@ -543,8 +545,8 @@ retained only as the deprecated legacy fallback.
 <details>
 <summary><strong>Where is the IPA?</strong></summary>
 
-Preview 3 is available from the
-[GitHub release](https://github.com/chrissotraidis/goldenpad/releases/tag/v0.1.0-preview.3).
+Preview 4 is available from the
+[GitHub release](https://github.com/chrissotraidis/goldenpad/releases/tag/v0.1.0-preview.4).
 It is an unsigned, ROM-free developer-preview IPA and must be re-signed. It does
 not include game data; follow [Play on iPhone or iPad](#play-on-iphone-or-ipad)
 for installation and first-launch instructions.
@@ -554,9 +556,9 @@ for installation and first-launch instructions.
 <summary><strong>Do I need JIT or a TLB-free ROM?</strong></summary>
 
 No. GoldenPad's game code is compiled ahead of time, so the iPhone/iPad release
-does not need JIT. Preview 3 accepts the supported original US retail dump and
+does not need JIT. Preview 4 accepts the supported original US retail dump and
 creates the required TLB-free runtime copy privately on the device. Do not use
-the old Preview 1 manual conversion instructions for Preview 2 or Preview 3.
+the old Preview 1 manual conversion instructions for Preview 2, Preview 3, or Preview 4.
 </details>
 
 <details>
@@ -620,6 +622,7 @@ override those current authority documents.
 | [`docs/TESTING.md`](docs/TESTING.md) | Reproducible verification procedures and hashes |
 | [`docs/RELEASE_CHECKLIST.md`](docs/RELEASE_CHECKLIST.md) | Clean-checkout, package, signing, and publication gates |
 | [`docs/RELEASE_NOTES_0.1.0-preview.3.md`](docs/RELEASE_NOTES_0.1.0-preview.3.md) | Preview 3 downloads, checksums, controls update and disclosed limitations |
+| [`docs/RELEASE_NOTES_0.1.0-preview.4.md`](docs/RELEASE_NOTES_0.1.0-preview.4.md) | Preview 4 tank, Aim, shared control mapping, checksums, and acceptance boundary |
 | [`docs/MULTIPLAYER_ROADMAP.md`](docs/MULTIPLAYER_ROADMAP.md) | Local ownership, determinism, LAN research, network feasibility, and go/no-go gates |
 | [`docs/EXTERNAL_REVIEW_2026-08-22.md`](docs/EXTERNAL_REVIEW_2026-08-22.md) | Preserved independent revision-2 review plus maintained disposition against Preview 3; supporting evidence, not current authority |
 | [`docs/EXTERNAL_TECHNICAL_REVIEW_HANDOFF.md`](docs/EXTERNAL_TECHNICAL_REVIEW_HANDOFF.md) | Read-only expert-review prompt for confidence-ranked analysis of the hardest remaining defects |

--- a/Sources/Mac/RecompMacInput.swift
+++ b/Sources/Mac/RecompMacInput.swift
@@ -45,8 +45,15 @@ private func goldenPadRecompSetUnlockAllMissions(_ enabled: Int32)
 @_silgen_name("goldenpad_recomp_request_return_to_title")
 private func goldenPadRecompRequestReturnToTitle()
 
-@_silgen_name("goldenpad_recomp_desktop_gameplay_active")
-private func goldenPadRecompDesktopGameplayActive() -> Int32
+@_silgen_name("goldenpad_recomp_get_input_context")
+private func goldenPadRecompGetInputContext(
+    _ controller: Int32,
+    _ gameplayActive: UnsafeMutablePointer<Int32>,
+    _ controlStyle: UnsafeMutablePointer<Int32>,
+    _ aiming: UnsafeMutablePointer<Int32>,
+    _ tankState: UnsafeMutablePointer<Int32>,
+    _ nativeLookUpright: UnsafeMutablePointer<Int32>
+)
 
 enum RecompMacBindableKey: UInt16, CaseIterable, Identifiable {
     case a = 0, s = 1, d = 2, f = 3, h = 4, g = 5
@@ -184,20 +191,6 @@ final class RecompMacInput: ObservableObject {
         static let rightControl: UInt16 = 62
     }
 
-    private enum N64 {
-        static let a: UInt16 = 0x8000
-        static let b: UInt16 = 0x4000
-        static let z: UInt16 = 0x2000
-        static let start: UInt16 = 0x1000
-        static let dpadUp: UInt16 = 0x0800
-        static let dpadDown: UInt16 = 0x0400
-        static let dpadLeft: UInt16 = 0x0200
-        static let dpadRight: UInt16 = 0x0100
-        static let r: UInt16 = 0x0010
-        static let cLeft: UInt16 = 0x0002
-        static let cRight: UInt16 = 0x0001
-    }
-
     @Published private(set) var externalControllerName: String?
     @Published private(set) var mouseCaptured = false
 
@@ -216,11 +209,16 @@ final class RecompMacInput: ObservableObject {
     private var menuMouseStep = SIMD2<Float>.zero
     private var menuMouseStepFrames = 0
     private var menuMouseNeutralFrames = 0
+    private var menuStickLatch = RecompMenuStickLatch()
     private var viewMouseFireHeld = false
     private var viewMouseActionHeld = false
     private var pendingMouseDelta = SIMD2<Float>.zero
     private var pendingMenuMouseDelta = SIMD2<Float>.zero
-    private var mouseSensitivity: Float = 2.25
+    private var mouseSensitivity: Float = 2.5
+    private var invertAimY = false
+    private let mouseClampProbeEnabled = ProcessInfo.processInfo.arguments.contains(
+        "--mouse-clamp-probe"
+    )
     private var keyboardBindings = RecompMacKeyboardBindings.load()
     private var observers: [NSObjectProtocol] = []
     private var ticker: Timer?
@@ -362,6 +360,7 @@ final class RecompMacInput: ObservableObject {
         menuMouseStep = .zero
         menuMouseStepFrames = 0
         menuMouseNeutralFrames = 0
+        menuStickLatch.reset()
         viewMouseFireHeld = false
         viewMouseActionHeld = false
         pendingMouseDelta = .zero
@@ -371,6 +370,7 @@ final class RecompMacInput: ObservableObject {
     }
 
     func configureInvertAimY(_ enabled: Bool) {
+        invertAimY = enabled
         goldenPadRecompSetInvertAimY(enabled ? 1 : 0)
     }
 
@@ -402,69 +402,116 @@ final class RecompMacInput: ObservableObject {
     }
 
     private func publish() {
-        refreshRuntimeInputMode()
+        var context = runtimeInputContext(port: 0)
+        refreshRuntimeInputMode(context: context)
+        let mapping = RecompControlMapping(runtimeStyle: context.runtimeStyle)
         var buttons: UInt16 = 0
-        var movement = keyboardMovement
+        var movement = gameplayMovement(includeHorizontal: true)
+        var controllerManualAimStick: SIMD2<Float>?
         var rightStick = SIMD2<Float>.zero
+        var fireActive = actionIsActive(.fire)
+        var aimActive = actionIsActive(.aim)
+        var actionActive = actionIsActive(.action)
+        var weaponActive = actionIsActive(.changeWeapon)
+        let startActive = actionIsActive(.start)
 
-        if actionIsActive(.action) { buttons |= N64.b }
-        if actionIsActive(.changeWeapon) { buttons |= N64.a }
-        if actionIsActive(.fire) { buttons |= N64.z }
-        if actionIsActive(.start) { buttons |= N64.start }
-        if actionIsActive(.aim) { buttons |= N64.r }
-        // Live play uses GoldenEye's native C-button sidestep so A/D never
-        // fights mouse yaw. Menus always retain the full four-way N64 stick.
         if gameplayInputActive {
-            if actionIsActive(.moveLeft) { buttons |= N64.cLeft }
-            if actionIsActive(.moveRight) { buttons |= N64.cRight }
             beginWeaponWheelPulseIfNeeded()
             if weaponWheelPulseFrames > 0 {
-                buttons |= N64.a
-                if weaponWheelDirection < 0 { buttons |= N64.z }
+                weaponActive = true
+                if weaponWheelDirection < 0 { fireActive = true }
             }
-        }
+            if mouseCaptured {
+                fireActive = fireActive || viewMouseFireHeld || mouseFirePulseFrames > 0
+                actionActive = actionActive || viewMouseActionHeld || mouseActionPulseFrames > 0
+            }
+        } else {
+            // Menu/watch navigation is digital and edge-triggered by the game.
+            // Full analog W/S crossed GoldenEye's repeat threshold every tick,
+            // allowing a short key press to skip 1.2 and 1.3 entirely.
+            if actionIsActive(.changeWeapon) || menuConfirmPulseFrames > 0 {
+                buttons |= RecompN64Button.a
+            }
+            if actionIsActive(.action) || menuBackPulseFrames > 0 {
+                buttons |= RecompN64Button.b
+            }
+            if startActive { buttons |= RecompN64Button.start }
 
-        if gameplayInputActive, mouseCaptured {
-            if viewMouseFireHeld || mouseFirePulseFrames > 0 {
-                buttons |= N64.z
-            }
-            if viewMouseActionHeld || mouseActionPulseFrames > 0 {
-                buttons |= N64.b
-            }
-        } else if !gameplayInputActive {
-            if menuConfirmPulseFrames > 0 { buttons |= N64.a }
-            if menuBackPulseFrames > 0 { buttons |= N64.b }
-            if movement == .zero {
-                movement = nextMenuMouseMovement()
-            } else {
-                // A deliberate keyboard/menu command owns this interval. Drop
-                // incidental pointer travel so it cannot add a second step.
+            let keyboardOwnsNavigation = actionIsActive(.moveForward)
+                || actionIsActive(.moveBackward)
+                || actionIsActive(.moveLeft)
+                || actionIsActive(.moveRight)
+            if keyboardOwnsNavigation {
                 pendingMenuMouseDelta = .zero
                 menuMouseStep = .zero
                 menuMouseStepFrames = 0
                 menuMouseNeutralFrames = 0
+            } else {
+                buttons |= nextMenuMouseButtons()
             }
         }
 
         if let gamepad = controller?.extendedGamepad {
             let controllerMovement = SIMD2(gamepad.leftThumbstick.xAxis.value, gamepad.leftThumbstick.yAxis.value)
-            if movement == .zero, simd_length(controllerMovement) > 0.15 {
-                movement = controllerMovement.applyingRadialDeadZone(0.15)
+            controllerManualAimStick = controllerMovement
+            if simd_length(controllerMovement) > 0.08 {
+                movement = controllerMovement
             }
-            rightStick = SIMD2(gamepad.rightThumbstick.xAxis.value, gamepad.rightThumbstick.yAxis.value)
-                .applyingRadialDeadZone(0.15)
-                .applyingResponseCurve(1.5)
-            if gamepad.buttonA.isPressed || gamepad.buttonY.isPressed || gamepad.rightShoulder.isPressed {
-                buttons |= N64.a
+            if gameplayInputActive {
+                rightStick = SIMD2(gamepad.rightThumbstick.xAxis.value, gamepad.rightThumbstick.yAxis.value)
+                    .applyingRadialDeadZone(0.15)
+                    .applyingResponseCurve(1.5)
+                weaponActive = weaponActive || gamepad.buttonA.isPressed
+                    || gamepad.buttonY.isPressed || gamepad.rightShoulder.isPressed
+                actionActive = actionActive || gamepad.buttonB.isPressed || gamepad.buttonX.isPressed
+                aimActive = aimActive || gamepad.leftTrigger.value > 0.25
+                fireActive = fireActive || gamepad.rightTrigger.value > 0.25
+            } else {
+                if gamepad.buttonA.isPressed || gamepad.buttonY.isPressed || gamepad.rightShoulder.isPressed {
+                    buttons |= RecompN64Button.a
+                }
+                if gamepad.buttonB.isPressed || gamepad.buttonX.isPressed {
+                    buttons |= RecompN64Button.b
+                }
             }
-            if gamepad.buttonB.isPressed || gamepad.buttonX.isPressed { buttons |= N64.b }
-            if gamepad.leftTrigger.value > 0.25 { buttons |= N64.r }
-            if gamepad.rightTrigger.value > 0.25 { buttons |= N64.z }
-            if gamepad.buttonMenu.isPressed { buttons |= N64.start }
-            if gamepad.dpad.up.isPressed { buttons |= N64.dpadUp }
-            if gamepad.dpad.down.isPressed { buttons |= N64.dpadDown }
-            if gamepad.dpad.left.isPressed { buttons |= N64.dpadLeft }
-            if gamepad.dpad.right.isPressed { buttons |= N64.dpadRight }
+            if gamepad.buttonMenu.isPressed { buttons |= RecompN64Button.start }
+            if gamepad.dpad.up.isPressed { buttons |= RecompN64Button.dpadUp }
+            if gamepad.dpad.down.isPressed { buttons |= RecompN64Button.dpadDown }
+            if gamepad.dpad.left.isPressed { buttons |= RecompN64Button.dpadLeft }
+            if gamepad.dpad.right.isPressed { buttons |= RecompN64Button.dpadRight }
+        }
+
+        if gameplayInputActive {
+            buttons |= mapping.gameplayButtons(
+                fire: fireActive,
+                aim: aimActive,
+                action: actionActive,
+                weapon: weaponActive,
+                start: startActive
+            )
+            // Suppress synthesized movement immediately on the frame Aim is
+            // requested, before GoldenEye updates insightaimmode.
+            context.aiming = context.aiming || aimActive
+            let resolved = mapping.movement(
+                buttons: buttons,
+                stick: movement,
+                modern: true,
+                context: context
+            )
+            buttons = resolved.buttons
+            movement = resolved.stick
+            if let controllerManualAimStick,
+               let manualAimStick = mapping.manualAimStick(
+                   stick: controllerManualAimStick,
+                   invertVertical: invertAimY,
+                   context: context) {
+                movement = manualAimStick
+                rightStick = .zero
+            }
+            menuStickLatch.reset()
+        } else {
+            buttons |= menuStickLatch.buttons(for: movement)
+            movement = .zero
         }
 
         if !gameplayInputActive {
@@ -481,8 +528,8 @@ final class RecompMacInput: ObservableObject {
         advanceWeaponWheelPulse()
     }
 
-    private func refreshRuntimeInputMode() {
-        let nextGameplayInputActive = goldenPadRecompDesktopGameplayActive() != 0
+    private func refreshRuntimeInputMode(context: RecompRuntimeInputContext) {
+        let nextGameplayInputActive = context.gameplayActive
         guard nextGameplayInputActive != gameplayInputActive else { return }
         gameplayInputActive = nextGameplayInputActive
         pendingMouseDelta = .zero
@@ -490,6 +537,7 @@ final class RecompMacInput: ObservableObject {
         menuMouseStep = .zero
         menuMouseStepFrames = 0
         menuMouseNeutralFrames = 0
+        menuStickLatch.reset()
         if gameplayInputActive {
             // A mission transition should immediately hand the pointer to
             // camera look. Requiring a click after every load left motion in
@@ -498,6 +546,24 @@ final class RecompMacInput: ObservableObject {
         } else {
             releaseMouseCapture()
         }
+    }
+
+    private func runtimeInputContext(port: Int32) -> RecompRuntimeInputContext {
+        var gameplayActive: Int32 = 0
+        var controlStyle: Int32 = -1
+        var aiming: Int32 = 0
+        var tankState: Int32 = -1
+        var nativeLookUpright: Int32 = 0
+        goldenPadRecompGetInputContext(
+            port, &gameplayActive, &controlStyle, &aiming, &tankState,
+            &nativeLookUpright)
+        return RecompRuntimeInputContext(
+            gameplayActive: gameplayActive != 0,
+            runtimeStyle: controlStyle,
+            aiming: aiming != 0,
+            tankState: tankState,
+            nativeLookUpright: nativeLookUpright != 0
+        )
     }
 
     private func keyIsActive(_ code: UInt16) -> Bool {
@@ -542,18 +608,11 @@ final class RecompMacInput: ObservableObject {
         return keyIsActive(configured)
     }
 
-    private var keyboardMovement: SIMD2<Float> {
-        // In GoldenEye's 1.1 Honey layout the N64 stick becomes the manual-aim
-        // axis while R is held. Mouse look already owns that axis on desktop,
-        // so forwarding W/S as well makes Shift+W pitch the view downward.
-        // Keep Honey aim stationary and predictable instead.
-        if gameplayInputActive, actionIsActive(.aim) {
-            return .zero
-        }
+    private func gameplayMovement(includeHorizontal: Bool) -> SIMD2<Float> {
         var movement = SIMD2<Float>.zero
         if actionIsActive(.moveForward) { movement.y += 1 }
         if actionIsActive(.moveBackward) { movement.y -= 1 }
-        if !gameplayInputActive {
+        if includeHorizontal {
             if actionIsActive(.moveLeft) { movement.x -= 1 }
             if actionIsActive(.moveRight) { movement.x += 1 }
         }
@@ -587,19 +646,23 @@ final class RecompMacInput: ObservableObject {
         goldenPadRecompQueueMouseLook(0, x, y)
     }
 
-    private func nextMenuMouseMovement() -> SIMD2<Float> {
+    private func nextMenuMouseButtons() -> UInt16 {
         if menuMouseStepFrames > 0 {
             menuMouseStepFrames -= 1
-            return menuMouseStep
+            if menuMouseStep.x < 0 { return RecompN64Button.dpadLeft }
+            if menuMouseStep.x > 0 { return RecompN64Button.dpadRight }
+            if menuMouseStep.y > 0 { return RecompN64Button.dpadUp }
+            if menuMouseStep.y < 0 { return RecompN64Button.dpadDown }
+            return 0
         }
         if menuMouseNeutralFrames > 0 {
             menuMouseNeutralFrames -= 1
-            return .zero
+            return 0
         }
 
         let threshold: Float = 18
         let delta = pendingMenuMouseDelta
-        guard max(abs(delta.x), abs(delta.y)) >= threshold else { return .zero }
+        guard max(abs(delta.x), abs(delta.y)) >= threshold else { return 0 }
         if abs(delta.x) > abs(delta.y) {
             menuMouseStep = SIMD2(delta.x < 0 ? -1 : 1, 0)
         } else {
@@ -610,7 +673,7 @@ final class RecompMacInput: ObservableObject {
         pendingMenuMouseDelta = .zero
         menuMouseStepFrames = 2
         menuMouseNeutralFrames = 2
-        return menuMouseStep
+        return nextMenuMouseButtons()
     }
 
     private func beginWeaponWheelPulseIfNeeded() {

--- a/Sources/RecompControlMapping.swift
+++ b/Sources/RecompControlMapping.swift
@@ -1,0 +1,208 @@
+struct RecompN64Button {
+    static let a: UInt16 = 0x8000
+    static let b: UInt16 = 0x4000
+    static let z: UInt16 = 0x2000
+    static let start: UInt16 = 0x1000
+    static let dpadUp: UInt16 = 0x0800
+    static let dpadDown: UInt16 = 0x0400
+    static let dpadLeft: UInt16 = 0x0200
+    static let dpadRight: UInt16 = 0x0100
+    static let r: UInt16 = 0x0010
+    static let cUp: UInt16 = 0x0008
+    static let cDown: UInt16 = 0x0004
+    static let cLeft: UInt16 = 0x0002
+    static let cRight: UInt16 = 0x0001
+}
+
+struct RecompRuntimeInputContext: Equatable {
+    /// -1 means Bond is not mounted. GoldenEye's native tank run states are
+    /// 0 entering, 1 starting, and 2 running.
+    var gameplayActive: Bool
+    var runtimeStyle: Int32
+    var aiming: Bool
+    var tankState: Int32
+    var nativeLookUpright: Bool
+
+    var isInTank: Bool { tankState >= 0 }
+    var isTankRunning: Bool { tankState == 2 }
+}
+
+struct RecompMovementMapping: Equatable {
+    var buttons: UInt16
+    var stick: SIMD2<Float>
+}
+
+/// Translates GoldenPad's semantic actions into GoldenEye's active 1.x layout.
+/// The same table is compiled into the Mac, iPhone, and iPad hosts.
+struct RecompControlMapping {
+    let runtimeStyle: Int32
+
+    private var usesKissyButtons: Bool {
+        runtimeStyle == 2 || runtimeStyle == 3
+    }
+
+    var usesDigitalMovement: Bool {
+        runtimeStyle == 1 || runtimeStyle == 3
+    }
+
+    var fireButton: UInt16 {
+        usesKissyButtons ? RecompN64Button.a : RecompN64Button.z
+    }
+
+    var aimButton: UInt16 {
+        usesKissyButtons ? RecompN64Button.z : RecompN64Button.r
+    }
+
+    var weaponButton: UInt16 {
+        usesKissyButtons ? RecompN64Button.r : RecompN64Button.a
+    }
+
+    func gameplayButtons(
+        fire: Bool,
+        aim: Bool,
+        action: Bool,
+        weapon: Bool,
+        start: Bool
+    ) -> UInt16 {
+        var buttons: UInt16 = 0
+        if fire { buttons |= fireButton }
+        if aim { buttons |= aimButton }
+        if action { buttons |= RecompN64Button.b }
+        if weapon { buttons |= weaponButton }
+        if start { buttons |= RecompN64Button.start }
+        return buttons
+    }
+
+    func movement(
+        buttons: UInt16,
+        stick: SIMD2<Float>,
+        modern: Bool,
+        context: RecompRuntimeInputContext,
+        threshold: Float = 0.30
+    ) -> RecompMovementMapping {
+        guard modern, context.gameplayActive else {
+            return RecompMovementMapping(buttons: buttons, stick: stick)
+        }
+
+        // Modern Aim owns both look axes. Never synthesize GoldenEye's C-button
+        // lean/step controls from the movement stick while the real game state is
+        // aiming. Likewise, leave the original tank entry animation undisturbed.
+        if context.aiming || (context.isInTank && !context.isTankRunning) {
+            return RecompMovementMapping(buttons: buttons, stick: .zero)
+        }
+
+        if context.isInTank {
+            if usesDigitalMovement {
+                return RecompMovementMapping(
+                    buttons: buttons | directionalCButtons(for: stick, threshold: threshold),
+                    stick: .zero
+                )
+            }
+            // Honey/Kissy use native analog Y for drive and analog X for hull
+            // steering. Do not synthesize C-left/right here; those turn the turret.
+            return RecompMovementMapping(buttons: buttons, stick: stick)
+        }
+
+        if usesDigitalMovement {
+            // Solitaire/Goodnight define all four C directions as movement.
+            return RecompMovementMapping(
+                buttons: buttons | directionalCButtons(for: stick, threshold: threshold),
+                stick: .zero
+            )
+        }
+
+        // Honey/Kissy keep analog Y for walking while modern horizontal movement
+        // becomes the native C-button sidestep pair.
+        var mappedButtons = buttons
+        if stick.x < -threshold { mappedButtons |= RecompN64Button.cLeft }
+        if stick.x > threshold { mappedButtons |= RecompN64Button.cRight }
+        return RecompMovementMapping(buttons: mappedButtons, stick: SIMD2(0, stick.y))
+    }
+
+    /// Converts the external left stick into GoldenEye's original manual-sight
+    /// stick while aiming on foot. The game applies its Reverse/Upright option
+    /// after reading this value, so compensate for that live option first and
+    /// let GoldenPad's host setting provide the final user-facing polarity.
+    func manualAimStick(
+        stick: SIMD2<Float>,
+        invertVertical: Bool,
+        context: RecompRuntimeInputContext
+    ) -> SIMD2<Float>? {
+        guard context.gameplayActive, context.aiming, !context.isInTank else {
+            return nil
+        }
+
+        var rawY = context.nativeLookUpright ? stick.y : -stick.y
+        if invertVertical { rawY = -rawY }
+        return SIMD2(stick.x, rawY)
+    }
+
+    static func menuNavigationButtons(
+        up: Bool,
+        down: Bool,
+        left: Bool,
+        right: Bool
+    ) -> UInt16 {
+        var buttons: UInt16 = 0
+        if up { buttons |= RecompN64Button.dpadUp }
+        if down { buttons |= RecompN64Button.dpadDown }
+        if left { buttons |= RecompN64Button.dpadLeft }
+        if right { buttons |= RecompN64Button.dpadRight }
+        return buttons
+    }
+
+    private func directionalCButtons(
+        for stick: SIMD2<Float>,
+        threshold: Float
+    ) -> UInt16 {
+        var buttons: UInt16 = 0
+        if stick.y > threshold { buttons |= RecompN64Button.cUp }
+        if stick.y < -threshold { buttons |= RecompN64Button.cDown }
+        if stick.x < -threshold { buttons |= RecompN64Button.cLeft }
+        if stick.x > threshold { buttons |= RecompN64Button.cRight }
+        return buttons
+    }
+}
+
+/// GoldenEye's watch control-style list advances once per frame at full analog
+/// deflection. Publish one digital edge, then require neutral before another step.
+struct RecompMenuStickLatch {
+    private(set) var armed = true
+    private var pulseButton: UInt16 = 0
+    private var pulseFramesRemaining = 0
+
+    mutating func buttons(for stick: SIMD2<Float>) -> UInt16 {
+        let neutralThreshold: Float = 0.20
+        let activationThreshold: Float = 0.50
+        let absX = abs(stick.x)
+        let absY = abs(stick.y)
+
+        // Keep the edge visible for two host publications so GoldenEye cannot
+        // miss it between game polls. Because the button never returns to zero
+        // between these frames, native PressedThisFrame still advances once.
+        if pulseFramesRemaining > 0 {
+            pulseFramesRemaining -= 1
+            return pulseButton
+        }
+
+        if absX <= neutralThreshold && absY <= neutralThreshold {
+            armed = true
+            pulseButton = 0
+            return 0
+        }
+        guard armed, max(absX, absY) >= activationThreshold else { return 0 }
+        armed = false
+
+        pulseButton = absX > absY
+            ? (stick.x < 0 ? RecompN64Button.dpadLeft : RecompN64Button.dpadRight)
+            : (stick.y < 0 ? RecompN64Button.dpadDown : RecompN64Button.dpadUp)
+        pulseFramesRemaining = 1
+        return pulseButton
+    }
+
+    mutating func reset() {
+        armed = true
+        pulseButton = 0
+        pulseFramesRemaining = 0
+    }
+}

--- a/Sources/RecompPrototypeApp.swift
+++ b/Sources/RecompPrototypeApp.swift
@@ -39,7 +39,6 @@ struct GoldenPadApp: App {
     @AppStorage("recomp.lookSensitivity") private var lookSensitivity = 4.0
     @AppStorage("recomp.aimBehavior") private var aimBehavior = RecompPrototypeAimBehavior.toggle.rawValue
     @AppStorage("recomp.controllerLookMode") private var controllerLookMode = RecompPrototypeControllerLookMode.analog.rawValue
-    @AppStorage("recomp.movementMode") private var movementMode = RecompPrototypeMovementMode.previewTwo.rawValue
     @AppStorage("recomp.controllerMap.buttonA") private var controllerButtonA = RecompPrototypeControllerControl.buttonA.defaultAction.rawValue
     @AppStorage("recomp.controllerMap.buttonB") private var controllerButtonB = RecompPrototypeControllerControl.buttonB.defaultAction.rawValue
     @AppStorage("recomp.controllerMap.buttonX") private var controllerButtonX = RecompPrototypeControllerControl.buttonX.defaultAction.rawValue
@@ -119,7 +118,6 @@ struct GoldenPadApp: App {
                 input.configureLookSensitivity(lookSensitivity)
                 input.configureAimBehavior(aimBehavior)
                 input.configureControllerLookMode(controllerLookMode)
-                input.configureMovementMode(movementMode)
                 input.configureControllerMapping(controllerMapping)
                 input.configureInvertAimY(invertAimY)
                 input.configureUnlockAllMissions(unlockAllMissions)
@@ -136,9 +134,6 @@ struct GoldenPadApp: App {
             }
             .onChange(of: controllerLookMode) { _, value in
                 input.configureControllerLookMode(value)
-            }
-            .onChange(of: movementMode) { _, value in
-                input.configureMovementMode(value)
             }
             .onChange(of: controllerMappingRawValues) { _, _ in
                 input.configureControllerMapping(controllerMapping)
@@ -186,7 +181,6 @@ struct GoldenPadApp: App {
                         ),
                         aimBehavior: $aimBehavior,
                         controllerLookMode: $controllerLookMode,
-                        movementMode: $movementMode,
                         controllerButtonA: $controllerButtonA,
                         controllerButtonB: $controllerButtonB,
                         controllerButtonX: $controllerButtonX,
@@ -268,7 +262,6 @@ struct GoldenPadApp: App {
                     lookSensitivity: lookSensitivity,
                     aimBehavior: aimBehavior,
                     controllerLookMode: controllerLookMode,
-                    movementMode: movementMode,
                     activeControlStyle: input.activeControlStyle,
                     controllerMapping: controllerMapping,
                     invertAimY: invertAimY,
@@ -343,7 +336,6 @@ private struct RecompPrototypeSettingsView: View {
     @Binding var lookSensitivity: Double
     @Binding var aimBehavior: String
     @Binding var controllerLookMode: String
-    @Binding var movementMode: String
     @Binding var controllerButtonA: String
     @Binding var controllerButtonB: String
     @Binding var controllerButtonX: String
@@ -425,15 +417,7 @@ private struct RecompPrototypeSettingsView: View {
                 }
                 Section("GoldenEye Controls") {
                     LabeledContent("Active in-game style", value: controlStyleTitle(activeControlStyle))
-                    Picker("Movement adapter", selection: $movementMode) {
-                        ForEach(RecompPrototypeMovementMode.allCases, id: \.rawValue) { mode in
-                            Text(mode.title).tag(mode.rawValue)
-                        }
-                    }
-                    Text("Sidestep mode maps horizontal movement to GoldenEye's C-left and C-right actions for both touch and connected controllers. It activates only during single-player gameplay with 1.1 Honey. Preview 2 movement remains the default and is unchanged.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                    Text("GoldenEye's own control style and aim options are changed inside the watch menu. GoldenPad does not replace those game settings.")
+                    Text("GoldenPad follows GoldenEye's active 1.1-1.4 control style automatically. The game's own control style and aim options remain in the watch menu.")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
@@ -578,7 +562,6 @@ private enum RecompPrototypeDiagnostics {
         lookSensitivity: Double,
         aimBehavior: String,
         controllerLookMode: String,
-        movementMode: String,
         activeControlStyle: Int32,
         controllerMapping: [RecompPrototypeControllerControl: String],
         invertAimY: Bool,
@@ -609,7 +592,6 @@ private enum RecompPrototypeDiagnostics {
         Look sensitivity: \(String(format: "%.2f", lookSensitivity))x
         Aim behavior: \(aimBehavior)
         Controller right stick: \((RecompPrototypeControllerLookMode(rawValue: controllerLookMode) ?? .analog).title)
-        Movement adapter: \((RecompPrototypeMovementMode(rawValue: movementMode) ?? .previewTwo).title)
         Active GoldenEye control style: \(controlStyleTitle(activeControlStyle))
         Controller mapping: \(controllerMappingSummary(controllerMapping))
         Invert vertical while aiming: \(invertAimY ? "On" : "Off")

--- a/Sources/RecompPrototypeAudio.swift
+++ b/Sources/RecompPrototypeAudio.swift
@@ -18,6 +18,23 @@ private func goldenPadRecompAudioStats(
     _ underrunCallbacks: UnsafeMutablePointer<UInt64>?
 )
 
+@_silgen_name("goldenpad_recomp_set_audio_probe_enabled")
+private func goldenPadRecompSetAudioProbeEnabled(_ enabled: Int32)
+
+@_silgen_name("goldenpad_recomp_note_audio_host_rates")
+private func goldenPadRecompNoteAudioHostRates(
+    _ source: UInt32,
+    _ session: UInt32,
+    _ mixer: UInt32
+)
+
+@_silgen_name("goldenpad_recomp_audio_probe_stats")
+private func goldenPadRecompAudioProbeStats(
+    _ observedFrames: UnsafeMutablePointer<UInt64>?,
+    _ largeJumps: UnsafeMutablePointer<UInt64>?,
+    _ sequenceErrors: UnsafeMutablePointer<UInt64>?
+)
+
 @MainActor
 final class RecompPrototypeAudio: ObservableObject {
     @Published private(set) var status = "audio: inactive"
@@ -26,8 +43,12 @@ final class RecompPrototypeAudio: ObservableObject {
     private var sourceNode: AVAudioSourceNode?
     private var observers: [NSObjectProtocol] = []
     private var statsTimer: Timer?
+    private let audioProbeEnabled = ProcessInfo.processInfo.arguments.contains("--audio-probe")
+
+    private static let sourceSampleRate = 22_050.0
 
     init() {
+        goldenPadRecompSetAudioProbeEnabled(audioProbeEnabled ? 1 : 0)
         let center = NotificationCenter.default
         observers.append(center.addObserver(
             forName: AVAudioSession.interruptionNotification,
@@ -57,6 +78,11 @@ final class RecompPrototypeAudio: ObservableObject {
             try session.setCategory(.ambient, mode: .default)
             try session.setActive(true)
             try startEngine()
+            goldenPadRecompNoteAudioHostRates(
+                UInt32(Self.sourceSampleRate),
+                UInt32(session.sampleRate.rounded()),
+                UInt32(engine.mainMixerNode.outputFormat(forBus: 0).sampleRate.rounded())
+            )
             status = "audio: native PCM ready"
             startStatsPolling()
             print("[GoldenPadRecomp] audio: AVAudioEngine active at \(session.sampleRate) Hz")
@@ -81,7 +107,7 @@ final class RecompPrototypeAudio: ObservableObject {
         if sourceNode == nil {
             guard let format = AVAudioFormat(
                 commonFormat: .pcmFormatFloat32,
-                sampleRate: 22_050,
+                sampleRate: Self.sourceSampleRate,
                 channels: 2,
                 interleaved: false
             ) else {
@@ -123,10 +149,18 @@ final class RecompPrototypeAudio: ObservableObject {
                 var dropped: UInt64 = 0
                 var underrunFrames: UInt64 = 0
                 var underrunCallbacks: UInt64 = 0
+                var probeObserved: UInt64 = 0
+                var probeLargeJumps: UInt64 = 0
+                var probeSequenceErrors: UInt64 = 0
                 goldenPadRecompAudioStats(
                     &queued, &rendered, &nonzero, &dropped,
                     &underrunFrames, &underrunCallbacks
                 )
+                if self.audioProbeEnabled {
+                    goldenPadRecompAudioProbeStats(
+                        &probeObserved, &probeLargeJumps, &probeSequenceErrors
+                    )
+                }
                 if rendered > 0 && nonzero > 0 {
                     self.status = "audio: playing"
                 }
@@ -135,6 +169,12 @@ final class RecompPrototypeAudio: ObservableObject {
                     "nonzero=\(nonzero) dropped=\(dropped) " +
                     "underrunFrames=\(underrunFrames) underrunCallbacks=\(underrunCallbacks)"
                 )
+                if self.audioProbeEnabled {
+                    print(
+                        "[GoldenPadRecomp] audio-probe: observedFrames=\(probeObserved) " +
+                        "largeJumps=\(probeLargeJumps) sequenceErrors=\(probeSequenceErrors)"
+                    )
+                }
             }
         }
     }

--- a/Sources/RecompPrototypeInput.swift
+++ b/Sources/RecompPrototypeInput.swift
@@ -17,6 +17,9 @@ private func goldenPadRecompSetRightAnalog(_ controller: Int32, _ x: Int32, _ y:
 @_silgen_name("goldenpad_recomp_set_controller_connected")
 private func goldenPadRecompSetControllerConnected(_ connected: Int32)
 
+@_silgen_name("goldenpad_recomp_set_touch_input_port")
+private func goldenPadRecompSetTouchInputPort(_ port: Int32)
+
 @_silgen_name("goldenpad_recomp_set_two_player_test_mode")
 private func goldenPadRecompSetTwoPlayerTestMode(_ enabled: Int32)
 
@@ -38,11 +41,24 @@ private func goldenPadRecompSetUnlockAllMissions(_ enabled: Int32)
 @_silgen_name("goldenpad_recomp_request_return_to_title")
 private func goldenPadRecompRequestReturnToTitle()
 
+@_silgen_name("goldenpad_recomp_set_fire_rate_probe_enabled")
+private func goldenPadRecompSetFireRateProbeEnabled(_ enabled: Int32)
+
 @_silgen_name("goldenpad_recomp_gameplay_input_active")
 private func goldenPadRecompGameplayInputActive() -> Int32
 
-@_silgen_name("goldenpad_recomp_current_control_style")
-private func goldenPadRecompCurrentControlStyle() -> Int32
+@_silgen_name("goldenpad_recomp_get_input_context")
+private func goldenPadRecompGetInputContext(
+    _ controller: Int32,
+    _ gameplayActive: UnsafeMutablePointer<Int32>,
+    _ controlStyle: UnsafeMutablePointer<Int32>,
+    _ aiming: UnsafeMutablePointer<Int32>,
+    _ tankState: UnsafeMutablePointer<Int32>,
+    _ nativeLookUpright: UnsafeMutablePointer<Int32>
+)
+
+@_silgen_name("goldenpad_recomp_set_sidestep_probe_enabled")
+private func goldenPadRecompSetSidestepProbeEnabled(_ enabled: Int32)
 
 enum RecompPrototypeAimBehavior: String, CaseIterable {
     case toggle
@@ -67,69 +83,6 @@ enum RecompPrototypeControllerLookMode: String, CaseIterable {
         case .classic: "Original N64 C-buttons"
         case .off: "Off"
         }
-    }
-}
-
-enum RecompPrototypeMovementMode: String, CaseIterable {
-    case previewTwo
-    case honeySidestep
-
-    var title: String {
-        switch self {
-        case .previewTwo: "Preview 2 movement"
-        case .honeySidestep: "Sidestep with left/right"
-        }
-    }
-}
-
-private enum RecompPrototypeMovementMapper {
-    enum Direction {
-        case neutral
-        case left
-        case right
-    }
-
-    private static let pressThreshold: Float = 0.30
-    private static let releaseThreshold: Float = 0.20
-
-    static func map(
-        stick: SIMD2<Float>,
-        buttons: UInt16,
-        mode: RecompPrototypeMovementMode,
-        gameplayActive: Bool,
-        controlStyle: Int32,
-        cLeft: UInt16,
-        cRight: UInt16,
-        direction: inout Direction
-    ) -> (stick: SIMD2<Float>, buttons: UInt16) {
-        guard mode == .honeySidestep, gameplayActive, controlStyle == 0 else {
-            direction = .neutral
-            return (stick, buttons)
-        }
-
-        var mappedStick = stick
-        var mappedButtons = buttons
-        switch direction {
-        case .neutral:
-            if stick.x < -pressThreshold { direction = .left }
-            if stick.x > pressThreshold { direction = .right }
-        case .left:
-            if stick.x > pressThreshold {
-                direction = .right
-            } else if stick.x > -releaseThreshold {
-                direction = .neutral
-            }
-        case .right:
-            if stick.x < -pressThreshold {
-                direction = .left
-            } else if stick.x < releaseThreshold {
-                direction = .neutral
-            }
-        }
-        if direction == .left { mappedButtons |= cLeft }
-        if direction == .right { mappedButtons |= cRight }
-        mappedStick.x = 0
-        return (mappedStick, mappedButtons)
     }
 }
 
@@ -208,24 +161,143 @@ final class RecompPrototypeInput: ObservableObject {
         static let cRight: UInt16 = 0x0001
     }
 
+    private struct InputOwnershipRoute: Equatable {
+        var externalPort: Int32?
+        var touchPort: Int32?
+        var twoPlayerActive: Bool
+    }
+
+    private enum InputOwnershipRouter {
+        static func route(
+            controllerPresent: Bool,
+            twoPlayerRequested: Bool
+        ) -> InputOwnershipRoute {
+            if controllerPresent {
+                return InputOwnershipRoute(
+                    externalPort: 0,
+                    touchPort: twoPlayerRequested ? 1 : nil,
+                    twoPlayerActive: twoPlayerRequested
+                )
+            }
+            return InputOwnershipRoute(
+                externalPort: nil,
+                touchPort: twoPlayerRequested ? nil : 0,
+                twoPlayerActive: false
+            )
+        }
+
+        static var disconnectProbePasses: Bool {
+            let touchOnly = route(controllerPresent: false, twoPlayerRequested: false)
+            let externalOnly = route(controllerPresent: true, twoPlayerRequested: false)
+            let paired = route(controllerPresent: true, twoPlayerRequested: true)
+            let disconnected = route(controllerPresent: false, twoPlayerRequested: true)
+            let reconnected = route(controllerPresent: true, twoPlayerRequested: true)
+            let explicitCollapse = route(controllerPresent: false, twoPlayerRequested: false)
+            return touchOnly == InputOwnershipRoute(
+                externalPort: nil, touchPort: 0, twoPlayerActive: false
+            ) && externalOnly == InputOwnershipRoute(
+                externalPort: 0, touchPort: nil, twoPlayerActive: false
+            ) && paired == InputOwnershipRoute(
+                externalPort: 0, touchPort: 1, twoPlayerActive: true
+            ) && disconnected == InputOwnershipRoute(
+                externalPort: nil, touchPort: nil, twoPlayerActive: false
+            ) && reconnected == paired && explicitCollapse == touchOnly
+        }
+
+        static func retainedController<ID: Equatable>(
+            current: ID?,
+            available: [ID]
+        ) -> ID? {
+            if let current, available.contains(current) { return current }
+            return available.first
+        }
+
+        static var orderingProbePasses: Bool {
+            let controllerA = retainedController(current: nil, available: ["A"])
+            let afterBConnect = retainedController(current: controllerA, available: ["B", "A"])
+            let afterADisconnect = retainedController(current: afterBConnect, available: ["B"])
+            let afterAReconnect = retainedController(
+                current: afterADisconnect,
+                available: ["A", "B"]
+            )
+            return controllerA == "A" && afterBConnect == "A" &&
+                afterADisconnect == "B" && afterAReconnect == "B"
+        }
+    }
+
+    private enum InputSuspensionRouter {
+        static func isSuspended(overlay: Bool, scene: Bool) -> Bool {
+            overlay || scene
+        }
+
+        static var lifecycleProbePasses: Bool {
+            !isSuspended(overlay: false, scene: false) &&
+                isSuspended(overlay: true, scene: false) &&
+                isSuspended(overlay: false, scene: true) &&
+                isSuspended(overlay: true, scene: true)
+        }
+    }
+
+    private enum ControllerActivationGuard {
+        static func waitingForNeutral(
+            current: Bool,
+            controllerChanged: Bool,
+            controllerPresent: Bool,
+            inputIsNeutral: Bool
+        ) -> Bool {
+            if controllerChanged { return controllerPresent }
+            if current && inputIsNeutral { return false }
+            return current
+        }
+
+        static var lifecycleProbePasses: Bool {
+            let afterConnect = waitingForNeutral(
+                current: false,
+                controllerChanged: true,
+                controllerPresent: true,
+                inputIsNeutral: false
+            )
+            let whileHeld = waitingForNeutral(
+                current: afterConnect,
+                controllerChanged: false,
+                controllerPresent: true,
+                inputIsNeutral: false
+            )
+            let afterRelease = waitingForNeutral(
+                current: whileHeld,
+                controllerChanged: false,
+                controllerPresent: true,
+                inputIsNeutral: true
+            )
+            return afterConnect && whileHeld && !afterRelease
+        }
+    }
+
     @Published private(set) var externalControllerName: String?
     @Published private(set) var touchAimActive = false
     @Published private(set) var aimBehavior = RecompPrototypeAimBehavior.toggle
     @Published private(set) var controllerLookMode = RecompPrototypeControllerLookMode.analog
-    @Published private(set) var movementMode = RecompPrototypeMovementMode.previewTwo
     @Published private(set) var activeControlStyle: Int32 = -1
     @Published private(set) var twoPlayerTestModeActive = false
     @Published private(set) var fourPlayerTestModeActive = false
+    @Published private(set) var touchControlsVisible = true
     private var touchButtons: UInt16 = 0
     private var touchMovement = SIMD2<Float>.zero
     private var touchLook = SIMD2<Float>.zero
     private var touchCrouchIsPressed = false
     private var controllerCrouchWasPressed = false
-    private var externalSidestepDirection = RecompPrototypeMovementMapper.Direction.neutral
-    private var touchSidestepDirection = RecompPrototypeMovementMapper.Direction.neutral
-    private var movementNeutralFrames = 0
     private var twoPlayerTestModeRequested = false
     private var fourPlayerTestModeRequested = false
+    private var overlayInputSuspended = false
+    private var sceneInputSuspended = false
+    private var controllerRequiresNeutralRelease = false
+    private var invertAimY = false
+    private let fourPlayerRenderProbeForcesFourPlayer = ProcessInfo.processInfo.arguments.contains(
+        "--four-player-render-probe"
+    )
+    private let ownershipProbeForcesTwoPlayer =
+        ProcessInfo.processInfo.arguments.contains("--controller-ownership-probe") ||
+        ProcessInfo.processInfo.arguments.contains("--four-player-render-probe")
     private var lookSensitivity: Float = 4.0
     private var controller: GCController?
     private var controllerMapping = Dictionary(
@@ -236,10 +308,37 @@ final class RecompPrototypeInput: ObservableObject {
     #if targetEnvironment(simulator)
     private var simulatorKeyboardHeldButtons: UInt16 = 0
     private var simulatorKeyboardPulseFrames: [UInt16: Int] = [:]
+    private var simulatorKeyboardHeldStick: UInt8 = 0
+    private var simulatorKeyboardStickPulseFrames: [UInt8: Int] = [:]
     #endif
 
     init() {
+        let sidestepProbeEnabled = ProcessInfo.processInfo.arguments.contains("--sidestep-probe")
+        let ownershipProbeEnabled = ownershipProbeForcesTwoPlayer
+        goldenPadRecompSetSidestepProbeEnabled(sidestepProbeEnabled ? 1 : 0)
+        if ownershipProbeEnabled {
+            NSLog(
+                "[GoldenPad] Controller ownership lifecycle probe: " +
+                (InputOwnershipRouter.disconnectProbePasses &&
+                    InputOwnershipRouter.orderingProbePasses &&
+                    InputSuspensionRouter.lifecycleProbePasses &&
+                    ControllerActivationGuard.lifecycleProbePasses ? "PASS" : "FAIL")
+            )
+        }
+        goldenPadRecompSetFireRateProbeEnabled(
+            ProcessInfo.processInfo.arguments.contains("--fire-rate-probe") ? 1 : 0
+        )
         refreshController()
+        if ownershipProbeEnabled {
+            // Exercise the real integration route without changing AppStorage:
+            // controller Player 1 plus touch Player 2 for this launch only.
+            configureTwoPlayerTestMode(true)
+        }
+        if fourPlayerRenderProbeForcesFourPlayer {
+            // Extend the launch-only route with neutral Players 3/4. The normal
+            // AppStorage-backed toggle remains unchanged.
+            configureFourPlayerTestMode(true)
+        }
         let center = NotificationCenter.default
         observers.append(center.addObserver(forName: .GCControllerDidConnect, object: nil, queue: .main) { [weak self] _ in
             Task { @MainActor in self?.refreshController() }
@@ -282,18 +381,12 @@ final class RecompPrototypeInput: ObservableObject {
     }
 
     func configureControllerLookMode(_ rawValue: String) {
-        controllerLookMode = RecompPrototypeControllerLookMode(rawValue: rawValue) ?? .analog
-        publish()
-    }
-
-    func configureMovementMode(_ rawValue: String) {
-        let next = RecompPrototypeMovementMode(rawValue: rawValue) ?? .previewTwo
-        guard movementMode != next else { return }
-        movementMode = next
-        externalSidestepDirection = .neutral
-        touchSidestepDirection = .neutral
-        movementNeutralFrames = 1
-        publish()
+        let next = RecompPrototypeControllerLookMode(rawValue: rawValue) ?? .analog
+        guard next != controllerLookMode else { return }
+        controllerLookMode = next
+        // Give the game one neutral publication when changing semantics so a
+        // held stick cannot carry an old-mode turn/strafe into the new mode.
+        publishController(port: 0, buttons: 0, stick: .zero, look: .zero)
     }
 
     func configureControllerMapping(_ rawValues: [RecompPrototypeControllerControl: String]) {
@@ -308,7 +401,38 @@ final class RecompPrototypeInput: ObservableObject {
         publish()
     }
 
+    func setHostInputSuspended(_ suspended: Bool) {
+        updateInputSuspension(overlay: suspended)
+    }
+
+    func setSceneInputSuspended(_ suspended: Bool) {
+        updateInputSuspension(scene: suspended)
+    }
+
+    private var hostInputSuspended: Bool {
+        InputSuspensionRouter.isSuspended(
+            overlay: overlayInputSuspended,
+            scene: sceneInputSuspended
+        )
+    }
+
+    private func updateInputSuspension(
+        overlay: Bool? = nil,
+        scene: Bool? = nil
+    ) {
+        let wasSuspended = hostInputSuspended
+        if let overlay { overlayInputSuspended = overlay }
+        if let scene { sceneInputSuspended = scene }
+        guard wasSuspended != hostInputSuspended else { return }
+        if hostInputSuspended {
+            clearTouchInputState()
+            controllerCrouchWasPressed = false
+        }
+        publish()
+    }
+
     func configureInvertAimY(_ enabled: Bool) {
+        invertAimY = enabled
         goldenPadRecompSetInvertAimY(enabled ? 1 : 0)
     }
 
@@ -317,26 +441,42 @@ final class RecompPrototypeInput: ObservableObject {
     }
 
     func configureTwoPlayerTestMode(_ enabled: Bool) {
-        twoPlayerTestModeRequested = enabled
-        updateTestModes()
+        let previousOwnership = ownershipRoute
+        twoPlayerTestModeRequested = ownershipProbeForcesTwoPlayer || enabled
+        updateTestModes(previousOwnership: previousOwnership)
     }
 
     func configureFourPlayerTestMode(_ enabled: Bool) {
-        fourPlayerTestModeRequested = enabled
+        fourPlayerTestModeRequested = fourPlayerRenderProbeForcesFourPlayer || enabled
         updateTestModes()
     }
 
-    private func updateTestModes() {
-        let wasTwoPlayerActive = twoPlayerTestModeActive
-        twoPlayerTestModeActive = twoPlayerTestModeRequested && controller != nil
+    private var ownershipRoute: InputOwnershipRoute {
+        InputOwnershipRouter.route(
+            controllerPresent: controller != nil,
+            twoPlayerRequested: twoPlayerTestModeRequested
+        )
+    }
+
+    private func updateTestModes(
+        previousOwnership: InputOwnershipRoute? = nil,
+        controllerChanged: Bool = false
+    ) {
+        let nextOwnership = ownershipRoute
+        if controllerChanged || previousOwnership.map({ $0 != nextOwnership }) == true {
+            // Route changes publish a neutral boundary before any new owner can
+            // write a held button or stick into a different player port.
+            clearTouchInputState()
+            publishNeutralControllers()
+        }
+        twoPlayerTestModeActive = nextOwnership.twoPlayerActive
         fourPlayerTestModeActive = twoPlayerTestModeActive && fourPlayerTestModeRequested
+        touchControlsVisible = nextOwnership.touchPort != nil
+        goldenPadRecompSetControllerConnected(controller == nil ? 0 : 1)
+        goldenPadRecompSetTouchInputPort(nextOwnership.touchPort ?? -1)
         goldenPadRecompSetTwoPlayerTestMode(twoPlayerTestModeActive ? 1 : 0)
         goldenPadRecompSetFourPlayerTestMode(fourPlayerTestModeActive ? 1 : 0)
-        if wasTwoPlayerActive && !twoPlayerTestModeActive && controller != nil {
-            releaseTouchInput()
-        } else {
-            publish()
-        }
+        publish()
     }
 
     func requestReturnToMainMenu() {
@@ -352,8 +492,8 @@ final class RecompPrototypeInput: ObservableObject {
     }
 
     func setCrouchPressed(_ pressed: Bool) {
-        if pressed && !touchCrouchIsPressed {
-            goldenPadRecompRequestCrouchToggle(twoPlayerTestModeActive ? 1 : 0)
+        if pressed && !touchCrouchIsPressed, let touchPort = ownershipRoute.touchPort {
+            goldenPadRecompRequestCrouchToggle(touchPort)
         }
         touchCrouchIsPressed = pressed
     }
@@ -378,40 +518,59 @@ final class RecompPrototypeInput: ObservableObject {
     }
 
     func releaseTouchInput() {
+        clearTouchInputState()
+        publish()
+    }
+
+    private func clearTouchInputState() {
         touchButtons = 0
         touchAimActive = false
         touchMovement = .zero
         touchLook = .zero
         touchCrouchIsPressed = false
-        publish()
     }
 
     private func refreshController() {
-        controller = GCController.controllers().first(where: { $0.extendedGamepad != nil })
+        let previousOwnership = ownershipRoute
+        let previousController = controller
+        let availableControllers = GCController.controllers().filter { $0.extendedGamepad != nil }
+        if let previousController,
+           availableControllers.contains(where: { $0 === previousController }) {
+            controller = previousController
+        } else {
+            controller = availableControllers.first
+        }
         controllerCrouchWasPressed = false
         externalControllerName = controller.map { $0.vendorName ?? "External controller" }
-        twoPlayerTestModeActive = twoPlayerTestModeRequested && controller != nil
-        fourPlayerTestModeActive = twoPlayerTestModeActive && fourPlayerTestModeRequested
-        if controller != nil && !twoPlayerTestModeActive {
-            releaseTouchInput()
-        }
-        goldenPadRecompSetControllerConnected(controller == nil ? 0 : 1)
-        goldenPadRecompSetTwoPlayerTestMode(twoPlayerTestModeActive ? 1 : 0)
-        goldenPadRecompSetFourPlayerTestMode(fourPlayerTestModeActive ? 1 : 0)
-        publish()
+        controllerRequiresNeutralRelease = ControllerActivationGuard.waitingForNeutral(
+            current: controllerRequiresNeutralRelease,
+            controllerChanged: previousController !== controller,
+            controllerPresent: controller != nil,
+            inputIsNeutral: false
+        )
+        updateTestModes(
+            previousOwnership: previousOwnership,
+            controllerChanged: previousController !== controller
+        )
     }
 
     private func publish() {
-        let gameplayActive = goldenPadRecompGameplayInputActive() != 0
-        let controlStyle = twoPlayerTestModeActive ? -2 : goldenPadRecompCurrentControlStyle()
-        if activeControlStyle != controlStyle {
-            activeControlStyle = controlStyle
+        if hostInputSuspended {
+            touchLook = .zero
+            publishNeutralControllers()
+            return
         }
+
         let queuedTouchLook = clamp(touchLook * lookSensitivity)
         touchLook = .zero
         var externalButtons: UInt16 = 0
         var externalStick = SIMD2<Float>.zero
         var controllerLook = SIMD2<Float>.zero
+        var controllerCrouchIsPressed = false
+        var externalFireActive = false
+        var externalAimActive = false
+        var externalActionActive = false
+        var externalWeaponActive = false
 
         if let gamepad = controller?.extendedGamepad {
             externalStick = SIMD2(gamepad.leftThumbstick.xAxis.value, gamepad.leftThumbstick.yAxis.value)
@@ -421,7 +580,6 @@ final class RecompPrototypeInput: ObservableObject {
             )
                 .applyingRadialDeadZone(0.15)
                 .applyingResponseCurve(1.5)
-            var controllerCrouchIsPressed = false
             let pressedControls: [(RecompPrototypeControllerControl, Bool)] = [
                 (.buttonA, gamepad.buttonA.isPressed),
                 (.buttonB, gamepad.buttonB.isPressed),
@@ -434,20 +592,14 @@ final class RecompPrototypeInput: ObservableObject {
             ]
             for (control, isPressed) in pressedControls where isPressed {
                 switch controllerMapping[control] ?? control.defaultAction {
-                case .fire: externalButtons |= N64.z
-                case .aim: externalButtons |= N64.r
-                case .action: externalButtons |= N64.b
-                case .weapon: externalButtons |= N64.a
+                case .fire: externalFireActive = true
+                case .aim: externalAimActive = true
+                case .action: externalActionActive = true
+                case .weapon: externalWeaponActive = true
                 case .duck: controllerCrouchIsPressed = true
                 case .none: break
                 }
             }
-            if controllerCrouchIsPressed && !controllerCrouchWasPressed {
-                // The external controller remains Player 1 in both normal and
-                // two-player test modes. Touch is the only input routed to P2.
-                goldenPadRecompRequestCrouchToggle(0)
-            }
-            controllerCrouchWasPressed = controllerCrouchIsPressed
             if gamepad.buttonMenu.isPressed { externalButtons |= N64.start }
             if gamepad.dpad.up.isPressed { externalButtons |= N64.dpadUp }
             if gamepad.dpad.down.isPressed { externalButtons |= N64.dpadDown }
@@ -462,11 +614,45 @@ final class RecompPrototypeInput: ObservableObject {
         if simulatorButtons & N64.dpadDown != 0 { externalStick.y = -1 }
         if simulatorButtons & N64.dpadLeft != 0 { externalStick.x = -1 }
         if simulatorButtons & N64.dpadRight != 0 { externalStick.x = 1 }
+        let simulatorStick = consumeSimulatorKeyboardStick()
+        if simulatorStick != .zero { externalStick = simulatorStick }
         #endif
+
+        let controllerInputIsNeutral = externalButtons == 0 &&
+            !externalFireActive && !externalAimActive &&
+            !externalActionActive && !externalWeaponActive &&
+            simd_length(externalStick) <= 0.15 &&
+            controllerLook == .zero &&
+            !controllerCrouchIsPressed
+        let wasWaitingForNeutral = controllerRequiresNeutralRelease
+        controllerRequiresNeutralRelease = ControllerActivationGuard.waitingForNeutral(
+            current: controllerRequiresNeutralRelease,
+            controllerChanged: false,
+            controllerPresent: controller != nil,
+            inputIsNeutral: controllerInputIsNeutral
+        )
+        if wasWaitingForNeutral {
+            // A newly selected or reconnected controller stays neutral until
+            // every held input has been released. This prevents a button held
+            // through disconnect from becoming a fresh press on a new owner.
+            externalButtons = 0
+            externalStick = .zero
+            controllerLook = .zero
+            controllerCrouchIsPressed = false
+            externalFireActive = false
+            externalAimActive = false
+            externalActionActive = false
+            externalWeaponActive = false
+        }
+        if controllerCrouchIsPressed && !controllerCrouchWasPressed {
+            // The external controller remains Player 1 in both normal and
+            // two-player test modes. Touch is the only input routed to P2.
+            goldenPadRecompRequestCrouchToggle(0)
+        }
+        controllerCrouchWasPressed = controllerCrouchIsPressed
 
         switch controllerLookMode {
         case .analog:
-            if !gameplayActive { controllerLook = .zero }
             break
         case .classic:
             let threshold: Float = 0.30
@@ -479,63 +665,163 @@ final class RecompPrototypeInput: ObservableObject {
             controllerLook = .zero
         }
 
-        var mappedExternalMovement = RecompPrototypeMovementMapper.map(
-            stick: externalStick,
-            buttons: externalButtons,
-            mode: movementMode,
-            gameplayActive: gameplayActive && !twoPlayerTestModeActive,
-            controlStyle: controlStyle,
-            cLeft: N64.cLeft,
-            cRight: N64.cRight,
-            direction: &externalSidestepDirection
-        )
-        var mappedTouchMovement = RecompPrototypeMovementMapper.map(
-            stick: touchMovement,
-            buttons: touchButtons,
-            mode: movementMode,
-            gameplayActive: gameplayActive && !twoPlayerTestModeActive,
-            controlStyle: controlStyle,
-            cLeft: N64.cLeft,
-            cRight: N64.cRight,
-            direction: &touchSidestepDirection
-        )
+        let route = ownershipRoute
+        let gameplayActive = goldenPadRecompGameplayInputActive() != 0
 
-        if movementNeutralFrames > 0 {
-            mappedExternalMovement.stick = .zero
-            mappedExternalMovement.buttons &= ~(N64.cLeft | N64.cRight)
-            mappedTouchMovement.stick = .zero
-            mappedTouchMovement.buttons &= ~(N64.cLeft | N64.cRight)
-            movementNeutralFrames -= 1
-        }
-
-        externalStick = mappedExternalMovement.stick
-        externalButtons = mappedExternalMovement.buttons
-
-        // The saved 4x tuning belongs to relative touch deltas. A physical
-        // right stick is an absolute value published every frame; multiplying
-        // it by 4x saturated the camera at roughly one-quarter stick travel.
-        // Keep the post-dead-zone controller value normalized instead.
-        if twoPlayerTestModeActive {
-            publishController(port: 0, buttons: externalButtons, stick: externalStick, look: controllerLook)
-            publishController(port: 1, buttons: mappedTouchMovement.buttons, stick: mappedTouchMovement.stick, look: .zero)
-            if fourPlayerTestModeActive {
-                publishController(port: 2, buttons: 0, stick: .zero, look: .zero)
-                publishController(port: 3, buttons: 0, stick: .zero, look: .zero)
+        if !gameplayActive {
+            activeControlStyle = -1
+            // Preserve the physically working Preview 3/P4 menu path exactly.
+            // GoldenEye owns analog menu repeat and button edges; no style,
+            // tank, Aim, or menu-latch translation belongs in this branch.
+            if externalFireActive { externalButtons |= N64.z }
+            if externalAimActive { externalButtons |= N64.r }
+            if externalActionActive { externalButtons |= N64.b }
+            if externalWeaponActive { externalButtons |= N64.a }
+            for port in 0..<4 {
+                let resolvedPort = Int32(port)
+                if route.externalPort == resolvedPort {
+                    publishController(
+                        port: resolvedPort,
+                        buttons: externalButtons,
+                        stick: externalStick,
+                        look: controllerLook
+                    )
+                } else if route.touchPort == resolvedPort {
+                    publishController(
+                        port: resolvedPort,
+                        buttons: touchButtons,
+                        stick: touchMovement,
+                        look: .zero
+                    )
+                } else {
+                    publishController(port: resolvedPort, buttons: 0, stick: .zero, look: .zero)
+                }
             }
-        } else if controller != nil {
-            publishController(port: 0, buttons: externalButtons, stick: externalStick, look: controllerLook)
-            publishController(port: 1, buttons: 0, stick: .zero, look: .zero)
-        } else {
-            publishController(port: 0, buttons: mappedTouchMovement.buttons, stick: mappedTouchMovement.stick, look: .zero)
-            publishController(port: 1, buttons: 0, stick: .zero, look: .zero)
+            if queuedTouchLook != .zero, let touchPort = route.touchPort {
+                goldenPadRecompQueueTouchLook(
+                    touchPort,
+                    Int32((queuedTouchLook.x * 32_767).rounded()),
+                    Int32((queuedTouchLook.y * 32_767).rounded())
+                )
+            }
+            return
         }
-        if gameplayActive && queuedTouchLook != .zero && (controller == nil || twoPlayerTestModeActive) {
+
+        var externalContext = route.externalPort.map(runtimeInputContext) ?? inactiveInputContext
+        var touchContext = route.touchPort.map(runtimeInputContext) ?? inactiveInputContext
+        activeControlStyle = route.externalPort != nil
+            ? externalContext.runtimeStyle : touchContext.runtimeStyle
+        externalContext.gameplayActive = true
+        touchContext.gameplayActive = true
+        let externalMapping = RecompControlMapping(runtimeStyle: externalContext.runtimeStyle)
+        let touchMapping = RecompControlMapping(runtimeStyle: touchContext.runtimeStyle)
+
+        // Use the requested semantic Aim as an immediate safety boundary as
+        // well as the authoritative game state. This prevents a one-frame
+        // synthesized C-button lean before insightaimmode updates.
+        externalContext.aiming = externalContext.aiming || externalAimActive
+        let touchFireActive = touchButtons & N64.z != 0
+        let touchAimRequested = touchButtons & N64.r != 0
+        let touchActionActive = touchButtons & N64.b != 0
+        let touchWeaponActive = touchButtons & N64.a != 0
+        let touchStartActive = touchButtons & N64.start != 0
+        touchContext.aiming = touchContext.aiming || touchAimRequested
+
+        externalButtons |= externalMapping.gameplayButtons(
+            fire: externalFireActive,
+            aim: externalAimActive,
+            action: externalActionActive,
+            weapon: externalWeaponActive,
+            start: externalButtons & N64.start != 0
+        )
+        let resolvedTouchButtons = touchMapping.gameplayButtons(
+            fire: touchFireActive,
+            aim: touchAimRequested,
+            action: touchActionActive,
+            weapon: touchWeaponActive,
+            start: touchStartActive
+        )
+
+        var externalMovement = externalMapping.movement(
+            buttons: externalButtons,
+            stick: externalStick,
+            modern: controllerLookMode == .analog,
+            context: externalContext
+        )
+        var publishedControllerLook = controllerLook
+        if controllerLookMode == .analog,
+           let manualAimStick = externalMapping.manualAimStick(
+               stick: externalStick,
+               invertVertical: invertAimY,
+               context: externalContext) {
+            // GoldenEye's original manual-sight path owns damping, reticle
+            // position, and weapon orientation. Aim mode interprets this N64
+            // stick as sight movement rather than character movement.
+            externalMovement.stick = manualAimStick
+            publishedControllerLook = .zero
+        }
+        let mappedTouchMovement = touchMapping.movement(
+            buttons: resolvedTouchButtons,
+            stick: touchMovement,
+            modern: true,
+            context: touchContext
+        )
+
+        for port in 0..<4 {
+            let resolvedPort = Int32(port)
+            if route.externalPort == resolvedPort {
+                publishController(
+                    port: resolvedPort,
+                    buttons: externalMovement.buttons,
+                    stick: externalMovement.stick,
+                    look: publishedControllerLook
+                )
+            } else if route.touchPort == resolvedPort {
+                publishController(
+                    port: resolvedPort,
+                    buttons: mappedTouchMovement.buttons,
+                    stick: mappedTouchMovement.stick,
+                    look: .zero
+                )
+            } else {
+                publishController(port: resolvedPort, buttons: 0, stick: .zero, look: .zero)
+            }
+        }
+        if queuedTouchLook != .zero, let touchPort = route.touchPort {
             goldenPadRecompQueueTouchLook(
-                twoPlayerTestModeActive ? 1 : 0,
+                touchPort,
                 Int32((queuedTouchLook.x * 32_767).rounded()),
                 Int32((queuedTouchLook.y * 32_767).rounded())
             )
         }
+    }
+
+    private var inactiveInputContext: RecompRuntimeInputContext {
+        RecompRuntimeInputContext(
+            gameplayActive: false,
+            runtimeStyle: -1,
+            aiming: false,
+            tankState: -1,
+            nativeLookUpright: false
+        )
+    }
+
+    private func runtimeInputContext(port: Int32) -> RecompRuntimeInputContext {
+        var gameplayActive: Int32 = 0
+        var controlStyle: Int32 = -1
+        var aiming: Int32 = 0
+        var tankState: Int32 = -1
+        var nativeLookUpright: Int32 = 0
+        goldenPadRecompGetInputContext(
+            port, &gameplayActive, &controlStyle, &aiming, &tankState,
+            &nativeLookUpright)
+        return RecompRuntimeInputContext(
+            gameplayActive: gameplayActive != 0,
+            runtimeStyle: controlStyle,
+            aiming: aiming != 0,
+            tankState: tankState,
+            nativeLookUpright: nativeLookUpright != 0
+        )
     }
 
     private func publishController(
@@ -558,6 +844,12 @@ final class RecompPrototypeInput: ObservableObject {
         )
     }
 
+    private func publishNeutralControllers() {
+        for port in 0..<4 {
+            publishController(port: Int32(port), buttons: 0, stick: .zero, look: .zero)
+        }
+    }
+
     private func clamp(_ value: SIMD2<Float>) -> SIMD2<Float> {
         let magnitude = simd_length(value)
         return magnitude > 1 ? value / magnitude : value
@@ -573,6 +865,15 @@ final class RecompPrototypeInput: ObservableObject {
     }
 
     private func handleSimulatorKey(_ keyCode: GCKeyCode, pressed: Bool) {
+        if let stick = simulatorStickBit(for: keyCode) {
+            if pressed {
+                simulatorKeyboardHeldStick |= stick
+                simulatorKeyboardStickPulseFrames[stick] = 4
+            } else {
+                simulatorKeyboardHeldStick &= ~stick
+            }
+            return
+        }
         guard let button = simulatorButton(for: keyCode) else { return }
         if pressed {
             simulatorKeyboardHeldButtons |= button
@@ -595,6 +896,32 @@ final class RecompPrototypeInput: ObservableObject {
             }
         }
         return buttons
+    }
+
+    private func consumeSimulatorKeyboardStick() -> SIMD2<Float> {
+        var stick = simulatorKeyboardHeldStick
+        for (direction, frames) in Array(simulatorKeyboardStickPulseFrames) {
+            stick |= direction
+            if frames <= 1 {
+                simulatorKeyboardStickPulseFrames.removeValue(forKey: direction)
+            } else {
+                simulatorKeyboardStickPulseFrames[direction] = frames - 1
+            }
+        }
+        return SIMD2(
+            (stick & 0x08 != 0 ? 1 : 0) - (stick & 0x04 != 0 ? 1 : 0),
+            (stick & 0x01 != 0 ? 1 : 0) - (stick & 0x02 != 0 ? 1 : 0)
+        )
+    }
+
+    private func simulatorStickBit(for keyCode: GCKeyCode) -> UInt8? {
+        switch keyCode {
+        case .keyI: 0x01
+        case .keyK: 0x02
+        case .keyJ: 0x04
+        case .keyL: 0x08
+        default: nil
+        }
     }
 
     private func simulatorButton(for keyCode: GCKeyCode) -> UInt16? {

--- a/Sources/RecompPrototypeMetalCanvas.swift
+++ b/Sources/RecompPrototypeMetalCanvas.swift
@@ -25,6 +25,12 @@ private func goldenPadRecompSetAppActive(_ active: Int32)
 @_silgen_name("goldenpad_recomp_note_transient_inactive")
 private func goldenPadRecompNoteTransientInactive()
 
+@_silgen_name("goldenpad_recomp_set_lifecycle_probe_enabled")
+private func goldenPadRecompSetLifecycleProbeEnabled(_ enabled: Int32)
+
+@_silgen_name("goldenpad_recomp_set_depth_rebuild_probe_enabled")
+private func goldenPadRecompSetDepthRebuildProbeEnabled(_ enabled: Int32)
+
 #if GOLDENPAD_RECOMP_AOT_LINKED
 @_silgen_name("goldenpad_recomp_start_game")
 private func goldenPadRecompStartGame(
@@ -46,6 +52,15 @@ final class RecompPrototypeSurface: ObservableObject {
     private var rendererInitialized = false
     private var gameLaunchRequested = false
     private var statusTimer: Timer?
+
+    init() {
+        goldenPadRecompSetLifecycleProbeEnabled(
+            ProcessInfo.processInfo.arguments.contains("--lifecycle-probe") ? 1 : 0
+        )
+        goldenPadRecompSetDepthRebuildProbeEnabled(
+            ProcessInfo.processInfo.arguments.contains("--depth-rebuild-probe") ? 1 : 0
+        )
+    }
 
     func attach(to view: MTKView) {
         metalView = view

--- a/Support/RecompPrototype/recomp_game_start.cpp
+++ b/Support/RecompPrototype/recomp_game_start.cpp
@@ -29,6 +29,14 @@
 extern RspUcodeFunc aspMain;
 gpr get_entrypoint_address();
 
+#if !defined(GOLDENPAD_RECOMP_MAC)
+extern "C" uint64_t goldenpad_rt64_depth_format_rebuild_stats(
+    uint64_t *widthChanges,
+    uint64_t *sizeChanges,
+    uint64_t *rdramChanges,
+    uint32_t *latestAddress);
+#endif
+
 namespace zelda64 {
 void register_overlays();
 void register_patches();
@@ -65,6 +73,7 @@ std::atomic<bool> unlockAllMissions = false;
 std::atomic<bool> returnToTitleRequested = false;
 std::atomic<bool> appActive = true;
 std::atomic<bool> controllerConnected = false;
+std::atomic<int32_t> touchInputPort = -1;
 std::atomic<bool> twoPlayerTestMode = false;
 std::atomic<bool> fourPlayerTestMode = false;
 std::atomic<uint64_t> rt64DisplayListCount = 0;
@@ -76,6 +85,27 @@ std::atomic<uint8_t> inputStateReported = 0;
 std::atomic<bool> audioCallbackReported = false;
 std::atomic<bool> stateProbeStarted = false;
 std::atomic<uint8_t> invalidInputPortsReported = 0;
+std::atomic<bool> fireRateProbeEnabled = false;
+std::atomic<bool> sidestepProbeEnabled = false;
+std::atomic<bool> lifecycleProbeEnabled = false;
+std::atomic<bool> audioProbeEnabled = false;
+std::atomic<bool> depthRebuildProbeEnabled = false;
+std::atomic<uint32_t> audioRequestedFrequency = 0;
+std::atomic<uint32_t> audioHostSourceFrequency = 0;
+std::atomic<uint32_t> audioHostSessionFrequency = 0;
+std::atomic<uint32_t> audioHostMixerFrequency = 0;
+std::atomic<uint64_t> audioProbeObservedFrames = 0;
+std::atomic<uint64_t> audioProbeLargeJumps = 0;
+std::atomic<uint64_t> audioProbeSequenceErrors = 0;
+std::atomic<uint64_t> lifecycleProgressSequence = 0;
+std::atomic<uint64_t> lifecycleProgressStartedMs = 0;
+std::atomic<uint64_t> lifecycleProgressBaselineDisplayLists = 0;
+std::atomic<uint64_t> lifecycleProgressBaselineScreenUpdates = 0;
+std::atomic<uint64_t> lifecycleProgressBaselinePresented = 0;
+std::atomic<int32_t> lifecycleProgressKind = 0;
+std::atomic<int32_t> gameplayInputModeReported = -1;
+std::atomic<uint64_t> fireRateProbeSimulationTicks = 0;
+std::atomic<uint32_t> fireRateProbeRawGuardSamples = 0;
 std::mutex statusMutex;
 std::mutex diagnosticsMutex;
 std::string runtimeStatus = "AOT runtime: waiting for imported user ROM";
@@ -102,6 +132,108 @@ bool audioPlaybackPrimed = false;
 uint32_t audioFadeInFramesRemaining = 0;
 float audioLastLeft = 0.0f;
 float audioLastRight = 0.0f;
+bool audioProbeHasLastOutput = false;
+float audioProbeLastLeft = 0.0f;
+float audioProbeLastRight = 0.0f;
+
+constexpr float kAudioProbeJumpThreshold = 0.05f;
+
+uint64_t queryDepthFormatRebuildStats(
+    uint64_t *widthChanges,
+    uint64_t *sizeChanges,
+    uint64_t *rdramChanges,
+    uint32_t *latestAddress) {
+#if defined(GOLDENPAD_RECOMP_MAC)
+    *widthChanges = 0;
+    *sizeChanges = 0;
+    *rdramChanges = 0;
+    *latestAddress = 0;
+    return 0;
+#else
+    return goldenpad_rt64_depth_format_rebuild_stats(
+        widthChanges, sizeChanges, rdramChanges, latestAddress);
+#endif
+}
+
+int16_t audioProbeSample(uint64_t frame) {
+    // A 200-frame triangle stays continuous across its wrap and is cheap
+    // enough not to perturb the producer/consumer timing being measured.
+    constexpr uint64_t period = 200;
+    constexpr uint64_t halfPeriod = period / 2;
+    constexpr int32_t amplitude = 16'000;
+    constexpr int32_t step = amplitude * 2 / static_cast<int32_t>(halfPeriod);
+    const uint64_t phase = frame % period;
+    const int32_t value = phase < halfPeriod
+        ? -amplitude + static_cast<int32_t>(phase) * step
+        : amplitude - static_cast<int32_t>(phase - halfPeriod) * step;
+    return static_cast<int16_t>(value);
+}
+
+bool audioProbeStepIsLarge(float previous, float current) {
+    return std::abs(current - previous) > kAudioProbeJumpThreshold;
+}
+
+bool audioProbeDetectorSelfTestPasses() {
+    return !audioProbeStepIsLarge(0.10f, 0.12f) &&
+        audioProbeStepIsLarge(-0.45f, 0.45f);
+}
+
+void observeAudioProbeOutput(const float *left, const float *right, uint32_t frames) {
+    if (!audioProbeEnabled.load(std::memory_order_relaxed)) { return; }
+    uint64_t jumps = 0;
+    for (uint32_t frame = 0; frame < frames; ++frame) {
+        if (audioProbeHasLastOutput &&
+            (audioProbeStepIsLarge(audioProbeLastLeft, left[frame]) ||
+                audioProbeStepIsLarge(audioProbeLastRight, right[frame]))) {
+            ++jumps;
+        }
+        audioProbeHasLastOutput = true;
+        audioProbeLastLeft = left[frame];
+        audioProbeLastRight = right[frame];
+    }
+    audioProbeObservedFrames.fetch_add(frames, std::memory_order_relaxed);
+    audioProbeLargeJumps.fetch_add(jumps, std::memory_order_relaxed);
+}
+
+enum class LifecycleProgressState {
+    noRuntimeProgress,
+    presentationStalled,
+    recovered,
+};
+
+LifecycleProgressState classifyLifecycleProgress(
+    uint64_t displayListDelta,
+    uint64_t screenUpdateDelta,
+    uint64_t presentedDelta
+) {
+    if (presentedDelta != 0) {
+        return LifecycleProgressState::recovered;
+    }
+    if (displayListDelta != 0 || screenUpdateDelta != 0) {
+        return LifecycleProgressState::presentationStalled;
+    }
+    return LifecycleProgressState::noRuntimeProgress;
+}
+
+bool lifecycleProgressClassifierProbePasses() {
+    return classifyLifecycleProgress(0, 0, 0) == LifecycleProgressState::noRuntimeProgress &&
+        classifyLifecycleProgress(0, 12, 0) == LifecycleProgressState::presentationStalled &&
+        classifyLifecycleProgress(12, 12, 12) == LifecycleProgressState::recovered;
+}
+
+const char *lifecycleProgressStateName(LifecycleProgressState state) {
+    switch (state) {
+    case LifecycleProgressState::noRuntimeProgress: return "no-runtime-progress";
+    case LifecycleProgressState::presentationStalled: return "presentation-stalled";
+    case LifecycleProgressState::recovered: return "recovered";
+    }
+    return "unknown";
+}
+
+uint64_t monotonicMilliseconds() {
+    return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count());
+}
 
 void logEvent(const char *event, const char *format, ...) {
     char detail[768];
@@ -143,6 +275,7 @@ void configureDiagnostics(const std::filesystem::path &configPath) {
         std::filesystem::rename(latest, previous, error);
     }
     diagnosticsLogPath = latest;
+    gameplayInputModeReported.store(-1, std::memory_order_relaxed);
     std::ofstream log(diagnosticsLogPath, std::ios::trunc);
     log << "[GoldenPadRecomp] diagnostics: private current-session log started\n";
     if (unexpectedPreviousEnd) {
@@ -150,6 +283,47 @@ void configureDiagnostics(const std::filesystem::path &configPath) {
     }
     std::ofstream marker(diagnosticsSessionMarkerPath, std::ios::trunc);
     marker << "GoldenPad foreground session active\n";
+    if (lifecycleProbeEnabled.load(std::memory_order_relaxed)) {
+        log << "[GoldenPadRecomp] lifecycle-probe: classifier="
+            << (lifecycleProgressClassifierProbePasses() ? "PASS" : "FAIL") << '\n';
+    }
+    if (audioProbeEnabled.load(std::memory_order_relaxed)) {
+        log << "[GoldenPadRecomp] audio-probe: detector="
+            << (audioProbeDetectorSelfTestPasses() ? "PASS" : "FAIL") << '\n';
+    }
+    if (depthRebuildProbeEnabled.load(std::memory_order_relaxed)) {
+        uint64_t widthChanges = 0;
+        uint64_t sizeChanges = 0;
+        uint64_t rdramChanges = 0;
+        uint32_t latestAddress = 0;
+        const uint64_t rebuilds = queryDepthFormatRebuildStats(
+            &widthChanges, &sizeChanges, &rdramChanges, &latestAddress);
+        log << "[GoldenPadRecomp] depth-rebuild-probe: counter=READY"
+            << " baseline=" << rebuilds
+            << " causes=(width=" << widthChanges
+            << " size=" << sizeChanges
+            << " rdram=" << rdramChanges << ')'
+            << " latest=0x" << std::hex << latestAddress << std::dec << '\n';
+    }
+}
+
+void startLifecycleProgressWindow(int32_t kind, const char *kindName) {
+    if (!lifecycleProbeEnabled.load(std::memory_order_relaxed)) { return; }
+    const uint64_t displayLists = rt64DisplayListCount.load(std::memory_order_relaxed);
+    const uint64_t screenUpdates = rt64ScreenUpdateCount.load(std::memory_order_relaxed);
+    const uint64_t presented = rt64PresentedCount.load(std::memory_order_relaxed);
+    lifecycleProgressBaselineDisplayLists.store(displayLists, std::memory_order_relaxed);
+    lifecycleProgressBaselineScreenUpdates.store(screenUpdates, std::memory_order_relaxed);
+    lifecycleProgressBaselinePresented.store(presented, std::memory_order_relaxed);
+    lifecycleProgressStartedMs.store(monotonicMilliseconds(), std::memory_order_relaxed);
+    lifecycleProgressKind.store(kind, std::memory_order_relaxed);
+    const uint64_t sequence = lifecycleProgressSequence.fetch_add(1, std::memory_order_release) + 1;
+    logEvent("lifecycle-progress",
+        "sequence=%llu transition=%s baseline=(dl=%llu vi=%llu presented=%llu)",
+        static_cast<unsigned long long>(sequence), kindName,
+        static_cast<unsigned long long>(displayLists),
+        static_cast<unsigned long long>(screenUpdates),
+        static_cast<unsigned long long>(presented));
 }
 
 void markDiagnosticsSessionActive() {
@@ -245,6 +419,62 @@ float readGameFloat(uint8_t *rdram, uint32_t address) {
     return std::bit_cast<float>(static_cast<uint32_t>(readGameWord(rdram, address)));
 }
 
+constexpr uint32_t kFireRateWindowTicks = 100;
+constexpr uint32_t kFireRateProbeRunLimit = 3;
+constexpr uint8_t kKf7SovietItem = 8;
+constexpr uint8_t kKf7SovietRawRate = 3;
+
+struct PlayerFireRateWindow {
+    bool active = false;
+    uint32_t runs = 0;
+    uint32_t ticks = 0;
+    int32_t lastWeapon = -1;
+    int32_t lastAmmo = -1;
+    int32_t player = -1;
+    int32_t weapon = -1;
+    int32_t startingAmmo = -1;
+    int32_t endingAmmo = -1;
+    int32_t startingCounter = -1;
+    int32_t endingCounter = -1;
+    uint32_t shotEvents = 0;
+};
+
+struct GuardFireRateWindow {
+    bool active = false;
+    uint32_t runs = 0;
+    uint32_t guardKey = 0;
+    uint64_t startingTick = 0;
+    uint8_t startingCounter = 0;
+    uint8_t endingCounter = 0;
+    uint32_t shotEvents = 0;
+};
+
+PlayerFireRateWindow playerFireRateWindow;
+GuardFireRateWindow guardFireRateWindow;
+
+bool isAutomaticPlayerWeapon(int32_t weapon) {
+    // GoldenEye's full-auto group runs from the Skorpion through the RC-P90.
+    return weapon >= 7 && weapon <= 14;
+}
+
+void completeGuardFireRateWindow(uint64_t simulationTick) {
+    if (!guardFireRateWindow.active ||
+        simulationTick - guardFireRateWindow.startingTick < kFireRateWindowTicks) {
+        return;
+    }
+    logEvent("fire-rate-probe",
+        "guard run=%u complete ticks=%u item=%u rawRate=%u events=%u counter=%u->%u",
+        guardFireRateWindow.runs + 1,
+        kFireRateWindowTicks,
+        kKf7SovietItem,
+        kKf7SovietRawRate,
+        guardFireRateWindow.shotEvents,
+        guardFireRateWindow.startingCounter,
+        guardFireRateWindow.endingCounter);
+    ++guardFireRateWindow.runs;
+    guardFireRateWindow.active = false;
+}
+
 size_t getQueuedFrames();
 
 void monitorGameState(uint8_t *rdram) {
@@ -255,6 +485,9 @@ void monitorGameState(uint8_t *rdram) {
     uint64_t previousScreenUpdates = 0;
     uint64_t previousPresented = 0;
     int stalledActiveSamples = 0;
+    uint64_t observedLifecycleSequence = 0;
+    uint64_t nextLifecycleSampleMs = 0;
+    int lifecycleProgressSamples = 0;
     int heartbeat = 0;
     while (runtimeStarted.load(std::memory_order_relaxed)) {
         const int32_t menu = readGameWord(rdram, 0x8002A6C0);
@@ -276,6 +509,44 @@ void monitorGameState(uint8_t *rdram) {
         const uint64_t screenUpdates = rt64ScreenUpdateCount.load(std::memory_order_relaxed);
         const uint64_t presented = rt64PresentedCount.load(std::memory_order_relaxed);
         const bool active = appActive.load(std::memory_order_relaxed);
+        if (lifecycleProbeEnabled.load(std::memory_order_relaxed) && active) {
+            const uint64_t sequence = lifecycleProgressSequence.load(std::memory_order_acquire);
+            if (sequence != observedLifecycleSequence) {
+                observedLifecycleSequence = sequence;
+                lifecycleProgressSamples = 0;
+                nextLifecycleSampleMs = lifecycleProgressStartedMs.load(
+                    std::memory_order_relaxed) + 2'000;
+            }
+            const uint64_t nowMs = monotonicMilliseconds();
+            if (sequence != 0 && lifecycleProgressSamples < 5 &&
+                nowMs >= nextLifecycleSampleMs) {
+                const uint64_t displayListDelta = displayLists -
+                    lifecycleProgressBaselineDisplayLists.load(std::memory_order_relaxed);
+                const uint64_t screenUpdateDelta = screenUpdates -
+                    lifecycleProgressBaselineScreenUpdates.load(std::memory_order_relaxed);
+                const uint64_t presentedDelta = presented -
+                    lifecycleProgressBaselinePresented.load(std::memory_order_relaxed);
+                const LifecycleProgressState progress = classifyLifecycleProgress(
+                    displayListDelta, screenUpdateDelta, presentedDelta);
+                const int32_t kind = lifecycleProgressKind.load(std::memory_order_relaxed);
+                const uint64_t ageMs = nowMs -
+                    lifecycleProgressStartedMs.load(std::memory_order_relaxed);
+                logEvent("lifecycle-progress",
+                    "sequence=%llu transition=%s ageMs=%llu delta=(dl=%llu vi=%llu presented=%llu) state=%s sample=%d/5",
+                    static_cast<unsigned long long>(sequence),
+                    kind == 1 ? "transient-inactive" : "foreground-resume",
+                    static_cast<unsigned long long>(ageMs),
+                    static_cast<unsigned long long>(displayListDelta),
+                    static_cast<unsigned long long>(screenUpdateDelta),
+                    static_cast<unsigned long long>(presentedDelta),
+                    lifecycleProgressStateName(progress), lifecycleProgressSamples + 1);
+                ++lifecycleProgressSamples;
+                nextLifecycleSampleMs += 2'000;
+                if (progress == LifecycleProgressState::recovered || ageMs >= 10'000) {
+                    lifecycleProgressSamples = 5;
+                }
+            }
+        }
         if (heartbeat == 0) {
             const uint32_t player = static_cast<uint32_t>(readGameWord(rdram, 0x80079EB0));
             const bool playerValid = player >= 0x80000000u && player < 0xA0000000u;
@@ -307,7 +578,9 @@ void monitorGameState(uint8_t *rdram) {
                 static_cast<unsigned long long>(audioUnderrunCallbacks.load(std::memory_order_relaxed)),
                 fourPlayerTestMode.load(std::memory_order_relaxed) ? "external-p1+touch-p2+neutral-p3/p4" :
                     (twoPlayerTestMode.load(std::memory_order_relaxed) ? "external-p1+touch-p2" :
-                        (controllerConnected.load(std::memory_order_relaxed) ? "external-p1" : "touch-p1")),
+                        (controllerConnected.load(std::memory_order_relaxed) ? "external-p1" :
+                            (touchInputPort.load(std::memory_order_relaxed) == 0 ?
+                                "touch-p1" : "neutral-awaiting-controller"))),
                 controllerLookX[0].load(std::memory_order_relaxed),
                 controllerLookY[0].load(std::memory_order_relaxed),
                 controllerLookX[1].load(std::memory_order_relaxed),
@@ -326,6 +599,30 @@ void monitorGameState(uint8_t *rdram) {
                 playerValid ? readGameFloat(rdram, player + 0x158) : 0.0f,
                 basisValid ? "valid" : "unavailable",
                 viewX, viewY, viewZ, upX, upY, upZ);
+            if (audioProbeEnabled.load(std::memory_order_relaxed)) {
+                logEvent("audio-probe",
+                    "observedFrames=%llu largeJumps=%llu sequenceErrors=%llu",
+                    static_cast<unsigned long long>(
+                        audioProbeObservedFrames.load(std::memory_order_relaxed)),
+                    static_cast<unsigned long long>(
+                        audioProbeLargeJumps.load(std::memory_order_relaxed)),
+                    static_cast<unsigned long long>(
+                        audioProbeSequenceErrors.load(std::memory_order_relaxed)));
+            }
+            if (depthRebuildProbeEnabled.load(std::memory_order_relaxed)) {
+                uint64_t widthChanges = 0;
+                uint64_t sizeChanges = 0;
+                uint64_t rdramChanges = 0;
+                uint32_t latestAddress = 0;
+                const uint64_t rebuilds = queryDepthFormatRebuildStats(
+                    &widthChanges, &sizeChanges, &rdramChanges, &latestAddress);
+                logEvent("depth-rebuild-probe",
+                    "total=%llu causes=(width=%llu size=%llu rdram=%llu) latest=0x%08X",
+                    static_cast<unsigned long long>(rebuilds),
+                    static_cast<unsigned long long>(widthChanges),
+                    static_cast<unsigned long long>(sizeChanges),
+                    static_cast<unsigned long long>(rdramChanges), latestAddress);
+            }
         }
         const bool rendererHadStarted = displayLists != 0 || screenUpdates != 0;
         const bool rendererAdvanced = displayLists != previousDisplayLists ||
@@ -398,6 +695,7 @@ void queueSamples(int16_t *samples, size_t sampleCount) {
 
     const uint64_t readFrame = audioReadFrame.load(std::memory_order_acquire);
     uint64_t writeFrame = audioWriteFrame.load(std::memory_order_relaxed);
+    const bool probeEnabled = audioProbeEnabled.load(std::memory_order_relaxed);
     const uint64_t queuedFrames = std::min(writeFrame - std::min(writeFrame, readFrame), kAudioRingFrames);
     const uint64_t availableFrames = kAudioRingFrames - queuedFrames;
     if (incomingFrames > availableFrames) {
@@ -410,8 +708,14 @@ void queueSamples(int16_t *samples, size_t sampleCount) {
         const uint64_t destination = ((writeFrame + frame) % kAudioRingFrames) * 2;
         // Match GoldenEye64Recomp's reference host: N64ModernRuntime's RDRAM
         // address XOR leaves each interleaved stereo pair in reversed order.
-        audioRing[destination] = samples[frame * 2 + 1];
-        audioRing[destination + 1] = samples[frame * 2];
+        if (probeEnabled) {
+            const int16_t probeSample = audioProbeSample(writeFrame + frame);
+            audioRing[destination] = probeSample;
+            audioRing[destination + 1] = static_cast<int16_t>(-probeSample);
+        } else {
+            audioRing[destination] = samples[frame * 2 + 1];
+            audioRing[destination + 1] = samples[frame * 2];
+        }
     }
     audioWriteFrame.store(writeFrame + incomingFrames, std::memory_order_release);
 }
@@ -428,7 +732,15 @@ size_t getFramesRemaining() {
     return queued > kAudioPrebufferFrames ? queued - kAudioPrebufferFrames : 0;
 }
 void setFrequency(uint32_t frequency) {
+    audioRequestedFrequency.store(frequency, std::memory_order_relaxed);
     logEvent("audio", "game requested %u Hz output", frequency);
+    const uint32_t source = audioHostSourceFrequency.load(std::memory_order_relaxed);
+    if (source != 0) {
+        logEvent("audio-rates", "requested=%u source=%u session=%u mixer=%u",
+            frequency, source,
+            audioHostSessionFrequency.load(std::memory_order_relaxed),
+            audioHostMixerFrequency.load(std::memory_order_relaxed));
+    }
 }
 void pollInput() {
     if (!inputPollReported.exchange(true)) {
@@ -490,6 +802,12 @@ void runRuntime(ultramodern::renderer::WindowHandle window, std::filesystem::pat
     try {
         configureDiagnostics(configPath);
         logEvent("runtime", "worker started");
+        if (fireRateProbeEnabled.load(std::memory_order_acquire)) {
+            logEvent("fire-rate-probe",
+                "enabled; observation only, %u-tick windows, maximum %u player and guard runs",
+                kFireRateWindowTicks,
+                kFireRateProbeRunLimit);
+        }
         std::filesystem::create_directories(configPath);
         recomp::register_config_path(std::move(configPath));
         configurePrototypeGraphics();
@@ -621,6 +939,12 @@ extern "C" void goldenpad_recomp_set_controller_state(int32_t controllerNum, uin
     const size_t port = static_cast<size_t>(controllerNum);
     const uint32_t normalizedButtons = buttons & 0xFFFFu;
     const uint32_t previousButtons = controllerButtons[port].exchange(normalizedButtons, std::memory_order_relaxed);
+    if (sidestepProbeEnabled.load(std::memory_order_relaxed) &&
+        (normalizedButtons & 0x0003u) != 0 &&
+        (previousButtons & 0x0003u) == 0) {
+        logEvent("sidestep-probe", "controller=%d buttons=0x%04X stick=(%d,%d)",
+            controllerNum + 1, normalizedButtons, stickX, stickY);
+    }
     if (previousButtons != normalizedButtons) {
         const uint32_t transition = controllerButtonTransitions[port].fetch_add(1) + 1;
         if (transition <= 12 || transition % 120 == 0) {
@@ -628,8 +952,19 @@ extern "C" void goldenpad_recomp_set_controller_state(int32_t controllerNum, uin
                 controllerNum + 1, normalizedButtons, transition);
         }
     }
-    controllerStickX[port].store(std::clamp(stickX, -80, 80), std::memory_order_relaxed);
-    controllerStickY[port].store(std::clamp(stickY, -80, 80), std::memory_order_relaxed);
+    const int32_t normalizedStickX = std::clamp(stickX, -80, 80);
+    const int32_t normalizedStickY = std::clamp(stickY, -80, 80);
+    const int32_t previousStickX = controllerStickX[port].exchange(
+        normalizedStickX, std::memory_order_relaxed);
+    const int32_t previousStickY = controllerStickY[port].exchange(
+        normalizedStickY, std::memory_order_relaxed);
+    const bool stickWasActive = std::abs(previousStickX) > 8 || std::abs(previousStickY) > 8;
+    const bool stickIsActive = std::abs(normalizedStickX) > 8 || std::abs(normalizedStickY) > 8;
+    if (stickWasActive != stickIsActive) {
+        logEvent("input", "controller %d left stick %s at (%d,%d)",
+            controllerNum + 1, stickIsActive ? "active" : "neutral",
+            normalizedStickX, normalizedStickY);
+    }
 }
 
 extern "C" void goldenpad_recomp_set_right_analog(int32_t controllerNum, int32_t lookX, int32_t lookY) {
@@ -665,6 +1000,159 @@ extern "C" void goldenpad_recomp_set_controller_connected(int32_t connected) {
         logEvent("input", "external controller %s; touch overlay %s",
             next ? "connected" : "disconnected",
             next && !twoPlayerTestMode.load(std::memory_order_relaxed) ? "hidden" : "visible");
+    }
+}
+
+extern "C" void goldenpad_recomp_set_touch_input_port(int32_t port) {
+    const int32_t normalizedPort = port >= 0 && port < static_cast<int32_t>(kControllerPorts)
+        ? port : -1;
+    const int32_t previousPort = touchInputPort.exchange(
+        normalizedPort, std::memory_order_relaxed);
+    if (previousPort != normalizedPort) {
+        if (normalizedPort < 0) {
+            logEvent("input-ownership", "touch is neutral and owns no player port");
+        } else {
+            logEvent("input-ownership", "touch owns player %d", normalizedPort + 1);
+        }
+    }
+}
+
+extern "C" void goldenpad_recomp_set_fire_rate_probe_enabled(int32_t enabled) {
+    const bool next = enabled != 0;
+    fireRateProbeEnabled.store(next, std::memory_order_release);
+    if (next) {
+        fireRateProbeSimulationTicks.store(0, std::memory_order_relaxed);
+        fireRateProbeRawGuardSamples.store(0, std::memory_order_relaxed);
+        playerFireRateWindow = {};
+        guardFireRateWindow = {};
+    }
+}
+
+extern "C" void goldenpad_recomp_set_sidestep_probe_enabled(int32_t enabled) {
+    sidestepProbeEnabled.store(enabled != 0, std::memory_order_relaxed);
+}
+
+extern "C" void goldenpad_recomp_fire_rate_player_sample(
+    uint8_t *rdram, recomp_context *ctx) {
+    if (!fireRateProbeEnabled.load(std::memory_order_acquire)) {
+        return;
+    }
+    const int32_t player = _arg<0, int32_t>(rdram, ctx);
+    const int32_t weapon = _arg<1, int32_t>(rdram, ctx);
+    const int32_t ammo = _arg<2, int32_t>(rdram, ctx);
+    const int32_t counter = _arg<3, int32_t>(rdram, ctx);
+    if (player != 0) {
+        return;
+    }
+
+    const uint64_t simulationTick =
+        fireRateProbeSimulationTicks.fetch_add(1, std::memory_order_relaxed) + 1;
+    completeGuardFireRateWindow(simulationTick);
+
+    if (!isAutomaticPlayerWeapon(weapon)) {
+        playerFireRateWindow.active = false;
+        playerFireRateWindow.lastWeapon = weapon;
+        playerFireRateWindow.lastAmmo = ammo;
+        return;
+    }
+    const int32_t previousAmmo = playerFireRateWindow.lastAmmo;
+    const uint32_t shotEvents = playerFireRateWindow.lastWeapon == weapon &&
+        previousAmmo > ammo ? static_cast<uint32_t>(previousAmmo - ammo) : 0;
+    playerFireRateWindow.lastWeapon = weapon;
+    playerFireRateWindow.lastAmmo = ammo;
+    if (!playerFireRateWindow.active) {
+        if (shotEvents == 0 ||
+            playerFireRateWindow.runs >= kFireRateProbeRunLimit) {
+            return;
+        }
+        playerFireRateWindow.active = true;
+        playerFireRateWindow.ticks = 1;
+        playerFireRateWindow.player = player;
+        playerFireRateWindow.weapon = weapon;
+        playerFireRateWindow.startingAmmo = previousAmmo;
+        playerFireRateWindow.endingAmmo = ammo;
+        playerFireRateWindow.startingCounter = counter;
+        playerFireRateWindow.endingCounter = counter;
+        playerFireRateWindow.shotEvents = shotEvents;
+        logEvent("fire-rate-probe",
+            "player run=%u begin ticks=%u weapon=%d ammo=%d counter=%d",
+            playerFireRateWindow.runs + 1,
+            kFireRateWindowTicks,
+            weapon,
+            previousAmmo,
+            counter);
+        return;
+    }
+    if (playerFireRateWindow.weapon != weapon) {
+        playerFireRateWindow.active = false;
+        return;
+    }
+    playerFireRateWindow.shotEvents += shotEvents;
+    playerFireRateWindow.endingAmmo = ammo;
+    playerFireRateWindow.endingCounter = counter;
+    ++playerFireRateWindow.ticks;
+    if (playerFireRateWindow.ticks >= kFireRateWindowTicks) {
+        logEvent("fire-rate-probe",
+            "player run=%u complete ticks=%u weapon=%d events=%u ammo=%d->%d counter=%d->%d",
+            playerFireRateWindow.runs + 1,
+            playerFireRateWindow.ticks,
+            playerFireRateWindow.weapon,
+            playerFireRateWindow.shotEvents,
+            playerFireRateWindow.startingAmmo,
+            playerFireRateWindow.endingAmmo,
+            playerFireRateWindow.startingCounter,
+            playerFireRateWindow.endingCounter);
+        ++playerFireRateWindow.runs;
+        playerFireRateWindow.active = false;
+    }
+}
+
+extern "C" void goldenpad_recomp_fire_rate_guard_sample(
+    uint8_t *rdram, recomp_context *ctx) {
+    if (!fireRateProbeEnabled.load(std::memory_order_acquire)) {
+        return;
+    }
+    const int32_t item = _arg<0, int32_t>(rdram, ctx);
+    const uint8_t before = static_cast<uint8_t>(_arg<1, int32_t>(rdram, ctx));
+    const uint8_t after = static_cast<uint8_t>(_arg<2, int32_t>(rdram, ctx));
+    const uint32_t guardKey = _arg<3, uint32_t>(rdram, ctx);
+    const uint32_t rawSample =
+        fireRateProbeRawGuardSamples.fetch_add(1, std::memory_order_relaxed);
+    if (rawSample < 8) {
+        logEvent("fire-rate-probe",
+            "guard raw=%u item=%d counter=%u->%u key=0x%08X",
+            rawSample + 1,
+            item,
+            before,
+            after,
+            guardKey);
+    }
+    const bool committedGate = item == kKf7SovietItem &&
+        after == static_cast<uint8_t>(before + 1u) &&
+        after % kKf7SovietRawRate == 0;
+    if (!committedGate) {
+        return;
+    }
+
+    if (!guardFireRateWindow.active && guardFireRateWindow.runs < kFireRateProbeRunLimit) {
+        guardFireRateWindow.active = true;
+        guardFireRateWindow.guardKey = guardKey;
+        guardFireRateWindow.startingTick =
+            fireRateProbeSimulationTicks.load(std::memory_order_relaxed);
+        guardFireRateWindow.startingCounter = after;
+        guardFireRateWindow.endingCounter = after;
+        guardFireRateWindow.shotEvents = 1;
+        logEvent("fire-rate-probe",
+            "guard run=%u begin ticks=%u item=%d rawRate=%u counter=%u",
+            guardFireRateWindow.runs + 1,
+            kFireRateWindowTicks,
+            item,
+            kKf7SovietRawRate,
+            after);
+    } else if (guardFireRateWindow.active &&
+        guardFireRateWindow.guardKey == guardKey) {
+        ++guardFireRateWindow.shotEvents;
+        guardFireRateWindow.endingCounter = after;
     }
 }
 
@@ -713,6 +1201,7 @@ extern "C" void goldenpad_recomp_set_app_active(int32_t active) {
         }
         if (next) {
             markDiagnosticsSessionActive();
+            startLifecycleProgressWindow(2, "foreground-resume");
         }
         logEvent("lifecycle", "host became %s; RT64 presentation %s",
             next ? "active" : "inactive", next ? "resumed" : "suspended");
@@ -728,6 +1217,31 @@ extern "C" void goldenpad_recomp_set_app_active(int32_t active) {
 
 extern "C" void goldenpad_recomp_note_transient_inactive() {
     logEvent("lifecycle", "transient inactive state observed; RT64 presentation kept active");
+    if (appActive.load(std::memory_order_relaxed)) {
+        startLifecycleProgressWindow(1, "transient-inactive");
+    }
+}
+
+extern "C" void goldenpad_recomp_set_lifecycle_probe_enabled(int32_t enabled) {
+    lifecycleProbeEnabled.store(enabled != 0, std::memory_order_relaxed);
+}
+
+extern "C" void goldenpad_recomp_set_audio_probe_enabled(int32_t enabled) {
+    audioProbeEnabled.store(enabled != 0, std::memory_order_relaxed);
+}
+
+extern "C" void goldenpad_recomp_set_depth_rebuild_probe_enabled(int32_t enabled) {
+    depthRebuildProbeEnabled.store(enabled != 0, std::memory_order_relaxed);
+}
+
+extern "C" void goldenpad_recomp_note_audio_host_rates(
+    uint32_t source, uint32_t session, uint32_t mixer
+) {
+    audioHostSourceFrequency.store(source, std::memory_order_relaxed);
+    audioHostSessionFrequency.store(session, std::memory_order_relaxed);
+    audioHostMixerFrequency.store(mixer, std::memory_order_relaxed);
+    logEvent("audio-rates", "requested=%u source=%u session=%u mixer=%u",
+        audioRequestedFrequency.load(std::memory_order_relaxed), source, session, mixer);
 }
 
 extern "C" int32_t goldenpad_recomp_is_app_active() {
@@ -804,72 +1318,131 @@ extern "C" void goldenpad_recomp_request_return_to_title() {
     logEvent("navigation", "return to main menu requested");
 }
 
-namespace {
-uint32_t currentPlayerAddress(uint8_t *rdram) {
-    const uint32_t player = static_cast<uint32_t>(readGameWord(rdram, 0x80079EB0));
-    return player >= 0x80000000 && player <= 0x9FFFFFFF ? player : 0;
-}
+extern "C" int32_t goldenpad_recomp_gameplay_input_active() {
+    const auto reportMode = [](int32_t active) {
+        const int32_t previous = gameplayInputModeReported.exchange(
+            active, std::memory_order_relaxed);
+        if (previous != active) {
+            logEvent("input-mode", "mobile mapping uses %s semantics",
+                active != 0 ? "live-gameplay strafe" : "menu/watch stick");
+        }
+        return active;
+    };
 
-bool gameplayInputActive(uint8_t *rdram) {
+    uint8_t *rdram = activeRdram.load(std::memory_order_acquire);
     if (!runtimeStarted.load(std::memory_order_relaxed) || rdram == nullptr) {
-        return false;
+        return reportMode(0);
     }
 
     constexpr int32_t kTitleStage = 90;
-    if (readGameWord(rdram, 0x80023FA8) == kTitleStage) {
-        return false;
+    const int32_t stage = readGameWord(rdram, 0x80023FA8);
+    if (stage == kTitleStage) {
+        return reportMode(0);
     }
 
-    const uint32_t playerAddress = currentPlayerAddress(rdram);
-    if (playerAddress == 0) {
-        return false;
+    const uint32_t playerAddress = static_cast<uint32_t>(
+        readGameWord(rdram, 0x80079EB0));
+    if (playerAddress < 0x80000000 || playerAddress > 0x9FFFFFFF) {
+        return reportMode(0);
     }
 
+    // These are GoldenEye's own watch-state fields. Switch away from gameplay
+    // semantics as soon as a watch transition begins; waiting for
+    // outside_watch_menu to clear allowed the first watch-navigation sample to
+    // leak through as a strafe during the opening animation.
     const int32_t watchAnimationState = readGameWord(rdram, playerAddress + 0x1C8);
     const int32_t outsideWatchMenu = readGameWord(rdram, playerAddress + 0x1CC);
     const int32_t openCloseSoloWatchMenu = readGameWord(rdram, playerAddress + 0x1D0);
-    const int32_t controlsLocked = readGameWord(rdram, 0x80048170);
-    const int32_t multiplayerMenuOpen = readGameWord(rdram, playerAddress + 0x29C4);
-    return watchAnimationState == 0 && outsideWatchMenu != 0 && openCloseSoloWatchMenu == 0 &&
-        controlsLocked == 0 && multiplayerMenuOpen == 0;
+    return reportMode(
+        watchAnimationState == 0 &&
+        outsideWatchMenu != 0 &&
+        openCloseSoloWatchMenu == 0 ? 1 : 0);
 }
-} // namespace
 
-extern "C" int32_t goldenpad_recomp_gameplay_input_active() {
-    const bool active = gameplayInputActive(activeRdram.load(std::memory_order_acquire));
-    if (!active) {
-        for (size_t port = 0; port < kControllerPorts; port++) {
-            queuedTouchLookX[port].store(0, std::memory_order_relaxed);
-            queuedTouchLookY[port].store(0, std::memory_order_relaxed);
-            queuedMouseLookX[port].store(0, std::memory_order_relaxed);
-            queuedMouseLookY[port].store(0, std::memory_order_relaxed);
-            crouchToggleRequested[port].store(false, std::memory_order_relaxed);
-            inventorySlotRequested[port].store(-1, std::memory_order_relaxed);
-            reloadRequested[port].store(false, std::memory_order_relaxed);
+extern "C" void goldenpad_recomp_get_input_context(
+    int32_t controllerNum,
+    int32_t *gameplayActiveOut,
+    int32_t *controlStyleOut,
+    int32_t *aimingOut,
+    int32_t *tankStateOut,
+    int32_t *nativeLookUprightOut
+) {
+    int32_t gameplayActive = 0;
+    int32_t controlStyle = -1;
+    int32_t aiming = 0;
+    int32_t tankState = -1;
+    int32_t nativeLookUpright = 0;
+
+    uint8_t *rdram = activeRdram.load(std::memory_order_acquire);
+    if (runtimeStarted.load(std::memory_order_relaxed) && rdram != nullptr &&
+        controllerNum >= 0 && controllerNum < static_cast<int32_t>(kControllerPorts)) {
+        constexpr uint32_t kTitleStage = 90;
+        constexpr uint32_t kStageAddress = 0x80023FA8;
+        constexpr uint32_t kPlayerPointersAddress = 0x80079CE0;
+        constexpr uint32_t kInsightAimModeOffset = 0x124;
+        constexpr uint32_t kWatchAnimationStateOffset = 0x1C8;
+        constexpr uint32_t kOutsideWatchMenuOffset = 0x1CC;
+        constexpr uint32_t kOpenCloseSoloWatchMenuOffset = 0x1D0;
+        constexpr uint32_t kControlStyleOffset = 0x2A58;
+        constexpr uint32_t kPlayerIsInTankAddress = 0x80036248;
+        constexpr uint32_t kPlayerTankPropAddress = 0x80036250;
+        constexpr uint32_t kEnterTankStateAddress = 0x800797B8;
+        // game_options_entries[PLAYER_OPTION_LOOK].current_value:
+        // 0 is Reverse and 1 is Upright in GoldenEye's own menu.
+        constexpr uint32_t kNativeLookOptionAddress = 0x80040884;
+
+        const uint32_t playerAddress = static_cast<uint32_t>(readGameWord(
+            rdram, kPlayerPointersAddress + static_cast<uint32_t>(controllerNum) * 4));
+        if (readGameWord(rdram, kStageAddress) != static_cast<int32_t>(kTitleStage) &&
+            playerAddress >= 0x80000000 && playerAddress <= 0x9FFFFFFF) {
+            const int32_t style = readGameWord(rdram, playerAddress + kControlStyleOffset);
+            controlStyle = style >= 0 && style <= 3 ? style : -1;
+            aiming = readGameWord(rdram, playerAddress + kInsightAimModeOffset) != 0 ? 1 : 0;
+            nativeLookUpright = readGameWord(rdram, kNativeLookOptionAddress) == 1 ? 1 : 0;
+            gameplayActive =
+                readGameWord(rdram, playerAddress + kWatchAnimationStateOffset) == 0 &&
+                readGameWord(rdram, playerAddress + kOutsideWatchMenuOffset) != 0 &&
+                readGameWord(rdram, playerAddress + kOpenCloseSoloWatchMenuOffset) == 0 ? 1 : 0;
+
+            // GoldenEye exposes one mission tank through global state. It exists
+            // only in the single-player Runway and Streets setups, so associate
+            // it with Player 1 and require both the flag and live prop pointer.
+            if (controllerNum == 0 && readGameWord(rdram, kPlayerIsInTankAddress) == 1) {
+                const uint32_t tankProp = static_cast<uint32_t>(
+                    readGameWord(rdram, kPlayerTankPropAddress));
+                if (tankProp >= 0x80000000 && tankProp <= 0x9FFFFFFF) {
+                    const int32_t candidateState = readGameWord(rdram, kEnterTankStateAddress);
+                    tankState = candidateState >= 0 && candidateState <= 2
+                        ? candidateState : 0;
+                }
+            }
         }
     }
-    return active ? 1 : 0;
-}
 
-extern "C" int32_t goldenpad_recomp_current_control_style() {
-    uint8_t *rdram = activeRdram.load(std::memory_order_acquire);
-    if (!runtimeStarted.load(std::memory_order_relaxed) || rdram == nullptr) {
-        return -1;
-    }
-    const uint32_t playerAddress = currentPlayerAddress(rdram);
-    if (playerAddress == 0) {
-        return -1;
-    }
-    const int32_t style = readGameWord(rdram, playerAddress + 0x2A58);
-    return style >= 0 && style <= 7 ? style : -1;
-}
+    if (gameplayActiveOut != nullptr) { *gameplayActiveOut = gameplayActive; }
+    if (controlStyleOut != nullptr) { *controlStyleOut = controlStyle; }
+    if (aimingOut != nullptr) { *aimingOut = aiming; }
+    if (tankStateOut != nullptr) { *tankStateOut = tankState; }
+    if (nativeLookUprightOut != nullptr) { *nativeLookUprightOut = nativeLookUpright; }
 
-extern "C" int32_t goldenpad_recomp_desktop_gameplay_active() {
-#if defined(GOLDENPAD_RECOMP_MAC)
-    return goldenpad_recomp_gameplay_input_active();
-#else
-    return 1;
-#endif
+    if (controllerNum >= 0 && controllerNum < static_cast<int32_t>(kControllerPorts)) {
+        static std::array<std::atomic<uint32_t>, kControllerPorts> reported{};
+        const uint32_t encoded = 0x80000000u |
+            (static_cast<uint32_t>(gameplayActive) << 12) |
+            (static_cast<uint32_t>(controlStyle + 1) << 8) |
+            (static_cast<uint32_t>(aiming) << 4) |
+            (static_cast<uint32_t>(nativeLookUpright) << 3) |
+            static_cast<uint32_t>(tankState + 1);
+        const uint32_t previous = reported[static_cast<size_t>(controllerNum)].exchange(
+            encoded, std::memory_order_relaxed);
+        if (previous != encoded) {
+            const char *tankLabel = tankState < 0 ? "outside" :
+                tankState == 0 ? "entering" : tankState == 1 ? "starting" : "running";
+            logEvent("input-context", "player=%d gameplay=%d style=%d aim=%d look=%s tank=%s",
+                controllerNum + 1, gameplayActive, controlStyle, aiming,
+                nativeLookUpright != 0 ? "upright" : "reverse", tankLabel);
+        }
+    }
 }
 
 extern "C" void recomp_get_camera_inputs(uint8_t *rdram, recomp_context *ctx) {
@@ -882,42 +1455,42 @@ extern "C" void recomp_get_camera_inputs(uint8_t *rdram, recomp_context *ctx) {
         return;
     }
     const size_t port = static_cast<size_t>(controllerNum);
-    const bool aiming = (controllerButtons[port].load(std::memory_order_relaxed) & 0x0010u) != 0;
-    // Port the working MGB64 controller rate exactly while leaving the tuned
-    // relative-touch path unchanged. MGB64 resolves to 1.2 degrees/frame at
-    // full hip-fire deflection and about 0.133 degrees/frame while aiming;
-    // the recomp gameplay patch applies 3 and 1 degrees respectively.
-    const float controllerScale = aiming ? (0.13333334f / 1.0f) : (1.2f / 3.0f);
+    int32_t aimingValue = 0;
+    goldenpad_recomp_get_input_context(
+        controllerNum, nullptr, nullptr, &aimingValue, nullptr, nullptr);
+    const bool aiming = aimingValue != 0;
+    // Physical testing accepted the MGB64-derived 1.56 degree baseline, then
+    // requested one final 20 percent increase. Raise only absolute controller
+    // look while preserving relative touch, mouse input, the 0.15 dead zone,
+    // and the existing response curve.
+    constexpr float kControllerHipDegreesPerFrame = 1.872f;
+    // Modern right-stick Aim must retain the accepted normal-look response.
+    // The game patch multiplies Aim samples by 1 and hip samples by 3, so the
+    // bridge compensates for that implementation detail while producing the
+    // same final 1.872 degrees per frame in both states.
+    constexpr float kControllerAimDegreesPerFrame = kControllerHipDegreesPerFrame;
+    const float controllerScale = aiming
+        ? (kControllerAimDegreesPerFrame / 1.0f)
+        : (kControllerHipDegreesPerFrame / 3.0f);
     float x = static_cast<float>(controllerLookX[port].load(std::memory_order_relaxed)) /
             32'767.0f * controllerScale +
         static_cast<float>(queuedTouchLookX[port].exchange(0, std::memory_order_acq_rel)) / 32'767.0f;
     float y = static_cast<float>(controllerLookY[port].load(std::memory_order_relaxed)) /
             32'767.0f * controllerScale +
         static_cast<float>(queuedTouchLookY[port].exchange(0, std::memory_order_acq_rel)) / 32'767.0f;
-    x = std::clamp(x, -1.0f, 1.0f);
-    y = std::clamp(y, -1.0f, 1.0f);
-#if defined(GOLDENPAD_RECOMP_MAC)
-    // Mouse movement is relative, so preserve every queued unit instead of
-    // collapsing fast sweeps to the same normalized maximum. Compensate for
-    // the game patch's 3 degrees hip-fire / 1 degree aimed multiplier so the
-    // selected mouse sensitivity stays consistent while aiming.
+    // Desktop mouse deltas are relative rather than bounded stick positions.
+    // Preserve every queued unit and compensate for the patch's lower Aim
+    // multiplier so the configured mouse sensitivity remains consistent.
     const float mouseAimCompensation = aiming ? 3.0f : 1.0f;
     x += static_cast<float>(queuedMouseLookX[port].exchange(0, std::memory_order_acq_rel)) /
         32'767.0f * mouseAimCompensation;
     y += static_cast<float>(queuedMouseLookY[port].exchange(0, std::memory_order_acq_rel)) /
         32'767.0f * mouseAimCompensation;
-#endif
-    // GoldenEye's sight-aim camera applies the opposite vertical convention
-    // from normal free look. Normalize that by default, while retaining an
-    // explicit setting for players who prefer inverted aiming.
-#if defined(GOLDENPAD_RECOMP_MAC)
-    // On Mac the native setting follows its label: normal vertical aim is the
-    // default, and enabling "Invert vertical aim" performs the inversion.
+    x = std::clamp(x, -1.0f, 1.0f);
+    y = std::clamp(y, -1.0f, 1.0f);
+    // Relative touch and mouse look use the same host setting on every target.
+    // External gamepads use GoldenEye's native manual-sight path while aiming.
     if (aiming && invertAimY.load(std::memory_order_relaxed)) {
-#else
-    // Preserve the already tuned iPhone/iPad behavior.
-    if (aiming && !invertAimY.load(std::memory_order_relaxed)) {
-#endif
         y = -y;
     }
     *xOut = x;
@@ -969,12 +1542,14 @@ extern "C" uint32_t goldenpad_recomp_audio_render(float *left, float *right, uin
     }
     const uint64_t readFrame = audioReadFrame.load(std::memory_order_relaxed);
     const uint64_t writeFrame = audioWriteFrame.load(std::memory_order_acquire);
+    const bool probeEnabled = audioProbeEnabled.load(std::memory_order_relaxed);
     const uint64_t queued = std::min(
         writeFrame - std::min(writeFrame, readFrame), kAudioRingFrames);
     if (!audioPlaybackPrimed) {
         if (queued < kAudioPrebufferFrames) {
             std::fill(left, left + frames, 0.0f);
             std::fill(right, right + frames, 0.0f);
+            observeAudioProbeOutput(left, right, frames);
             return 0;
         }
         audioPlaybackPrimed = true;
@@ -998,6 +1573,7 @@ extern "C" uint32_t goldenpad_recomp_audio_render(float *left, float *right, uin
         audioLastLeft = 0.0f;
         audioLastRight = 0.0f;
         audioPlaybackPrimed = false;
+        observeAudioProbeOutput(left, right, frames);
         return 0;
     }
 
@@ -1015,13 +1591,35 @@ extern "C" uint32_t goldenpad_recomp_audio_render(float *left, float *right, uin
         right[frame] = static_cast<float>(audioRing[source + 1]) / 32768.0f * gain;
         nonzero += audioRing[source] != 0;
         nonzero += audioRing[source + 1] != 0;
+        if (probeEnabled) {
+            const int16_t expected = audioProbeSample(readFrame + frame);
+            if (audioRing[source] != expected ||
+                audioRing[source + 1] != static_cast<int16_t>(-expected)) {
+                audioProbeSequenceErrors.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
     }
     audioLastLeft = left[produced - 1];
     audioLastRight = right[produced - 1];
     audioReadFrame.store(readFrame + produced, std::memory_order_release);
     audioRenderedFrames.fetch_add(produced, std::memory_order_relaxed);
     audioNonzeroSamples.fetch_add(nonzero, std::memory_order_relaxed);
+    observeAudioProbeOutput(left, right, produced);
     return produced;
+}
+
+extern "C" void goldenpad_recomp_audio_probe_stats(
+    uint64_t *observedFrames, uint64_t *largeJumps, uint64_t *sequenceErrors
+) {
+    if (observedFrames != nullptr) {
+        *observedFrames = audioProbeObservedFrames.load(std::memory_order_relaxed);
+    }
+    if (largeJumps != nullptr) {
+        *largeJumps = audioProbeLargeJumps.load(std::memory_order_relaxed);
+    }
+    if (sequenceErrors != nullptr) {
+        *sequenceErrors = audioProbeSequenceErrors.load(std::memory_order_relaxed);
+    }
 }
 
 extern "C" void goldenpad_recomp_audio_stats(

--- a/Support/RecompPrototype/recomp_rt64_surface_stub.cpp
+++ b/Support/RecompPrototype/recomp_rt64_surface_stub.cpp
@@ -19,6 +19,22 @@ extern "C" void goldenpad_recomp_set_right_analog(int32_t, int32_t, int32_t) {}
 extern "C" void goldenpad_recomp_set_controller_connected(int32_t) {}
 extern "C" void goldenpad_recomp_set_two_player_test_mode(int32_t) {}
 extern "C" void goldenpad_recomp_set_four_player_test_mode(int32_t) {}
+extern "C" void goldenpad_recomp_set_fire_rate_probe_enabled(int32_t) {}
+extern "C" void goldenpad_recomp_set_sidestep_probe_enabled(int32_t) {}
+extern "C" void goldenpad_recomp_set_lifecycle_probe_enabled(int32_t) {}
+extern "C" void goldenpad_recomp_set_audio_probe_enabled(int32_t) {}
+extern "C" void goldenpad_recomp_set_depth_rebuild_probe_enabled(int32_t) {}
+extern "C" void goldenpad_recomp_note_audio_host_rates(uint32_t, uint32_t, uint32_t) {}
+extern "C" int32_t goldenpad_recomp_gameplay_input_active() { return 0; }
+extern "C" void goldenpad_recomp_get_input_context(
+    int32_t, int32_t *gameplay, int32_t *style, int32_t *aiming,
+    int32_t *tankState, int32_t *nativeLookUpright) {
+    if (gameplay != nullptr) { *gameplay = 0; }
+    if (style != nullptr) { *style = -1; }
+    if (aiming != nullptr) { *aiming = 0; }
+    if (tankState != nullptr) { *tankState = -1; }
+    if (nativeLookUpright != nullptr) { *nativeLookUpright = 0; }
+}
 extern "C" void goldenpad_recomp_set_app_active(int32_t) {}
 extern "C" void goldenpad_recomp_note_transient_inactive() {}
 extern "C" void goldenpad_recomp_queue_touch_look(int32_t, int32_t, int32_t) {}
@@ -30,9 +46,6 @@ extern "C" void goldenpad_recomp_set_invert_aim_y(int32_t) {}
 extern "C" void goldenpad_recomp_set_unlock_all_missions(int32_t) {}
 extern "C" void goldenpad_recomp_request_return_to_title() {}
 extern "C" int32_t goldenpad_recomp_previous_session_ended_unexpectedly() { return 0; }
-extern "C" int32_t goldenpad_recomp_gameplay_input_active() { return 0; }
-extern "C" int32_t goldenpad_recomp_current_control_style() { return -1; }
-extern "C" int32_t goldenpad_recomp_desktop_gameplay_active() { return 0; }
 
 extern "C" uint32_t goldenpad_recomp_audio_render(
     float *left, float *right, uint32_t frames) {

--- a/Tests/RecompControlMappingTests.swift
+++ b/Tests/RecompControlMappingTests.swift
@@ -1,0 +1,197 @@
+import simd
+
+private struct MappingTestFailure: Error, CustomStringConvertible {
+    let description: String
+}
+
+private func expect<T: Equatable>(_ actual: T, _ expected: T, _ description: String) throws {
+    guard actual == expected else {
+        throw MappingTestFailure(
+            description: "\(description): expected \(expected), got \(actual)"
+        )
+    }
+}
+
+private func context(
+    gameplay: Bool = true,
+    style: Int32,
+    aiming: Bool = false,
+    tankState: Int32 = -1,
+    nativeLookUpright: Bool = false
+) -> RecompRuntimeInputContext {
+    RecompRuntimeInputContext(
+        gameplayActive: gameplay,
+        runtimeStyle: style,
+        aiming: aiming,
+        tankState: tankState,
+        nativeLookUpright: nativeLookUpright
+    )
+}
+
+private func verifyStyle(
+    _ style: Int32,
+    fire: UInt16,
+    aim: UInt16,
+    weapon: UInt16,
+    digitalMovement: Bool
+) throws {
+    let mapping = RecompControlMapping(runtimeStyle: style)
+    try expect(mapping.fireButton, fire, "style \(style) fire")
+    try expect(mapping.aimButton, aim, "style \(style) aim")
+    try expect(mapping.weaponButton, weapon, "style \(style) weapon")
+    try expect(mapping.usesDigitalMovement, digitalMovement, "style \(style) movement family")
+    try expect(
+        mapping.gameplayButtons(
+            fire: true, aim: true, action: true, weapon: true, start: true),
+        fire | aim | weapon | RecompN64Button.b | RecompN64Button.start,
+        "style \(style) semantic chord"
+    )
+}
+
+@main
+private struct RecompControlMappingTests {
+    static func main() throws {
+        try verifyStyle(
+            0, fire: RecompN64Button.z, aim: RecompN64Button.r,
+            weapon: RecompN64Button.a, digitalMovement: false)
+        try verifyStyle(
+            1, fire: RecompN64Button.z, aim: RecompN64Button.r,
+            weapon: RecompN64Button.a, digitalMovement: true)
+        try verifyStyle(
+            2, fire: RecompN64Button.a, aim: RecompN64Button.z,
+            weapon: RecompN64Button.r, digitalMovement: false)
+        try verifyStyle(
+            3, fire: RecompN64Button.a, aim: RecompN64Button.z,
+            weapon: RecompN64Button.r, digitalMovement: true)
+
+        let movement = SIMD2<Float>(0.75, 0.80)
+        let honey = RecompControlMapping(runtimeStyle: 0)
+        let solitaire = RecompControlMapping(runtimeStyle: 1)
+
+        try expect(
+            honey.movement(buttons: 0, stick: movement, modern: true, context: context(style: 0)),
+            RecompMovementMapping(
+                buttons: RecompN64Button.cRight,
+                stick: SIMD2<Float>(0, 0.80)),
+            "1.1 on foot uses analog Y and C-left/right sidestep"
+        )
+        try expect(
+            solitaire.movement(buttons: 0, stick: movement, modern: true, context: context(style: 1)),
+            RecompMovementMapping(
+                buttons: RecompN64Button.cUp | RecompN64Button.cRight,
+                stick: .zero),
+            "1.2 on foot uses four C-button movement directions"
+        )
+        try expect(
+            honey.movement(
+                buttons: 0, stick: movement, modern: true,
+                context: context(style: 0, tankState: 2)),
+            RecompMovementMapping(buttons: 0, stick: movement),
+            "1.1 running tank uses analog Y drive and analog X hull steering"
+        )
+        try expect(
+            solitaire.movement(
+                buttons: 0, stick: movement, modern: true,
+                context: context(style: 1, tankState: 2)),
+            RecompMovementMapping(
+                buttons: RecompN64Button.cUp | RecompN64Button.cRight,
+                stick: .zero),
+            "1.2 running tank uses four C-button drive directions"
+        )
+
+        for style: Int32 in 0...3 {
+            let mapping = RecompControlMapping(runtimeStyle: style)
+            try expect(
+                mapping.movement(
+                    buttons: RecompN64Button.dpadUp,
+                    stick: movement,
+                    modern: true,
+                    context: context(style: style, aiming: true, tankState: 2)),
+                RecompMovementMapping(buttons: RecompN64Button.dpadUp, stick: .zero),
+                "style \(style) aim suppresses synthesized movement"
+            )
+            for transitionState: Int32 in 0...1 {
+                try expect(
+                    mapping.movement(
+                        buttons: 0,
+                        stick: movement,
+                        modern: true,
+                        context: context(style: style, tankState: transitionState)),
+                    RecompMovementMapping(buttons: 0, stick: .zero),
+                    "style \(style) tank transition \(transitionState) stays neutral"
+                )
+            }
+        }
+
+        let rightUp = SIMD2<Float>(0.75, 0.80)
+        try expect(
+            honey.manualAimStick(
+                stick: rightUp,
+                invertVertical: false,
+                context: context(style: 0, aiming: true, nativeLookUpright: false)),
+            SIMD2<Float>(0.75, -0.80),
+            "Reverse native option is compensated for non-inverted manual aim"
+        )
+        try expect(
+            honey.manualAimStick(
+                stick: rightUp,
+                invertVertical: false,
+                context: context(style: 0, aiming: true, nativeLookUpright: true)),
+            rightUp,
+            "Upright native option preserves non-inverted manual aim"
+        )
+        try expect(
+            honey.manualAimStick(
+                stick: rightUp,
+                invertVertical: true,
+                context: context(style: 0, aiming: true, nativeLookUpright: false)),
+            rightUp,
+            "GoldenPad inversion reverses the compensated manual-aim axis"
+        )
+        try expect(
+            honey.manualAimStick(
+                stick: rightUp,
+                invertVertical: false,
+                context: context(style: 0, aiming: false)),
+            nil,
+            "normal gameplay keeps right stick on the camera path"
+        )
+        try expect(
+            honey.manualAimStick(
+                stick: rightUp,
+                invertVertical: false,
+                context: context(style: 0, aiming: true, tankState: 2)),
+            nil,
+            "mounted Aim keeps right stick on the tank turret path"
+        )
+
+        try expect(
+            honey.movement(
+                buttons: RecompN64Button.a,
+                stick: movement,
+                modern: false,
+                context: context(style: 0, tankState: 2)),
+            RecompMovementMapping(buttons: RecompN64Button.a, stick: movement),
+            "classic C-button mode bypasses modern translation"
+        )
+        try expect(
+            honey.movement(
+                buttons: RecompN64Button.b,
+                stick: movement,
+                modern: true,
+                context: context(gameplay: false, style: 0)),
+            RecompMovementMapping(buttons: RecompN64Button.b, stick: movement),
+            "menu mode bypasses gameplay movement translation"
+        )
+
+        var latch = RecompMenuStickLatch()
+        try expect(latch.buttons(for: SIMD2<Float>(0, 1)), RecompN64Button.dpadUp, "menu first edge")
+        try expect(latch.buttons(for: SIMD2<Float>(0, 1)), RecompN64Button.dpadUp, "menu edge spans two host publications")
+        try expect(latch.buttons(for: SIMD2<Float>(0, 1)), 0, "held menu stick does not create a second edge")
+        try expect(latch.buttons(for: SIMD2<Float>(0, 0.3)), 0, "partial release does not rearm")
+        try expect(latch.buttons(for: .zero), 0, "neutral rearms without input")
+        try expect(latch.buttons(for: SIMD2<Float>(-1, 0)), RecompN64Button.dpadLeft, "menu second edge")
+
+        print("PASS: shared GoldenEye 1.1-1.4 input and tank matrix")
+    }
+}

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -27,7 +27,7 @@ package with:
 ```sh
 ./scripts/package-recomp-prototype-ipa.sh
 ./scripts/verify-recomp-prototype-ipa.sh \
-  dist/GoldenPad-0.1.0-preview.3-unsigned.ipa
+  dist/GoldenPad-0.1.0-preview.4-unsigned.ipa
 ```
 
 The packager copies the signed app into a temporary staging directory, removes
@@ -42,17 +42,20 @@ validation stay inside the app container. An in-place update reuses an existing
 valid `GoldenEye_TLBFREE.z64`. No retail input, save, generated source, signing
 identity, or provisioning profile is placed in the IPA.
 
-The audited Preview 3 IPA SHA-256 is
-`ef2ab9575d5a9df5d7d8d4138caa789625be3407ebc796a4d9339ea1fe6ba777`.
-Its exact final signed rebuild was installed in place on iPad with byte-identical
-ROM, save, and preference readbacks before publication approval.
+The audited Preview 4 IPA SHA-256 is
+`ff163b0af6b54596590da8e39cbaff0b388b69f1607ca34f62ce61e7fe144130`.
+The physically accepted test baseline is frozen separately. The final public
+build adds the user's requested 20 percent controller-look increase and has
+complete build, matrix, and package evidence, but not a second physical pass.
 
 ## Native Apple-Silicon Mac alpha
 
 The Mac app is a separate native arm64 artifact, not a Catalyst build and not
 part of the mobile `.ipa`. It is an Alpha below the accepted iPhone/iPad
 single-player quality bar. Preview 3's exact mouse/keyboard control build has
-hands-on acceptance. The thin far-right blue edge, older-OS coverage, and
+hands-on acceptance. Preview 4 compiles and package-audits the shared control
+repair, while issue #17 reporter gameplay verification remains open. The thin
+far-right blue edge, older-OS coverage, and
 sustained-performance depth remain open; keep renderer work independent from
 the accepted input contract.
 
@@ -83,8 +86,8 @@ signature, and runs the Mac artifact audit. No ROM, save, generated source or
 Apple signing identity is included.
 
 The audited Alpha archive is
-`dist/GoldenPad-0.1.0-preview.3-macos-arm64-alpha.zip` at SHA-256
-`819bc8eabc1fc84d2a37c1847f68c8832c023f0b0643851ca3f6251244fc32ba`.
+`dist/GoldenPad-0.1.0-preview.4-macos-arm64-alpha.zip` at SHA-256
+`63bec02ad6e323a213f9cb9d15f763a58d6eb7bd4a1a40af6341a4fb8fb333ba`.
 It is native arm64, ad-hoc signed and not notarized.
 
 The complete AOT build must have the maintained GoldenEye iOS context patch

--- a/docs/PREVIEW_4_INPUT_FIX.md
+++ b/docs/PREVIEW_4_INPUT_FIX.md
@@ -1,0 +1,395 @@
+# Preview 4 shared input repair
+
+Status: **iPadOS menu, on-foot controls, and Runway 1.1 tank path physically
+accepted; Preview 4 published; reporter Mac verification pending**
+
+Issue: [#17](https://github.com/chrissotraidis/goldenpad/issues/17)
+
+This document is the source-of-truth contract, validation checklist, and
+rollback record for the Preview 4 tank/control-style repair. A successful build
+or package is not gameplay acceptance. The accepted iPad matrix and the
+remaining reporter boundary are recorded below.
+
+## Rejected physical candidate (2026-08-23)
+
+The first `GoldenPad P4 Test` build is not a Preview 4 release candidate. Its
+static mapping and generated-patch checks passed, but physical iPad testing
+found that the checks did not cover the live mobile input path or mounted
+camera invariants:
+
+- controller right-stick look was approximately 30 percent too slow;
+- holding Aim allowed synthesized C-left/C-right input to trigger GoldenEye's
+  native lean, which appeared as unwanted lateral movement;
+- in 1.1 Honey, left-stick Y drove the tank but left-stick X turned the turret
+  instead of the hull;
+- both left-stick X and right-stick X could therefore turn the turret;
+- the hull could not be steered in the tested Honey configuration;
+- mounted vertical look escaped GoldenEye's native -20 degree lower limit and
+  reached -51.60 degrees, causing the tank model to fill most of the view;
+- the mobile host still emitted Honey Fire/Aim/Weapon buttons regardless of
+  the selected 1.3/1.4 control style; and
+- full analog watch navigation could cross the control-style selector once per
+  frame, making intermediate 1.2 and 1.3 selections difficult or impossible.
+
+The visible KF7 Soviet is not a defect. GoldenEye names that weapon `ITEM_AK47`
+internally, leaves the current ordinary weapon equipped when Bond enters, adds
+tank shells to the inventory, and permits switching between the KF7 and tank
+shells while mounted. Preview 4 must preserve that behavior.
+
+The superseding repair uses one shared semantic mapping for Mac, iPhone, and
+iPad. Platform hosts may gather different physical devices, but they may not
+interpret GoldenEye styles or runtime states differently.
+
+## Physically accepted iPadOS baseline (2026-08-23)
+
+Executable SHA-256
+`2b31f8868885712fbad34cef1aea20b1dee48f59fc9d930cbd3fa8b8e82b6b12`
+is the accepted controller/on-foot baseline. Physical iPadOS testing confirmed:
+
+- controller connection, left-stick menu navigation, and A-button progression;
+- mission startup, normal left-stick movement, and both-axis right-stick look;
+- holding left trigger keeps Bond stationary;
+- while on-foot Aim is held, the left stick moves GoldenEye's native
+  weapon/reticle with the expected polarity and damping;
+- the right stick is neutral during on-foot Aim; and
+- releasing Aim cleanly restores normal right-stick camera look.
+
+Do not regress or reinterpret those behaviors while closing the tank matrix.
+The exact signed ROM-free app, focused source inputs, generated patch halves,
+and acceptance manifest are frozen locally in the ignored directory
+`build-accepted-p4-on-foot-2b31f886/`. That snapshot is the immediate binary
+and source rollback control; it is not a public release artifact.
+
+The final Preview 4 publication applies one requested feel adjustment on top of
+this frozen baseline: absolute external-controller normal look and mounted
+turret response increase by 20 percent, from 1.56 to 1.872 degrees per frame.
+The radial dead zone, response curve, native on-foot manual Aim, left-stick
+movement, touch-relative look, mouse-relative look, menus, and tank mapping do
+not change.
+
+The same `2b31f886...` build subsequently passed the physical iPadOS Runway
+1.1 Honey tank path: native entry, drive, hull steering, turret control, weapon
+cycling, KF7 fire, Tank Shell fire, exit/re-entry, return to title, and a later
+Facility on-foot regression pass. The tester independently confirmed that
+retaining and cycling ordinary weapons while mounted matches original gameplay.
+This proves the shared runtime behavior on iPadOS; it does not substitute for
+the issue reporter's Mac keyboard/trackpad verification, so issue #17 remains
+open through the Preview 4 reporter test.
+
+### Controller-blocking candidate rejected (2026-08-23)
+
+Executable SHA-256
+`d6ecd358f1d07dc3fb2b779db0c8ceb6db4532cb380b76210a06aa66c3fc0814`
+is also rejected. Physical iPad testing found that an attached controller could
+not navigate the front end, so the tank matrix was unreachable. The failed-run
+log proved that the controller was connected and routed to Player 1 and that
+the bridge received repeated A-button `0x8000` transitions. This ruled out
+Bluetooth, ownership, and neutral-lock failure and isolated the regression to
+the new non-gameplay translation layer.
+
+The retry removes all new mobile menu translation. Before live gameplay, mobile
+now uses the exact accepted raw pass-through path for face buttons, D-pad, left
+analog stick, and right stick. Style, Aim, and tank translation begins only
+after the established gameplay predicate becomes true. The retry also logs
+bounded left-stick active/neutral transitions for discriminating evidence if
+the game still fails to consume valid host input.
+
+Physical testing accepted the retry's controller connection, left-stick menu
+navigation, A-button progression, mission startup, and normal analog-stick
+response. The same run isolated one remaining defect: holding left trigger
+entered Aim and correctly suppressed left-stick movement, but right-stick look
+became effectively unusable. The log proved that Aim state and near-full-scale
+right-stick samples both reached the runtime. The cause was the explicit
+controller rate split: 1.56 degrees/frame normally versus 0.173 degrees/frame
+while aiming.
+
+Executable SHA-256
+`0114fde73308ddfdb95d1bf8d9be939f6eed1502b86db83f0a30e9a76c13bf23`
+removed that rate split, but physical testing rejected it as the Aim repair.
+It kept driving the ordinary camera directly while Aim was held. That bypassed
+GoldenEye's manual-sight fields, inverted the expected vertical response, and
+fought the native sight damping/centering behavior.
+
+The superseding candidate restores the original semantic boundary. During
+on-foot Aim, the external left stick becomes GoldenEye's native manual-aim
+analog stick, character movement is disabled by the game's Aim state, and the
+right stick is neutral. GoldenEye therefore owns the weapon, reticle, damping,
+and return to center. The adapter reads the live Reverse/Upright option and
+compensates it so GoldenPad's default is non-inverted without changing the
+user's save. Normal right-stick camera look and mounted-tank turret look retain
+their accepted paths. Touch-relative and mouse-relative input remain separate
+input surfaces.
+
+Executable SHA-256
+`7e8a8cf7230d10b1cb5be0841c37d45ec438603db5f39c7d38e97a7f4c17ec43`
+proved the native weapon/reticle behavior in physical testing, including the
+correct polarity and damping, but is rejected because it assigned that behavior
+to the right stick. The installed successor changes only that physical source:
+on-foot Aim reads the left stick and explicitly neutralizes the right stick.
+
+## Scope
+
+The shipped GoldenEye source contains one player-enterable vehicle type: the
+tank. Exactly two mission setups contain it:
+
+- Runway (`UsetuprunZ.c`, `PROPDEF_TANK` index 119)
+- Streets (`UsetuppeteZ.c`, `PROPDEF_TANK` index 52)
+
+Other `Vehicle` and `Aircraft` props are driven by AI lists, scripted paths, or
+cutscenes. They do not use the player tank-entry or tank-control path and do not
+receive a host input override.
+
+Preview 4 supports GoldenEye's four original single-controller styles. The
+2.1-2.4 two-controller layouts remain outside the Mac single-player input
+contract and fall back to Honey semantics at the host boundary.
+
+## Authoritative mapping
+
+GoldenPad bindings are semantic. “Fire” must fire in every style even though
+the underlying N64 button changes.
+
+| Style | Tank drive and hull turn | Turret yaw | Fire | Aim | Weapon | Action |
+|---|---|---|---|---|---|---|
+| 1.1 Honey | N64 analog stick | Native turret state | Z | R | A | B |
+| 1.2 Solitaire | C buttons | Native turret state | Z | R | A | B |
+| 1.3 Kissy | N64 analog stick | Native turret state | A | Z | R | B |
+| 1.4 Goodnight | C buttons | Native turret state | A | Z | R | B |
+
+Shared modern behavior derived from that table:
+
+- W/S always means drive forward/backward while mounted.
+- A/D always means turn the tank hull left/right while mounted.
+- Mouse/trackpad X and controller right-stick X always turn the turret.
+- Mouse/trackpad Y and controller right-stick Y retain vertical look/aim.
+- Space, mouse-left, and controller right trigger always mean Fire.
+- Shift and controller left trigger always mean Aim.
+- Q, controller weapon buttons, and wheel-down always mean next Weapon.
+- Wheel-up emits the active style's Weapon+Fire chord for previous Weapon.
+- E, mouse-right, and controller action buttons remain native B for
+  enter/exit/reload/action in every 1.x style.
+
+On foot, 1.1/1.3 use analog Y for forward/back and native C-left/C-right for
+sidestep. Styles 1.2/1.4 use the four C buttons for movement, exactly as the
+original layouts require. Holding Aim restores GoldenEye's original division:
+the left stick moves the native weapon/reticle without moving Bond, and the
+right stick is neutral. Tank entry and startup publish neutral movement/look
+until GoldenEye's native run state reaches `TANK_RUN_STATE_RUNNING`.
+
+## Input modes
+
+The host recognizes three mutually exclusive modes:
+
+1. **Watch/menu**: W/S/A/D and menu pointer steps emit digital D-pad input.
+   This prevents full analog Y from advancing the control-style selector once
+   per game tick and skipping 1.2/1.3. Camera/right-stick look is neutral.
+2. **On-foot gameplay**: the accepted modern movement and relative-look paths
+   remain active.
+3. **Mounted-tank gameplay**: the active 1.x style selects analog or C-button
+   tank drive, while relative horizontal look updates the authoritative turret
+   target and smoothed orientation directly.
+
+Mac now uses the same strict watch-state predicate as mobile: gameplay requires
+`watch_animation_state == 0`, `outside_watch_menu != 0`, and
+`open_close_solo_watch_menu == 0`. Tank translation therefore cannot remain
+active behind the watch.
+
+## Implementation boundaries
+
+- `Sources/RecompControlMapping.swift` is the single shared host mapping table.
+- `Sources/Mac/RecompMacInput.swift` and `Sources/RecompPrototypeInput.swift`
+  gather semantic actions, then apply that table once per publish.
+- `Support/RecompPrototype/recomp_game_start.cpp` exposes live control style and
+  authoritative mounted state, classifies watch/gameplay mode, and reads live
+  `insightaimmode` for right-stick scaling.
+- `patches/goldeneye64recomp-ios-modern-controls.patch` owns proportional tank
+  turret look on the game thread. It updates named GoldenEye globals rather than
+  undocumented player/camera offsets.
+- Mounted vertical input updates GoldenEye's player pitch. The original render
+  path derives `field_2A08` from that pitch, and the original tank update owns
+  cannon-elevation clamping and smoothing through
+  `g_TankTurretVerticalAngleRelated` and `g_TankTurretVerticalAngle`. GoldenPad
+  must not write those elevation accumulators a second time.
+- `Config/RecompPrototypeInfo.plist.in` reads the
+  `GOLDENPAD_RECOMP_DISPLAY_NAME` Xcode setting. Its normal-build default remains
+  `GoldenPad`; preservation-sensitive side-by-side device builds may override
+  only that setting and the bundle identifier.
+- `RecompiledPatches/patches.c` and `patches_bin.c` must always be regenerated
+  together. CMake now rejects stale or missing turret markers.
+
+The tracked `.patch` file, not the ignored `ref/` checkout, is the canonical
+game-side change. The generated reference checkout exists only to build and
+validate the app.
+
+No ROM, save, EEPROM, settings database, or user Documents data is modified by
+this repair.
+
+## Automated checks
+
+Run from the repository root:
+
+```sh
+scripts/verify-recomp-input-matrix.sh
+git diff --check
+cmake --build build-recomp-macos --config Release --target GoldenPadMac
+```
+
+`verify-recomp-input-matrix.sh` compiles the real shared mapping source and checks:
+
+- Fire/Aim/Weapon/Action for 1.1, 1.2, 1.3, and 1.4
+- on-foot and tank movement for both analog and C-button style families
+- Aim and tank-entry movement suppression
+- classic-mode and non-gameplay bypass behavior
+- neutral-rearmed, one-edge watch/menu navigation
+- mobile non-gameplay input retains the accepted raw controller pass-through
+- external-controller on-foot Aim routes the left stick through GoldenEye's
+  native manual-sight path and neutralizes the right stick, while normal look
+  and mounted Aim retain their respective camera/turret paths
+- Reverse/Upright compensation and GoldenPad's opt-in vertical inversion have
+  the same meaning on iPhone, iPad, and Mac
+- the tracked GoldenEye patch applies cleanly and exactly matches the external
+  source files used for the build
+- the generated patch contains every mounted-state/turret-state marker
+
+Both package scripts run this verifier before staging an archive. Their archive
+verifiers require the shared live input-context symbol.
+
+### Final release evidence (2026-08-23)
+
+- GoldenEye MIPS patch compiled and both embedded patch halves regenerated.
+- Generated `patches.c` SHA-256:
+  `4a829165889a4e736199841c4c4237ee6a03ed97fa1ce6d891dfc864634862ff`
+- Generated `patches_bin.c` SHA-256:
+  `cb3e439a8eb1587ac11b7fa29551b3f204860f993b9114ebd5331c179bc92bc6`
+- Physically accepted signed ARM64 iPad test executable SHA-256:
+  `2b31f8868885712fbad34cef1aea20b1dee48f59fc9d930cbd3fa8b8e82b6b12`
+- Final version `0.1.0` build `4` unsigned release executable SHA-256:
+  `d83361f4daa70014b378aed20b9e26dc7c787d77b0fcd000816d536aecc8e66b`
+- Final unsigned IPA SHA-256:
+  `ff163b0af6b54596590da8e39cbaff0b388b69f1607ca34f62ce61e7fe144130`
+- Final Mac Alpha archive SHA-256:
+  `63bec02ad6e323a213f9cb9d15f763a58d6eb7bd4a1a40af6341a4fb8fb333ba`
+- The ARM64 iPad and Apple-Silicon Mac targets both compile with the same
+  `Sources/RecompControlMapping.swift` implementation.
+- Repository ROM/signing-path audit, shared input matrix, tracked-patch parity,
+  generated marker checks, and `git diff --check` pass.
+
+The signed test hash identifies the physically accepted 1.56-degree baseline.
+The final release hashes include the requested 20 percent increase to 1.872
+degrees per frame and have build, matrix, and package proof. The final unsigned
+release executable did not receive a second physical-device pass.
+
+### Temporary iPad smoke-test deployment (2026-08-23)
+
+This is a private device test, not a Preview 4 release artifact:
+
+- display name: `GoldenPad P4 Test`
+- bundle identifier: `com.chrissotraidis.goldenpad.preview4test`
+- source app retained: `com.chrissotraidis.goldenpad.recomp-prototype`
+- iPad Release executable SHA-256:
+  `2b31f8868885712fbad34cef1aea20b1dee48f59fc9d930cbd3fa8b8e82b6b12`
+- the preinstall `Documents` and `Library` backup remains local and untracked;
+  no ROM, save, preference, or backup path enters the repository or package
+- the P4 Test bundle was reinstalled in place; it was not uninstalled
+- the TLB-free ROM, runtime ROM, current save, save backup, and preferences
+  plist were read back and remained byte-for-byte unchanged
+- the left-stick native manual-Aim candidate was deliberately left closed after
+  installation
+  so the user, not a CoreDevice launch, performs its first run
+
+The iPad test exercises the shared semantic mapping, aim suppression, tank-state
+translation, game-side turret patch, and controller sensitivity. It cannot
+accept Mac-only keyboard, trackpad, or mouse gathering.
+
+Device rollback is intentionally narrow: uninstall only
+`com.chrissotraidis.goldenpad.preview4test`. Do not uninstall, replace, or clear
+the source app. Private ROM, save, preference, backup, and log data remain
+outside the repository and must never be committed or packaged.
+
+## Physical acceptance gate
+
+Test the installed iPad build with one extended gamepad first. Mac keyboard,
+trackpad, and mouse acceptance follows only after the iPad controller rows pass.
+
+### Runway and Streets, each style 1.1-1.4
+
+- Enter the tank with controller Action and let the hatch transition finish.
+- Left-stick Y drives forward/backward.
+- Left-stick X turns the hull left/right.
+- Right-stick X turns the turret smoothly in both directions and responds to
+  small versus large motion without binary stepping.
+- Right-stick Y moves the turret up/down without pitching below the native
+  mounted limit or filling the view with the tank model.
+- Drive, hull-turn, and turret-look simultaneously.
+- Right trigger fires only the currently selected weapon. Confirm the retained
+  KF7 fires when selected, then change to Tank Shells and confirm the cannon
+  fires instead. They must never fire simultaneously. Seeing the KF7 while
+  mounted is expected original behavior.
+- Hold Aim with left trigger while deliberately moving the left stick in all
+  directions: Bond/tank must remain stationary while right-stick aim works.
+- Change weapons forward and backward without firing a shell accidentally.
+- Open the watch while mounted, navigate in all four directions, and select
+  1.1, 1.2, 1.3, and 1.4 one step at a time.
+- Close the watch and confirm no stuck drive, turret, Fire, or Aim input.
+- Repeat after death/restart and after mission abort/re-entry.
+
+### Regression rows
+
+- Dam or Runway on foot: left-stick movement, both right-stick axes, Fire, Aim,
+  Action, Weapon, and Duck. The final Preview 4 right-stick response is 20
+  percent faster than the physically accepted `2b31f886...` baseline and 56
+  percent faster than the original rejected P4 Test rate.
+- On foot, hold left trigger and move the left stick in all directions. Bond
+  must remain stationary while the native weapon/reticle follows the left
+  stick in all four directions without rotating the ordinary camera directly.
+- Confirm the right stick does nothing while on-foot Aim remains held.
+- Hold the left stick off-center while Aim remains held: the sight must remain
+  at the requested offset rather than being pulled immediately toward center.
+  Release the left stick and then Aim, confirming native recentering and a
+  clean return to normal right-stick camera look.
+- Title, mission select, watch opening/closing, pause, death, and return to title:
+  no pointer-capture or navigation regression.
+- One touch-only iPad Runway pass after controller acceptance: both look axes,
+  movement, Aim, Fire, Action, and Weapon.
+- Existing Mac renderer/audio soak and Dam/Surface scene comparisons remain
+  mandatory; this input patch does not waive them.
+
+Record each row as PASS/FAIL with style, input device, mission, and build hash.
+Do not call Preview 4 accepted from build, launch, or package evidence alone.
+
+## Rollback
+
+Preview 4 is isolated in a focused merge. Preferred rollback after merge:
+
+```sh
+git revert <preview-4-input-fix-commit>
+```
+
+Then rebuild the external GoldenEye64Recomp reference from the reverted tracked
+patch set and regenerate **both** `RecompiledPatches/patches.c` and
+`patches_bin.c`. Never restore only one generated half.
+
+Files owned by this focused change:
+
+- `CMakeLists.txt`
+- `Config/RecompPrototypeInfo.plist.in`
+- `Sources/RecompControlMapping.swift`
+- `Sources/Mac/RecompMacInput.swift`
+- `Sources/RecompPrototypeInput.swift`
+- `Sources/RecompPrototypeApp.swift`
+- `Sources/RecompPrototypeAudio.swift`
+- `Sources/RecompPrototypeMetalCanvas.swift`
+- `Support/RecompPrototype/recomp_game_start.cpp`
+- `Support/RecompPrototype/recomp_rt64_surface_stub.cpp`
+- `Tests/RecompControlMappingTests.swift`
+- `patches/goldeneye64recomp-ios-modern-controls.patch`
+- `scripts/package-recomp-macos-alpha.sh`
+- `scripts/package-recomp-prototype-ipa.sh`
+- `scripts/verify-recomp-input-matrix.sh`
+- `scripts/verify-recomp-macos-alpha.sh`
+- `scripts/verify-recomp-prototype-ipa.sh`
+- `docs/PREVIEW_4_INPUT_FIX.md`
+
+Do not use a broad worktree reset for rollback. This checkout contains unrelated
+user-owned edits. Revert the focused commit, regenerate the ignored external
+patch pair, rebuild, and rerun the package verifier. If rollback occurs before
+commit, construct and review a reverse diff limited to the file list above.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,6 +1,6 @@
 # Release checklist
 
-GoldenPad 0.1.0 Preview 3 is the current coordinated release. It is a
+GoldenPad 0.1.0 Preview 4 is the current coordinated release. It is a
 developer preview, not an App Store/TestFlight release. `GoldenPad Legacy`
 remains a fallback artifact and must not be presented as primary.
 
@@ -97,6 +97,37 @@ drawable-size and direct-camera experiments caused much larger regressions.
   acceptance does not close those transitions.
 - [x] Obtain user approval to merge and publish Preview 3.
 
+## Coordinated Preview 4 shared-controls and tank update
+
+- [x] Freeze the exact physically accepted iPad test executable at SHA-256
+  `2b31f8868885712fbad34cef1aea20b1dee48f59fc9d930cbd3fa8b8e82b6b12`.
+- [x] Preserve raw non-gameplay controller passthrough so the tank repair cannot
+  disable title or mission-menu navigation.
+- [x] Use one shared 1.1 through 1.4 mapping on mobile and Mac, with native
+  left-stick manual Aim and no platform-specific control interpretation.
+- [x] Gate tank behavior on GoldenEye's live player/tank/entry state and retain
+  the native hatch transition, drive/hull path, turret state, selected-weapon
+  cycling, firing, and exit/re-entry behavior.
+- [x] Obtain physical iPad acceptance for menu, on-foot controls, Aim, Runway
+  tank drive/turn/turret/weapons, return to title, and a Facility regression
+  pass.
+- [x] Apply the user's final requested 20 percent absolute controller-look
+  increase from 1.56 to 1.872 degrees per frame without changing touch, mouse,
+  manual Aim, left movement, or menus.
+- [x] Rebuild both generated GoldenEye patch halves together and prove tracked
+  patch parity plus tank-state markers.
+- [x] Pass the shared 1.1 through 1.4 matrix, complete unsigned device build,
+  complete native arm64 Mac build, and both package audits.
+- [x] Package the 18-member unsigned IPA at SHA-256
+  `ff163b0af6b54596590da8e39cbaff0b388b69f1607ca34f62ce61e7fe144130`.
+- [x] Package the 20-member Mac Alpha at SHA-256
+  `63bec02ad6e323a213f9cb9d15f763a58d6eb7bd4a1a40af6341a4fb8fb333ba`.
+- [ ] Keep issue #17 open until the reporter verifies Preview 4 on Mac. Do not
+  treat iPad acceptance or Mac package proof as reporter acceptance.
+- [ ] The final 1.872-degree unsigned release executable has build and static
+  verification, not a second physical-device pass. Keep that distinction in
+  release notes and status.
+
 The remaining sections preserve the `GoldenPad Legacy` clean-checkout and
 packaging procedure.
 
@@ -150,11 +181,11 @@ plus warm performance checks on the target hardware.
   ```sh
   ./scripts/package-recomp-prototype-ipa.sh
   ./scripts/verify-recomp-prototype-ipa.sh \
-    dist/GoldenPad-0.1.0-preview.3-unsigned.ipa
+    dist/GoldenPad-0.1.0-preview.4-unsigned.ipa
 
   ./scripts/package-recomp-macos-alpha.sh
   ./scripts/verify-recomp-macos-alpha.sh \
-    dist/GoldenPad-0.1.0-preview.3-macos-arm64-alpha.zip
+    dist/GoldenPad-0.1.0-preview.4-macos-arm64-alpha.zip
   ```
 
 - Keep the README's install table and limitations accurate.

--- a/docs/RELEASE_NOTES_0.1.0-preview.4.md
+++ b/docs/RELEASE_NOTES_0.1.0-preview.4.md
@@ -1,0 +1,111 @@
+# GoldenPad 0.1.0 Preview 4
+
+Preview 4 repairs the shared GoldenEye controller path and the mission tank
+controls reported in issue #17. It keeps Preview 3's ROM import, saves, audio,
+renderer, touch layouts, Mac keyboard and mouse commands, and experimental
+multiplayer rendering boundaries.
+
+## Highlights
+
+- Uses one shared controller mapping on iPhone, iPad, and Apple Silicon Mac.
+  GoldenPad reads GoldenEye's active 1.1 Honey, 1.2 Solitaire, 1.3 Kissy, or
+  1.4 Goodnight style instead of applying a separate platform interpretation.
+- Preserves raw controller input outside live gameplay so the title screen,
+  mission menus, watch, and controller connection path do not inherit tank or
+  modern-look translation.
+- Restores GoldenEye's native manual-sight behavior while Aim is held: Bond is
+  stationary, the left stick moves the weapon and reticle, and the right stick
+  is neutral until Aim is released.
+- Repairs the player-enterable tank used by Runway and Streets. The left stick
+  owns drive and hull turning, the right stick owns turret aim after the native
+  hatch/start transition, and Fire operates only the currently selected weapon.
+  GoldenEye's authentic mounted weapon cycling remains available, including
+  ordinary weapons and Tank Shells.
+- Raises absolute external-controller right-stick response by the requested
+  final 20 percent, from 1.56 to 1.872 degrees per frame at full deflection.
+  Touch, mouse, native manual Aim, left-stick movement, and menus are unchanged.
+- Removes the obsolete separate movement-adapter setting. The active GoldenEye
+  control style is now reported automatically in Settings and diagnostics.
+
+## Downloads
+
+### iPhone and iPad
+
+`GoldenPad-0.1.0-preview.4-unsigned.ipa`
+
+SHA-256:
+
+```text
+ff163b0af6b54596590da8e39cbaff0b388b69f1607ca34f62ce61e7fe144130
+```
+
+The 18-member IPA is unsigned and must be re-signed for the user's own device.
+Its sorted unsigned app-content SHA-256 is
+`1ec161604af996f30bb3ac1e9c347f7c905623675ca32adf8d2c35a069c6a13c`.
+It contains no ROM, save, provisioning profile, signing identity, or private
+user path.
+
+### Apple Silicon Mac Alpha
+
+`GoldenPad-0.1.0-preview.4-macos-arm64-alpha.zip`
+
+SHA-256:
+
+```text
+63bec02ad6e323a213f9cb9d15f763a58d6eb7bd4a1a40af6341a4fb8fb333ba
+```
+
+The 20-member Mac archive contains a native arm64, ad-hoc-signed,
+non-notarized app. Its sorted app-content SHA-256 is
+`d2d0824047061b81ad3ef1b2fd2fd61fde09fc759176b782209c41279217a341`.
+
+## Acceptance record
+
+- On physical iPad, the user accepted menu navigation, ordinary movement and
+  right-stick look, left-trigger manual Aim, Runway tank entry, drive, hull
+  turn, turret control, weapon cycling, KF7 and Tank Shell firing, exit and
+  re-entry, return to title, and a later Facility regression pass.
+- That accepted signed test executable has SHA-256
+  `2b31f8868885712fbad34cef1aea20b1dee48f59fc9d930cbd3fa8b8e82b6b12`
+  and used the 1.56-degree controller-look baseline.
+- The final 1.872-degree public executable is version `0.1.0` build `4` and has SHA-256
+  `d83361f4daa70014b378aed20b9e26dc7c787d77b0fcd000816d536aecc8e66b`.
+  It incorporates the user's requested 20 percent response increase and passed
+  the shared input matrix, complete device build, symbol audit, and package
+  audit. This exact unsigned release executable was not installed for a second
+  physical pass before publication.
+- The native Mac target compiled and its archive passed architecture, signing,
+  dependency, symbol, license, private-path, and game-data audits. Issue #17
+  remains open because build/package proof does not replace reporter gameplay
+  verification on Mac.
+- The tracked modern-controls source patch matches the ignored build input.
+  Both generated patch halves were rebuilt together. Their SHA-256 values are
+  `4a829165889a4e736199841c4c4237ee6a03ed97fa1ce6d891dfc864634862ff`
+  for `patches.c` and
+  `cb3e439a8eb1587ac11b7fa29551b3f204860f993b9114ebd5331c179bc92bc6`
+  for `patches_bin.c`.
+
+## Known limitations
+
+- Issue #17 remains open until the reporter confirms Runway tank controls on
+  the Preview 4 Mac Alpha and provides diagnostics if a problem remains.
+- Local multiplayer remains experimental. Slight lighting flicker and real
+  Player 3 and Player 4 controller ownership remain open.
+- Online and peer-to-peer multiplayer are not implemented.
+- Native-60-Hz automatic-fire authenticity, intermittent audio static,
+  screenshot/background lifecycle behavior, A12X compatibility issue #9,
+  stage-specific rendering faults, and long-session performance remain tracked
+  technical debt.
+- The Mac Alpha retains the thin far-right blue edge and is not notarized.
+
+## Data and rights boundary
+
+GoldenPad does not include, download, or redistribute GoldenEye 007, a ROM,
+extracted retail assets, or saves. Users must supply their own supported
+original retail dump. This is a source-available developer preview and is not
+official, commercially licensed, App Store-cleared, or affiliated with
+Nintendo, Rare, or MGM.
+
+GoldenPad builds on GoldenEye64Recomp, N64Recomp, N64ModernRuntime, RT64, and
+their contributors. See the source-license manifest, third-party notices, and
+legal policy for exact provenance and redistribution boundaries.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -6,17 +6,17 @@ Updated: 2026-08-23
 
 | Surface | Current truth |
 | --- | --- |
-| Public release | Preview 3 is published with separately audited unsigned iPhone/iPad and arm64 Mac Alpha artifacts. |
+| Public release | Preview 4 is published with separately audited unsigned iPhone/iPad and arm64 Mac Alpha artifacts. |
 | Primary runtime | Static GoldenEye ARM64 output + N64ModernRuntime + RT64/Plume/Metal. MGB64 is Legacy only. |
-| Accepted baseline | Physical iPhone/iPad single-player, touch, Xbox/MFi P1, saves/preferences preservation, and the bounded four-view experimental render repair. |
-| Major gameplay debt | Native-60-Hz automatic-fire cadence remains incorrect; Preview 3 ships modern Honey sidestep as an opt-in adapter pending reporter confirmation. |
+| Accepted baseline | Physical iPhone/iPad single-player, touch, Xbox/MFi P1, native left-stick Aim, Runway tank controls, saves/preferences preservation, and the bounded four-view experimental render repair. |
+| Major gameplay debt | Native-60-Hz automatic-fire cadence remains incorrect. Preview 4 repairs shared 1.1 through 1.4 and tank input without changing that timing seam. |
 | Compatibility debt | A12X issue #9 is an unresolved first-frame RT64/Metal crash report, not an architecture/signing failure. |
 | Local multiplayer | Experimental rendering works; real P2–P4 controller ownership, reconnect behavior, and residual flicker remain open. |
 | Input lifecycle | Settings/share touch neutralization, disconnect-to-none ownership collapse, and mobile run-loop tracking remain open TD-14/TD-07 gaps. |
 | Network multiplayer | Not implemented. It is no-go until local ownership and deterministic state-hash gates pass. |
-| Preview 3 controls release | Accepted input-only update from Preview 2: opt-in mobile Honey sidestep, clearer setup copy, and the hands-on accepted Mac control build. |
+| Preview 4 controls release | Shared mobile/Mac 1.1 through 1.4 mapping, native left-stick Aim, Runway/Streets tank control repair, and the requested final 20 percent controller-look increase. |
 | Immediate engineering gate | Finish sustained-player fire-rate measurement on Preview 3; isolated guard windows already record 13/17/18 events per 100 ticks. |
-| Immediate user-facing follow-up | Ask the issue #8 reporter to verify touch and controller sidestep behavior; keep the opt-in adapter and Preview 2 default unchanged meanwhile. |
+| Immediate user-facing follow-up | Ask the issue #17 reporter to verify Preview 4 on Mac and provide diagnostics if needed; keep the issue open until reporter confirmation. |
 | Storage/build hygiene | The runtime-managed Application Support ROM copy lacks the Documents copy's explicit backup/protection attributes; game-bearing build provenance remains private-input/manual. |
 
 Documentation ownership:
@@ -47,6 +47,28 @@ into [`TECH_DEBT.md`](TECH_DEBT.md). It inspected historical commit `788667e`,
 so its source analysis remains supporting evidence while current status comes
 from Preview 3 and later isolated debt experiments. It is not repository
 instructions or a runtime acceptance artifact.
+
+Preview 4 replaces Preview 3's separate movement adapter with one shared input
+mapper that reads GoldenEye's active 1.1 through 1.4 style. Non-gameplay input
+remains raw so title and mission menus cannot inherit modern gameplay or tank
+translation. While Aim is held, the external left stick feeds GoldenEye's
+native manual-sight path, Bond remains stationary, and the external right stick
+is neutral. In the player-enterable Runway and Streets tank, the left stick
+owns drive and hull turning and the right stick updates native turret state only
+after the hatch/start transition reaches running.
+
+On physical iPad, the user accepted the frozen signed test executable
+`2b31f8868885712fbad34cef1aea20b1dee48f59fc9d930cbd3fa8b8e82b6b12`
+for menu navigation, on-foot controls, manual Aim, Runway drive, hull turn,
+turret aim, ordinary-weapon and Tank Shell cycling/firing, exit/re-entry,
+return to title, and a Facility regression pass. The final version `0.1.0`
+build `4` public executable
+`d83361f4daa70014b378aed20b9e26dc7c787d77b0fcd000816d536aecc8e66b`
+adds the user's requested 20 percent absolute controller-look increase from
+1.56 to 1.872 degrees per frame. It passed the complete matrix, device build,
+and package audit, but was not installed for a second physical pass. The native
+Mac target builds and package-audits; issue #17 remains open because reporter
+gameplay verification is still required.
 
 The Preview 2 signed iPhone/iPad release build launches real GoldenEye gameplay,
 preserves its private ROM, save and preference payloads across in-place
@@ -140,7 +162,21 @@ multiplayer or Mac sustained performance to stable-release status. The
 coordinated repository update produces separate audited platform artifacts: an
 iOS/iPadOS `.ipa` and an arm64 macOS Alpha archive containing `GoldenPad.app`.
 
-The audited Preview 3 mobile artifact is
+The audited Preview 4 mobile artifact is
+`GoldenPad-0.1.0-preview.4-unsigned.ipa` at SHA-256
+`ff163b0af6b54596590da8e39cbaff0b388b69f1607ca34f62ce61e7fe144130`.
+Its 18-member archive passed the ROM/save/signing/private-path/setup-copy and
+required-symbol audits and has sorted unsigned app-content SHA-256
+`1ec161604af996f30bb3ac1e9c347f7c905623675ca32adf8d2c35a069c6a13c`.
+The audited Preview 4 Mac Alpha artifact is
+`GoldenPad-0.1.0-preview.4-macos-arm64-alpha.zip` at SHA-256
+`63bec02ad6e323a213f9cb9d15f763a58d6eb7bd4a1a40af6341a4fb8fb333ba`;
+its 20-member archive has sorted app-content SHA-256
+`d2d0824047061b81ad3ef1b2fd2fd61fde09fc759176b782209c41279217a341`.
+Neither artifact contains ROM, save, provisioning, signing identity, or private
+build-path data.
+
+The historical audited Preview 3 mobile artifact is
 `GoldenPad-0.1.0-preview.3-unsigned.ipa` at SHA-256
 `ef2ab9575d5a9df5d7d8d4138caa789625be3407ebc796a4d9339ea1fe6ba777`.
 Its 18-member archive passed the ROM/save/signing/private-path/setup-copy audit
@@ -664,10 +700,10 @@ evidence ledger below is preserved as historical validation for
   The pinned source establishes the cadence mechanism. An isolated probe
   recorded guard windows of 13/17/18 events per 100 ticks; sustained player
   magnitude remains unmeasured, so no timing repair is authorized yet.
-- Preview 3 ships an opt-in 1.1 Honey sidestep adapter for touch and controller
-  while preserving Preview 2 movement as the default. Issue #8 remains open for
-  reporter confirmation and the wider physical style/lifecycle matrix; it is no
-  longer accurate to call sidestep wholly unimplemented.
+- Preview 4 supersedes the opt-in sidestep adapter with automatic shared
+  mappings for all four GoldenEye control styles. The full matrix is automated;
+  ordinary on-foot, Aim, and Runway tank behavior received physical iPad
+  acceptance. Issue #17 remains open for Mac reporter confirmation.
 - The published Preview 1 artifact crashes deterministically at the first RT64
   rendered frame on a reported A12X iPad Pro. A12X meets the declared ARM64,
   Metal, device-family, and OS requirements; treat [issue #9](https://github.com/chrissotraidis/goldenpad/issues/9)
@@ -693,7 +729,7 @@ evidence ledger below is preserved as historical validation for
 - Settings/share presentation does not explicitly release latched primary-host
   touch, disconnect-to-none can collapse held diagnostic touch onto Player 1,
   and the mobile publisher can pause in default run-loop tracking. These are
-  active TD-14/TD-07 gaps despite Preview 3's accepted ordinary controls.
+  active TD-14/TD-07 gaps despite Preview 4's accepted ordinary controls.
 - A small amount of audible static has been reported during otherwise working
   audio. Game, runtime, and host agree at 22,050 Hz, so rate mismatch is ruled
   out; long-session speaker, route-change, reset-race, and discontinuity
@@ -717,7 +753,7 @@ evidence ledger below is preserved as historical validation for
 
 ## Next gate
 
-Preview 3 is published as a prerelease with separately audited mobile and Mac
+Preview 4 is published as a prerelease with separately audited mobile and Mac
 Alpha artifacts. The hosted downloads matched their published checksums and
 passed the same package verifiers as the local artifacts. The next engineering
 gate is sustained-player fire-rate measurement using the isolated read-only

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -393,6 +393,49 @@ boundary and user acceptance recorded for Preview 3. They do not close the
 known multiplayer, blue-edge, fire-rate, audio, lifecycle, A12X, or broader
 long-session performance debt.
 
+Preview 4 release evidence:
+
+- `scripts/verify-recomp-input-matrix.sh` passes all 1.1 through 1.4 shared
+  control-style cases, raw mobile menu passthrough, external-controller native
+  manual Aim, the exact 1.872-degree controller-look rate, tracked upstream
+  patch parity, and generated tank-state markers;
+- the physically accepted signed iPad test executable SHA-256 is
+  `2b31f8868885712fbad34cef1aea20b1dee48f59fc9d930cbd3fa8b8e82b6b12`;
+- that physical pass covered title/mission navigation, ordinary on-foot
+  movement/right look, left-trigger stationary left-stick manual Aim, Runway
+  tank entry, drive, hull turn, turret aim, ordinary weapon and Tank Shell
+  cycling/firing, exit/re-entry, return to title, and a Facility regression;
+- the accepted test executable used 1.56 degrees per frame. The final version
+  `0.1.0` build `4` public executable applies the user's requested 20 percent
+  increase to 1.872 degrees
+  per frame and has SHA-256
+  `d83361f4daa70014b378aed20b9e26dc7c787d77b0fcd000816d536aecc8e66b`;
+- the complete unsigned device app and native arm64 Mac app both compile against
+  the same regenerated GoldenEye patch pair;
+- `patches.c` and `patches_bin.c` SHA-256 values are
+  `4a829165889a4e736199841c4c4237ee6a03ed97fa1ce6d891dfc864634862ff`
+  and `cb3e439a8eb1587ac11b7fa29551b3f204860f993b9114ebd5331c179bc92bc6`;
+- `scripts/verify-recomp-prototype-ipa.sh` passes the 18-member unsigned IPA at
+  SHA-256
+  `ff163b0af6b54596590da8e39cbaff0b388b69f1607ca34f62ce61e7fe144130`,
+  with sorted unsigned app-content SHA-256
+  `1ec161604af996f30bb3ac1e9c347f7c905623675ca32adf8d2c35a069c6a13c`;
+- `scripts/verify-recomp-macos-alpha.sh` passes the 20-member arm64 Alpha archive
+  at SHA-256
+  `63bec02ad6e323a213f9cb9d15f763a58d6eb7bd4a1a40af6341a4fb8fb333ba`,
+  with sorted app-content SHA-256
+  `d2d0824047061b81ad3ef1b2fd2fd61fde09fc759176b782209c41279217a341`;
+- the final unsigned release executable was not installed for a second physical
+  pass after the requested 20 percent response increase; and
+- Mac build/package proof does not close issue #17. Keep it open until the
+  reporter verifies gameplay and supplies diagnostics if a problem remains.
+
+Run the focused input gate before every Preview 4 package:
+
+```sh
+./scripts/verify-recomp-input-matrix.sh
+```
+
 ## Desktop baseline
 
 ```sh

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -1,5 +1,43 @@
 # Worklog
 
+## 2026-08-23 - accept and publish the Preview 4 tank and shared-controls repair
+
+- Froze the exact physically accepted signed iPad test executable at SHA-256
+  `2b31f8868885712fbad34cef1aea20b1dee48f59fc9d930cbd3fa8b8e82b6b12`
+  before making the final sensitivity adjustment.
+- Replaced the competing Preview 3 movement adapter with one shared mapping for
+  GoldenEye control styles 1.1 through 1.4 on iPhone, iPad, and Mac. Preserved
+  raw non-gameplay input so menu navigation cannot be disabled by gameplay or
+  tank state.
+- Routed held Aim through GoldenEye's native manual-sight semantics: stationary
+  Bond, left-stick sight movement, and neutral right stick until release.
+- Bound the Runway/Streets tank path to GoldenEye's player, prop, and entry-run
+  state. Preserved the hatch transition, left-stick drive/hull turn, native
+  turret state, selected-weapon cycling and firing, and exit/re-entry.
+- The user physically accepted menu, ordinary on-foot, Aim, Runway tank, return
+  to title, and Facility regression behavior. The user also confirmed mounted
+  ordinary weapons are authentic GoldenEye behavior, not simultaneous tank and
+  rifle firing.
+- Applied the requested final 20 percent absolute controller-look increase from
+  1.56 to 1.872 degrees per frame without changing touch, mouse, left movement,
+  manual Aim, or menus.
+- Reconciled the accepted branch with current `main` in an isolated worktree.
+  The clean build caught and removed a duplicated old mobile publisher, restored
+  the independent Preview 3 Mac inventory/reload/mouse commands, restored the
+  lifecycle/audio/depth diagnostic hooks, and regenerated both GoldenEye patch
+  halves together.
+- Added `docs/PREVIEW_4_INPUT_FIX.md`, the executable matrix in
+  `scripts/verify-recomp-input-matrix.sh`, and the shared pure mapping tests so
+  the repair and reversal boundary are explicit.
+- Built the complete unsigned iPhone/iPad app and native arm64 Mac app. The
+  18-member IPA audits at SHA-256
+  `ff163b0af6b54596590da8e39cbaff0b388b69f1607ca34f62ce61e7fe144130`;
+  the 20-member Mac Alpha audits at SHA-256
+  `63bec02ad6e323a213f9cb9d15f763a58d6eb7bd4a1a40af6341a4fb8fb333ba`.
+- Kept issue #17 open for reporter verification. The exact final 1.872-degree
+  unsigned executable has build, matrix, and package proof, not a second
+  physical-device pass.
+
 ## 2026-08-23 — preserve revision-2 review and refresh current documentation
 
 - Preserved the supplied independent review with its source SHA-256 and a

--- a/patches/goldeneye64recomp-ios-modern-controls.patch
+++ b/patches/goldeneye64recomp-ios-modern-controls.patch
@@ -1,20 +1,28 @@
 diff --git a/patches/externs.h b/patches/externs.h
-index 609e348..a6dfd75 100644
+index 609e348..6d1ac4d 100644
 --- a/patches/externs.h
 +++ b/patches/externs.h
-@@ -406,6 +406,7 @@ extern f32 titleTransitionX;
+@@ -406,6 +406,15 @@ extern f32 titleTransitionX;
  extern Mtxf dword_CODE_bss_80079E98;
  extern f32 g_SkyCloudOffset;
  extern struct player* g_CurrentPlayer;
++extern s32 g_PlayerIsInTank;
++extern s32 g_EnterTankAudioState;
++extern struct PropRecord* g_PlayerTankProp;
++extern f32 g_TankTurretOrientationAngleRad;
++extern f32 g_TankTurretOrientationAngleDeg;
++extern f32 g_TankTurretAngle;
 +void bondviewApplyVertaTheta(void);
++PropRecord* chrGetEquippedWeaponProp(struct ChrRecord* chr, s32 hand);
++void chrlvFireWeaponRelated(struct ChrRecord* chr, s32 hand);
  extern s32 cameraFrameCounter1;
  extern s32 cameraFrameCounter2;
  extern s32 cameraBufferToggle;
 diff --git a/patches/patches.h b/patches/patches.h
-index 77b502e..f952ae0 100644
+index 77b502e..9c0ca27 100644
 --- a/patches/patches.h
 +++ b/patches/patches.h
-@@ -117,6 +117,21 @@ int recomp_printf(const char* fmt, ...);
+@@ -117,6 +117,22 @@ int recomp_printf(const char* fmt, ...);
      extern u8 identifier[]
  
  float recomp_get_aspect_ratio(float);
@@ -24,9 +32,10 @@ index 77b502e..f952ae0 100644
 +s32 goldenpad_recomp_consume_return_to_title(void);
 +s32 goldenpad_recomp_consume_reload(s32 controllernum);
 +s32 goldenpad_recomp_consume_inventory_slot(s32 controllernum);
-+s32 currentPlayerGetCrouchPos(void);
-+void currentPlayerAdjustCrouchPos(s32 value);
-+u32 bondwalkItemCheckBitflags(s32 item, u32 mask);
++void goldenpad_recomp_fire_rate_player_sample(
++    s32 playernum, s32 weapon, s32 ammo, s32 counter);
++void goldenpad_recomp_fire_rate_guard_sample(
++    s32 item, s32 before, s32 after, u32 guardKey);
 +s32 getCurrentPlayerWeaponId(s32 hand);
 +void attempt_reload_item_in_hand(s32 hand);
 +s32 bondinvCountTotalItemsInInv(void);
@@ -37,10 +46,10 @@ index 77b502e..f952ae0 100644
  
  #endif
 diff --git a/patches/syms.ld b/patches/syms.ld
-index 31e51b1..b028f61 100644
+index 31e51b1..b1c0697 100644
 --- a/patches/syms.ld
 +++ b/patches/syms.ld
-@@ -76,4 +76,9 @@ boot_osPiRawStartDma = 0x8F000100;
+@@ -76,4 +76,11 @@ boot_osPiRawStartDma = 0x8F000100;
  osGetCount_recomp = 0x8F000104;
  sprintf_recomp = 0x8F000108;
  osPfsInit_recomp = 0x8F00010C;
@@ -50,13 +59,15 @@ index 31e51b1..b028f61 100644
 +goldenpad_recomp_consume_crouch_toggle = 0x8F000114;
 +goldenpad_recomp_unlock_all_missions_enabled = 0x8F000118;
 +goldenpad_recomp_consume_return_to_title = 0x8F00011C;
-+goldenpad_recomp_consume_reload = 0x8F000120;
-+goldenpad_recomp_consume_inventory_slot = 0x8F000124;
++goldenpad_recomp_fire_rate_player_sample = 0x8F000120;
++goldenpad_recomp_fire_rate_guard_sample = 0x8F000124;
++goldenpad_recomp_consume_reload = 0x8F000128;
++goldenpad_recomp_consume_inventory_slot = 0x8F00012C;
 diff --git a/patches/workbench_theboy.c b/patches/workbench_theboy.c
-index d4424c7..64f6206 100644
+index d4424c7..aeb865b 100644
 --- a/patches/workbench_theboy.c
 +++ b/patches/workbench_theboy.c
-@@ -473,6 +473,99 @@ void InitFrameRateControl(void)
+@@ -473,6 +473,182 @@ void InitFrameRateControl(void)
  extern s32 g_DebugMode;
  extern s32 g_DebugHighlightedOption;
  
@@ -65,26 +76,47 @@ index d4424c7..64f6206 100644
 +    return goldenpad_recomp_unlock_all_missions_enabled();
 +}
 +
++static f32 goldenpadWrapTankAngle(f32 angle)
++{
++    while (angle < 0.0f) {
++        angle += M_TAU_F;
++    }
++    while (angle >= M_TAU_F) {
++        angle -= M_TAU_F;
++    }
++    return angle;
++}
++
 +static void goldenpadApplyModernTouchControls(void)
 +{
++    static s32 crouched[4] = {FALSE, FALSE, FALSE, FALSE};
 +    s32 playernum = get_cur_playernum();
 +    s32 inventorySlot;
-+    const u32 disableCrouchFlag = 0x8000u;
-+    const s32 crouchSquat = 0;
 +    f32 lookX = 0.0f;
 +    f32 lookY = 0.0f;
 +    f32 degreesPerFrame;
++    s32 tankRunning;
++    const s32 tankRunStateRunning = 2; /* TANK_RUN_STATE_RUNNING in bondconstants.h */
 +
 +    if (goldenpad_recomp_consume_return_to_title()) {
++        crouched[0] = FALSE;
++        crouched[1] = FALSE;
++        crouched[2] = FALSE;
++        crouched[3] = FALSE;
 +        if (g_StageNum != LEVELID_TITLE) {
 +            bossRunTitleStage();
 +        }
 +        return;
 +    }
 +
++    tankRunning = g_PlayerIsInTank == 1 &&
++        g_PlayerTankProp != NULL &&
++        g_EnterTankAudioState == tankRunStateRunning;
++
 +    if (playernum < 0 || playernum >= 4 || g_StageNum == LEVELID_TITLE || g_CurrentPlayer == NULL ||
 +        g_CurrentPlayer->prop == NULL || g_CurrentPlayer->bonddead) {
 +        if (playernum >= 0 && playernum < 4) {
++            crouched[playernum] = FALSE;
 +            goldenpad_recomp_consume_crouch_toggle(playernum);
 +            goldenpad_recomp_consume_reload(playernum);
 +            goldenpad_recomp_consume_inventory_slot(playernum);
@@ -92,49 +124,75 @@ index d4424c7..64f6206 100644
 +        return;
 +    }
 +
-+    if (lvlGetControlsLockedFlag() || g_CurrentPlayer->watch_animation_state != 0 ||
-+        !g_CurrentPlayer->outside_watch_menu || g_CurrentPlayer->open_close_solo_watch_menu != 0 ||
-+        g_CurrentPlayer->mpmenuon) {
++    if (g_CurrentPlayer->watch_animation_state == 0 &&
++        g_CurrentPlayer->outside_watch_menu != 0 &&
++        g_CurrentPlayer->open_close_solo_watch_menu == 0) {
 +        recomp_get_camera_inputs(playernum, &lookX, &lookY);
-+        goldenpad_recomp_consume_crouch_toggle(playernum);
++    } else {
++        /* Drain a final queued sample without moving the camera behind the watch. */
++        recomp_get_camera_inputs(playernum, &lookX, &lookY);
 +        goldenpad_recomp_consume_reload(playernum);
 +        goldenpad_recomp_consume_inventory_slot(playernum);
-+        return;
++        lookX = 0.0f;
++        lookY = 0.0f;
 +    }
 +
-+    recomp_get_camera_inputs(playernum, &lookX, &lookY);
++    /* The native 45-tick hatch transition owns the camera and movement until
++     * the tank reaches its running state. Drain modern look without applying it. */
++    if (g_PlayerIsInTank == 1 && !tankRunning) {
++        lookX = 0.0f;
++        lookY = 0.0f;
++    }
++
 +    if (lookX != 0.0f || lookY != 0.0f) {
 +        /* GoldenPad's tuned MGB64 path resolves to 3 degrees per frame at
 +         * full deflection, and one third of that while aiming. */
 +        degreesPerFrame = g_CurrentPlayer->insightaimmode ? 1.0f : 3.0f;
-+        g_CurrentPlayer->vv_theta += lookX * degreesPerFrame;
++        if (tankRunning) {
++            /* Mounted yaw is rebuilt from these authoritative turret values
++             * every simulation tick. Shift target and smoothed orientation
++             * together so relative look remains proportional and native tank
++             * steering, collision rollback, and interpolation stay in charge. */
++            const f32 delta = lookX * degreesPerFrame * (M_TAU_F / 360.0f);
++            g_TankTurretAngle = goldenpadWrapTankAngle(g_TankTurretAngle + delta);
++            g_TankTurretOrientationAngleRad = goldenpadWrapTankAngle(
++                g_TankTurretOrientationAngleRad + delta);
++            /* US/NTSC tank smoothing is 0.92, so this accumulator stores
++             * current / (1 - smoothing), exactly as native bondview2 does. */
++            g_TankTurretOrientationAngleDeg = g_TankTurretOrientationAngleRad / 0.08f;
++        } else {
++            g_CurrentPlayer->vv_theta += lookX * degreesPerFrame;
++            while (g_CurrentPlayer->vv_theta < 0.0f) {
++                g_CurrentPlayer->vv_theta += 360.0f;
++            }
++            while (g_CurrentPlayer->vv_theta >= 360.0f) {
++                g_CurrentPlayer->vv_theta -= 360.0f;
++            }
++        }
 +        g_CurrentPlayer->vv_verta += lookY * degreesPerFrame;
-+
-+        while (g_CurrentPlayer->vv_theta < 0.0f) {
-+            g_CurrentPlayer->vv_theta += 360.0f;
-+        }
-+        while (g_CurrentPlayer->vv_theta >= 360.0f) {
-+            g_CurrentPlayer->vv_theta -= 360.0f;
-+        }
 +        if (g_CurrentPlayer->vv_verta > 90.0f) {
 +            g_CurrentPlayer->vv_verta = 90.0f;
 +        }
-+        if (g_CurrentPlayer->vv_verta < -90.0f) {
-+            g_CurrentPlayer->vv_verta = -90.0f;
++        if (g_CurrentPlayer->vv_verta < (tankRunning ? -20.0f : -90.0f)) {
++            g_CurrentPlayer->vv_verta = tankRunning ? -20.0f : -90.0f;
 +        }
 +        g_CurrentPlayer->vv_verta360 = g_CurrentPlayer->vv_verta;
 +        if (g_CurrentPlayer->vv_verta360 < 0.0f) {
 +            g_CurrentPlayer->vv_verta360 += 360.0f;
 +        }
-+        g_CurrentPlayer->speedtheta = 0.0f;
++        /* Native tank aiming deliberately preserves hull velocity. Outside the
++         * tank, cancel native yaw so modern right-stick yaw is not doubled. */
++        if (!tankRunning) {
++            g_CurrentPlayer->speedtheta = 0.0f;
++        }
 +        g_CurrentPlayer->speedverta = 0.0f;
 +        bondviewApplyVertaTheta();
 +    }
 +
 +    if (goldenpad_recomp_consume_crouch_toggle(playernum)) {
-+        if (!bondwalkItemCheckBitflags(getCurrentPlayerWeaponId(GUNRIGHT), disableCrouchFlag)) {
-+            currentPlayerAdjustCrouchPos(currentPlayerGetCrouchPos() == crouchSquat ? 2 : -2);
-+        }
++        crouched[playernum] = !crouched[playernum];
++        /* GoldenEye's native crouch enum is squat=0, half=1, stand=2. */
++        g_CurrentPlayer->crouchpos = crouched[playernum] ? 0 : 2;
 +    }
 +
 +    if (goldenpad_recomp_consume_reload(playernum)) {
@@ -153,14 +211,55 @@ index d4424c7..64f6206 100644
 +    }
 +}
 +
++static void goldenpadSampleGuardFire(struct ChrRecord* chr, s32 hand)
++{
++    PropRecord* weaponProp = chrGetEquippedWeaponProp(chr, hand);
++    u8* chrBytes = (u8*) chr;
++    s32 item = -1;
++    u8 before = chrBytes[0x04 + hand];
++
++    if (weaponProp != NULL && weaponProp->chr != NULL) {
++        item = ((s8*) weaponProp->chr)[0x80];
++    }
++
++    chrlvFireWeaponRelated(chr, hand);
++    goldenpad_recomp_fire_rate_guard_sample(
++        item, before, chrBytes[0x04 + hand], ((u32) chr & ~1u) | (u32) hand);
++}
++
++RECOMP_PATCH void chrlvTriggerFireWeapon(struct ChrRecord* chr)
++{
++    const u16 fireWeaponLeft = 0x0004;
++    const u16 fireWeaponRight = 0x0008;
++    const u16 fireTracer = 0x0080;
++    u16* hidden = (u16*) &((u8*) chr)[0x12];
++
++    *hidden &= ~fireTracer;
++
++    if (*hidden & fireWeaponRight) {
++        goldenpadSampleGuardFire(chr, GUNRIGHT);
++        *hidden &= ~fireWeaponRight;
++    }
++
++    if (*hidden & fireWeaponLeft) {
++        goldenpadSampleGuardFire(chr, GUNLEFT);
++        *hidden &= ~fireWeaponLeft;
++    }
++}
++
  RECOMP_PATCH void bossMainloop(void) {
      // declarations
  
-@@ -702,6 +795,7 @@ RECOMP_PATCH void bossMainloop(void) {
+@@ -702,6 +878,12 @@ RECOMP_PATCH void bossMainloop(void) {
                                      viSetViewPosition(localPlayer->viewleft, localPlayer->viewtop);
  
                                      lvlViewMoveTick();
 +                                    goldenpadApplyModernTouchControls();
++                                    goldenpad_recomp_fire_rate_player_sample(
++                                        get_cur_playernum(),
++                                        g_CurrentPlayer->hands[GUNRIGHT].weaponnum,
++                                        g_CurrentPlayer->hands[GUNRIGHT].weapon_ammo_in_magazine,
++                                        g_CurrentPlayer->hands[GUNRIGHT].field_88C);
                                  }
                              }
  

--- a/scripts/package-recomp-macos-alpha.sh
+++ b/scripts/package-recomp-macos-alpha.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "$0")/.." && pwd)
+"$repo_root/scripts/verify-recomp-input-matrix.sh"
+
 app_path=${GOLDENPAD_RECOMP_MAC_APP:-"$repo_root/build-recomp-macos-stable/Release/GoldenPad.app"}
-release_name=${GOLDENPAD_RELEASE_NAME:-0.1.0-preview.3}
+release_name=${GOLDENPAD_RELEASE_NAME:-0.1.0-preview.4}
 output_name="GoldenPad-${release_name}-macos-arm64-alpha.zip"
 output_path="$repo_root/dist/$output_name"
 

--- a/scripts/package-recomp-prototype-ipa.sh
+++ b/scripts/package-recomp-prototype-ipa.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 repo_root=$(cd "$(dirname "$0")/.." && pwd)
+"$repo_root/scripts/verify-recomp-input-matrix.sh"
+
 app_path=${GOLDENPAD_RECOMP_APP:-"$repo_root/build-recomp-prototype-device/Release-iphoneos/GoldenPadRecompPrototype.app"}
-release_name=${GOLDENPAD_RELEASE_NAME:-0.1.0-preview.3}
+release_name=${GOLDENPAD_RELEASE_NAME:-0.1.0-preview.4}
 output_name="GoldenPad-${release_name}-unsigned.ipa"
 output_path="$repo_root/dist/$output_name"
 

--- a/scripts/verify-recomp-input-matrix.sh
+++ b/scripts/verify-recomp-input-matrix.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/goldenpad-input-matrix.XXXXXX")
+trap 'rm -rf "$test_root"' EXIT HUP INT TERM
+reference_root="$repo_root/ref/goldeneye64recomp"
+tracked_patch="$repo_root/patches/goldeneye64recomp-ios-modern-controls.patch"
+generated_patch="$reference_root/RecompiledPatches/patches.c"
+
+xcrun swiftc \
+  -module-cache-path "$test_root/swift-module-cache" \
+  "$repo_root/Sources/RecompControlMapping.swift" \
+  "$repo_root/Tests/RecompControlMappingTests.swift" \
+  -o "$test_root/verify-recomp-input-matrix"
+
+"$test_root/verify-recomp-input-matrix"
+
+for mobile_menu_marker in \
+  'let gameplayActive = goldenPadRecompGameplayInputActive() != 0' \
+  'if !gameplayActive {' \
+  'buttons: externalButtons,' \
+  'stick: externalStick,'
+do
+  if ! grep -Fq "$mobile_menu_marker" "$repo_root/Sources/RecompPrototypeInput.swift"; then
+    echo "FAIL: mobile menu passthrough is missing $mobile_menu_marker" >&2
+    exit 1
+  fi
+done
+
+echo "PASS: mobile non-gameplay path preserves the accepted raw controller passthrough"
+
+for controller_aim_marker in \
+  'let manualAimStick = externalMapping.manualAimStick(' \
+  'stick: externalStick,' \
+  'externalMovement.stick = manualAimStick' \
+  'publishedControllerLook = .zero'
+do
+  if ! grep -Fq "$controller_aim_marker" "$repo_root/Sources/RecompPrototypeInput.swift"; then
+    echo "FAIL: native manual-aim routing is missing $controller_aim_marker" >&2
+    exit 1
+  fi
+done
+
+if ! grep -Fq 'if (aiming && invertAimY.load(std::memory_order_relaxed)) {' \
+  "$repo_root/Support/RecompPrototype/recomp_game_start.cpp"; then
+  echo "FAIL: shared vertical Aim polarity is missing" >&2
+  exit 1
+fi
+if grep -Fq 'if (aiming && !invertAimY.load(std::memory_order_relaxed)) {' \
+  "$repo_root/Support/RecompPrototype/recomp_game_start.cpp"; then
+  echo "FAIL: mobile vertical Aim polarity is still reversed" >&2
+  exit 1
+fi
+
+echo "PASS: external-controller on-foot Aim uses native manual-sight routing"
+
+if ! grep -Fq 'constexpr float kControllerHipDegreesPerFrame = 1.872f;' \
+  "$repo_root/Support/RecompPrototype/recomp_game_start.cpp"; then
+  echo "FAIL: Preview 4 controller sensitivity is not the accepted baseline plus 20 percent" >&2
+  exit 1
+fi
+
+echo "PASS: Preview 4 external-controller look rate is 1.872 degrees per frame"
+
+mkdir -p "$test_root/reference-clean"
+git -C "$reference_root" archive -o "$test_root/reference.tar" HEAD
+tar -xf "$test_root/reference.tar" -C "$test_root/reference-clean"
+git -C "$test_root/reference-clean" apply "$tracked_patch"
+
+for source_path in \
+  patches/externs.h \
+  patches/patches.h \
+  patches/syms.ld \
+  patches/workbench_theboy.c
+do
+  if ! cmp "$test_root/reference-clean/$source_path" "$reference_root/$source_path"; then
+    echo "FAIL: tracked patch output differs from build input $source_path" >&2
+    exit 1
+  fi
+done
+
+for marker in \
+  'goldenpad_recomp_consume_reload' \
+  'goldenpad_recomp_consume_inventory_slot' \
+  'goldenpad_recomp_fire_rate_player_sample' \
+  'goldenpad_recomp_fire_rate_guard_sample' \
+  'MEM_W(ctx->r1, 0X6248)' \
+  'MEM_W(ctx->r23, 0X6250)' \
+  'MEM_W(0X6284' \
+  'MEM_W(0X6274' \
+  'MEM_W(0X6278' \
+  'MEM_W(ctx->r1, -0X6848)'
+do
+  if ! grep -Fq "$marker" "$generated_patch"; then
+    echo "FAIL: generated patches.c is missing tank-state marker $marker" >&2
+    exit 1
+  fi
+done
+
+echo "PASS: tracked patch matches build input and generated control/tank markers are present"

--- a/scripts/verify-recomp-macos-alpha.sh
+++ b/scripts/verify-recomp-macos-alpha.sh
@@ -94,7 +94,7 @@ for required_symbol in \
   _goldenpad_recomp_consume_inventory_slot \
   _goldenpad_recomp_consume_reload \
   _goldenpad_recomp_queue_mouse_look \
-  _goldenpad_recomp_desktop_gameplay_active
+  _goldenpad_recomp_get_input_context
 do
   if ! nm -gU "$executable" | awk -v required="$required_symbol" '$3 == required { found = 1 } END { exit !found }'; then
     echo "Mac Alpha is missing required runtime symbol: $required_symbol" >&2

--- a/scripts/verify-recomp-prototype-ipa.sh
+++ b/scripts/verify-recomp-prototype-ipa.sh
@@ -32,7 +32,7 @@ fi
 test "$(plutil -extract CFBundleDisplayName raw "$app_path/Info.plist")" = "GoldenPad"
 test "$(plutil -extract CFBundleIdentifier raw "$app_path/Info.plist")" = "com.chrissotraidis.goldenpad.recomp-prototype"
 test "$(plutil -extract CFBundleShortVersionString raw "$app_path/Info.plist")" = "0.1.0"
-test "$(plutil -extract CFBundleVersion raw "$app_path/Info.plist")" = "3"
+test "$(plutil -extract CFBundleVersion raw "$app_path/Info.plist")" = "4"
 test "$(plutil -extract UIFileSharingEnabled raw "$app_path/Info.plist")" = "true"
 test "$(plutil -extract LSSupportsOpeningDocumentsInPlace raw "$app_path/Info.plist")" = "true"
 
@@ -82,6 +82,16 @@ for required_symbol in \
   _goldenpad_recomp_set_four_player_test_mode \
   _goldenpad_recomp_request_crouch_toggle \
   _goldenpad_recomp_consume_crouch_toggle \
+  _goldenpad_recomp_set_fire_rate_probe_enabled \
+  _goldenpad_recomp_set_sidestep_probe_enabled \
+  _goldenpad_recomp_set_lifecycle_probe_enabled \
+  _goldenpad_recomp_set_audio_probe_enabled \
+  _goldenpad_recomp_set_depth_rebuild_probe_enabled \
+  _goldenpad_rt64_depth_format_rebuild_stats \
+  _goldenpad_recomp_note_audio_host_rates \
+  _goldenpad_recomp_audio_probe_stats \
+  _goldenpad_recomp_gameplay_input_active \
+  _goldenpad_recomp_get_input_context \
   _goldenpad_recomp_audio_render \
   _goldenpad_recomp_import_rom \
   _goldenpad_recomp_validate_tlbfree_rom \


### PR DESCRIPTION
## Summary

- use one shared GoldenEye 1.1 through 1.4 mapping on mobile and Mac
- restore native left-stick manual Aim and raw non-gameplay menu passthrough
- repair Runway and Streets tank drive, hull turn, turret, entry, and selected-weapon behavior
- apply the requested final 20 percent external-controller look increase and ship build 4
- document physical acceptance, reporter boundary, hashes, and focused rollback

## Verification

- shared control and tank matrix passed
- complete unsigned iPhone/iPad Release build passed
- complete native arm64 Mac Release build passed
- unsigned IPA audit passed twice with identical SHA-256
- Mac Alpha archive audit passed
- ROM, save, signing, license, private-path, required-symbol, and generated-patch gates passed

Issue #17 remains open pending reporter verification on Mac.