### PR TITLE
Preview 5: restore authentic automatic fire cadence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,18 @@ if(goldenpad_apple_platform STREQUAL "mac")
                 "Generated Mac patches.c is missing ${required_bridge}; regenerate the modern-controls patch pair before building GoldenPad.")
         endif()
     endforeach()
+    foreach(required_fire_rate_marker IN ITEMS
+            "RECOMP_FUNC void bondwalkItemGetAutomaticFiringRate"
+            "MEM_B(ctx->r2, 0X22)"
+            "ctx->r1 = S32(ctx->r2 << 1)"
+            "ctx->r2 = ADD32(ctx->r1, ctx->r2)")
+        string(FIND "${goldenpad_mac_patches_text}"
+            "${required_fire_rate_marker}" goldenpad_mac_fire_rate_offset)
+        if(goldenpad_mac_fire_rate_offset EQUAL -1)
+            message(FATAL_ERROR
+                "Generated Mac patches.c is missing the TD-01 authentic-rate marker ${required_fire_rate_marker}; regenerate both embedded patch halves together.")
+        endif()
+    endforeach()
     foreach(required_tank_marker IN ITEMS
             "MEM_W(ctx->r1, 0X6248)"
             "MEM_W(ctx->r23, 0X6250)"
@@ -336,6 +348,18 @@ if(GOLDENPAD_RECOMP_PROTOTYPE)
                     "Generated RecompiledPatches/patches.c is missing ${required_bridge}. Apply patches/goldeneye64recomp-ios-modern-controls.patch and regenerate patches.c plus patches_bin.c together.")
             endif()
         endforeach()
+        foreach(required_fire_rate_marker IN ITEMS
+                "RECOMP_FUNC void bondwalkItemGetAutomaticFiringRate"
+                "MEM_B(ctx->r2, 0X22)"
+                "ctx->r1 = S32(ctx->r2 << 1)"
+                "ctx->r2 = ADD32(ctx->r1, ctx->r2)")
+            string(FIND "${goldenpad_recomp_patches_text}"
+                "${required_fire_rate_marker}" goldenpad_recomp_fire_rate_offset)
+            if(goldenpad_recomp_fire_rate_offset EQUAL -1)
+                message(FATAL_ERROR
+                    "Generated RecompiledPatches/patches.c is missing the TD-01 authentic-rate marker ${required_fire_rate_marker}; regenerate both embedded patch halves together.")
+            endif()
+        endforeach()
         foreach(required_multiplayer_patch IN ITEMS
                 "viGetViewTop"
                 "0XFFFE << 16"
@@ -449,7 +473,7 @@ if(GOLDENPAD_RECOMP_PROTOTYPE)
         MACOSX_BUNDLE_BUNDLE_NAME "GoldenPad"
         MACOSX_BUNDLE_GUI_IDENTIFIER "${GOLDENPAD_RECOMP_BUNDLE_IDENTIFIER}"
         MACOSX_BUNDLE_SHORT_VERSION_STRING "0.1.0"
-        MACOSX_BUNDLE_BUNDLE_VERSION "4"
+        MACOSX_BUNDLE_BUNDLE_VERSION "5"
         MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Config/RecompPrototypeInfo.plist.in"
         XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "${goldenpad_recomp_code_signing_allowed}"
         XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "${goldenpad_recomp_code_signing_required}"

--- a/Config/RecompPrototypeInfo.plist.in
+++ b/Config/RecompPrototypeInfo.plist.in
@@ -34,7 +34,7 @@
     <key>CFBundleShortVersionString</key>
     <string>0.1.0</string>
     <key>CFBundleVersion</key>
-    <string>4</string>
+    <string>5</string>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.games</string>
     <key>LSRequiresIPhoneOS</key>

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You need an iPhone or iPad running iOS/iPadOS 17 or later, a Mac or Windows
 computer, an Apple ID, and your own original US GoldenEye 007 Nintendo 64 ROM.
 
 > **No jailbreak or JIT is required. Do not search for a TLB-free ROM.**
-> Preview 4 accepts your ordinary `.z64`, `.v64`, `.n64`, or `.rom` dump and
+> Preview 5 accepts your ordinary `.z64`, `.v64`, `.n64`, or `.rom` dump and
 > prepares the required private runtime copy automatically on the device.
 
 1. Install **AltStore Classic** by following its official
@@ -63,7 +63,7 @@ computer, an Apple ID, and your own original US GoldenEye 007 Nintendo 64 ROM.
    Use AltStore Classic with AltServer, not AltStore PAL. PAL cannot install an
    arbitrary unsigned `.ipa` downloaded from GitHub.
 2. Download
-   [`GoldenPad-0.1.0-preview.4-unsigned.ipa`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.4/GoldenPad-0.1.0-preview.4-unsigned.ipa).
+   [`GoldenPad-0.1.0-preview.5-unsigned.ipa`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.5/GoldenPad-0.1.0-preview.5-unsigned.ipa).
    This is the iPhone/iPad app. Do not download the separate Mac `.zip`.
 3. Open AltStore Classic on the device, go to **My Apps**, tap **+**, and choose
    the downloaded GoldenPad `.ipa` from Files. Follow iOS's prompts to trust
@@ -113,17 +113,18 @@ the repository or application package.
 | Option | Status | What to do |
 |---|---|---|
 | Local Simulator build | **Verified** | Build with the complete verifier below, then run from Xcode or `simctl`. |
-| Local iPhone/iPad build | **Preview 4 controls accepted** | The user accepted menu, on-foot Aim, Runway tank drive/turn/turret/weapon behavior, exit/re-entry, and a Facility regression pass on physical iPad. The final requested 20% right-stick increase is build and matrix verified. |
-| Native Apple-Silicon Mac build | **Preview 4 Alpha** | GoldenPad officially supports Apple Silicon Macs in Alpha status. [Download the separate arm64 Mac Alpha](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.4/GoldenPad-0.1.0-preview.4-macos-arm64-alpha.zip); issue #17 reporter verification, the thin far-right blue edge, and broader sustained-performance coverage remain open. |
-| Unsigned `.ipa` | **Audited Preview 4** | Follow [Play on iPhone or iPad](#play-on-iphone-or-ipad) to install the public unsigned IPA with AltStore Classic. |
-| GitHub release | **Preview 4** | [Release notes, downloads and SHA-256](https://github.com/chrissotraidis/goldenpad/releases/tag/v0.1.0-preview.4). |
+| Local iPhone/iPad build | **Preview 5 accepted** | Preview 4's menu, Aim, tank, and sensitivity baseline is unchanged. Physical telemetry confirms Preview 5's corrected automatic-fire cadence at 12 Phantom shots/100 ticks, with accepted controls and gameplay. |
+| Native Apple-Silicon Mac build | **Preview 5 Alpha** | GoldenPad officially supports Apple Silicon Macs in Alpha status. [Download the separate arm64 Mac Alpha](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.5/GoldenPad-0.1.0-preview.5-macos-arm64-alpha.zip); issue #17 reporter verification, the thin far-right blue edge, and broader sustained-performance coverage remain open. |
+| Unsigned `.ipa` | **Audited Preview 5** | Follow [Play on iPhone or iPad](#play-on-iphone-or-ipad) to install the public unsigned IPA with AltStore Classic. |
+| GitHub release | **Preview 5** | [Release notes, downloads and SHA-256](https://github.com/chrissotraidis/goldenpad/releases/tag/v0.1.0-preview.5). |
 | App Store / TestFlight | **Not announced** | Store distribution requires separate rights, signing, review, and device acceptance. |
 
 The mobile baseline was accepted through normal single-player gameplay on a
 physical iPhone and iPad, including the editable touch layout and Xbox/MFi
-controller path. Preview 4 retains the bounded in-app ROM importer and frozen
-experimental multiplayer render repair, automatically follows GoldenEye's
-active 1.1 through 1.4 control style, and repairs the Runway/Streets tank path.
+controller path. Preview 5 retains the bounded in-app ROM importer, frozen
+experimental multiplayer render repair, Preview 4 shared control mapping, and
+Runway/Streets tank path while correcting player and guard automatic-fire
+cadence.
 Longer thermal/route sweeps
 and complete multiplayer acceptance remain open. This developer preview must
 not be described as App Store-ready.
@@ -137,7 +138,7 @@ mobile-parity or notarized Mac release.
 |---|---|
 | Native runtime | Statically recompiled game code runs as Apple ARM64; no JIT or emulator wrapper |
 | Rendering | RT64 presents high-resolution Metal output on physical iPad hardware |
-| Setup | Preview 4 imports the user's original NTSC-U retail dump from Files and converts it privately on device; no game data is included |
+| Setup | Preview 5 imports the user's original NTSC-U retail dump from Files and converts it privately on device; no game data is included |
 | Gameplay | Original front end and live Dam/Facility gameplay render and accept normal input |
 | Touch | Tuned GoldenPad move and relative-look zones plus aim, fire, action, weapon, duck, and Start controls |
 | Customization | Separate persisted iPhone/iPad layouts with per-control drag, resize, opacity and reset, plus look sensitivity and hold/toggle aim |
@@ -168,10 +169,10 @@ emulator. Another N64 game or GoldenEye revision cannot be substituted.
 
 ## Release files and advanced setup
 
-### Preview 4 downloads
+### Preview 5 downloads
 
 Download
-[`GoldenPad-0.1.0-preview.4-unsigned.ipa`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.4/GoldenPad-0.1.0-preview.4-unsigned.ipa)
+[`GoldenPad-0.1.0-preview.5-unsigned.ipa`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.5/GoldenPad-0.1.0-preview.5-unsigned.ipa)
 and its adjacent `.sha256` file. The IPA is intentionally unsigned. Follow
 [Play on iPhone or iPad](#play-on-iphone-or-ipad) for the supported AltStore
 Classic installation path.
@@ -182,10 +183,10 @@ the required TLB-free transformation privately on the device, verifies the
 exact output, and starts the native runtime automatically. A valid Preview 1
 `GoldenEye_TLBFREE.z64` is reused unchanged during an in-place update. See the
 [Preview 2 ROM import design and acceptance record](docs/PREVIEW_2_ROM_IMPORT.md),
-which Preview 4 retains unchanged.
+which Preview 5 retains unchanged.
 
 The separate Apple-Silicon Mac Alpha is
-[`GoldenPad-0.1.0-preview.4-macos-arm64-alpha.zip`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.4/GoldenPad-0.1.0-preview.4-macos-arm64-alpha.zip).
+[`GoldenPad-0.1.0-preview.5-macos-arm64-alpha.zip`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.5/GoldenPad-0.1.0-preview.5-macos-arm64-alpha.zip).
 It is an ad-hoc-signed, non-notarized arm64 app and remains below mobile release
 quality. It uses the same user-supplied-data boundary and must not be described
 as mobile parity.
@@ -193,7 +194,7 @@ as mobile parity.
 <details>
 <summary><strong>Preview 1 manual setup (legacy only)</strong></summary>
 
-> **Preview 2, Preview 3, and Preview 4 users do not need these steps or a prebuilt TLB-free ROM.** This
+> **Preview 2, Preview 3, Preview 4, and Preview 5 users do not need these steps or a prebuilt TLB-free ROM.** This
 > section is retained only for people intentionally running the older Preview 1
 > artifact.
 
@@ -223,7 +224,7 @@ resident in Expansion Pak memory and stores the original compressed data segment
 uncompressed in the layout expected by the recompiled code. The unmodified retail
 ROM has a different layout, so Preview 1 cannot read it directly. This is a
 technical limitation of the current build, not a DRM check. Preview 2 and
-Preview 3 and Preview 4 perform this same private conversion inside GoldenPad so users can
+Preview 3, Preview 4, and Preview 5 perform this same private conversion inside GoldenPad so users can
 select their ordinary retail dump directly; Preview 1 still needs the manual
 process below.
 
@@ -268,7 +269,7 @@ retail input and generated output remain yours and must not be redistributed.
 > currently be reproduced from the public checkout alone because its generated
 > game-code inputs are private and intentionally untracked. The public build
 > commands below produce the older `GoldenPad Legacy` fallback. To use the
-> current primary release, follow **Preview 4** and **First launch** instead.
+> current primary release, follow **Preview 5** and **First launch** instead.
 
 You need:
 
@@ -331,7 +332,7 @@ reference path.
 
 GoldenPad never downloads or bundles game data.
 
-1. Install the unsigned Preview 4 IPA by following
+1. Install the unsigned Preview 5 IPA by following
    [Play on iPhone or iPad](#play-on-iphone-or-ipad).
 2. Launch GoldenPad and choose your own supported original NTSC-U retail ROM
    from Files. The importer accepts `.z64`, `.v64`, `.n64`, and `.rom` byte
@@ -368,7 +369,7 @@ the game runtime are separate stages with different fixes.
   PAL, Japanese, modified, overdumped, and other revisions are rejected.
 - `.z64`, `.v64`, `.n64`, and `.rom` are accepted. Renaming another file or ROM
   does not change its contents and will not pass validation.
-- Preview 4 performs the TLB-free conversion itself. Do not download, request,
+- Preview 5 performs the TLB-free conversion itself. Do not download, request,
   or manually create a TLB-free ROM for the current release.
 - If GoldenPad cannot read a valid file from a cloud or third-party provider,
   copy it into **On My iPhone** or **On My iPad** in Files and try again.
@@ -493,13 +494,14 @@ MGB64 symbols. The older MGB64 IPA workflow remains a fallback only.
 
 ## Current limitations
 
-- Automatic player/guard weapon cadence is not yet timing-authentic at the
-  primary runtime's native 60 Hz. A deterministic measurement gate is required
-  before changing the accepted combat feel.
-- Preview 4 replaces the separate movement adapter with one shared mapping that
+- Preview 5 fixes native-60-Hz automatic player/guard firing cadence through
+  one shared source-derived interval conversion. It does not change semi-auto
+  classifications, first-shot behavior, damage, ammunition, or controls.
+- Preview 4 replaced the separate movement adapter with one shared mapping that
   follows GoldenEye's active 1.1 through 1.4 control style. Physical iPad
   testing accepted normal movement, native left-stick Aim, and Runway tank
-  controls. Issue #17 remains open until the Mac reporter confirms the release
+  controls; Preview 5 retains it unchanged. Issue #17 remains open until the
+  Mac reporter confirms the release
   ([issue #17](https://github.com/chrissotraidis/goldenpad/issues/17)).
 - A deterministic first-frame RT64/Metal crash is reported on an A12X iPad Pro
   with Preview 1. A12-family hardware is not yet validated; the compatibility
@@ -508,7 +510,7 @@ MGB64 symbols. The older MGB64 IPA workflow remains a fallback only.
   Slight lighting flicker and real three/four-controller routing remain open.
 - Peer-to-peer, LAN, internet, relay, and rollback multiplayer are not
   implemented.
-- Preview 4 retains Preview 2's complete, package-audited in-app retail-ROM conversion.
+- Preview 5 retains Preview 2's complete, package-audited in-app retail-ROM conversion.
   A clean physical-iPhone installation has reached the empty-container setup
   screen; fresh real-ROM import, wrong-ROM, cancellation and low-storage
   coverage remains open in the focused importer acceptance record.
@@ -545,8 +547,8 @@ retained only as the deprecated legacy fallback.
 <details>
 <summary><strong>Where is the IPA?</strong></summary>
 
-Preview 4 is available from the
-[GitHub release](https://github.com/chrissotraidis/goldenpad/releases/tag/v0.1.0-preview.4).
+Preview 5 is available from the
+[GitHub release](https://github.com/chrissotraidis/goldenpad/releases/tag/v0.1.0-preview.5).
 It is an unsigned, ROM-free developer-preview IPA and must be re-signed. It does
 not include game data; follow [Play on iPhone or iPad](#play-on-iphone-or-ipad)
 for installation and first-launch instructions.
@@ -556,9 +558,10 @@ for installation and first-launch instructions.
 <summary><strong>Do I need JIT or a TLB-free ROM?</strong></summary>
 
 No. GoldenPad's game code is compiled ahead of time, so the iPhone/iPad release
-does not need JIT. Preview 4 accepts the supported original US retail dump and
+does not need JIT. Preview 5 accepts the supported original US retail dump and
 creates the required TLB-free runtime copy privately on the device. Do not use
-the old Preview 1 manual conversion instructions for Preview 2, Preview 3, or Preview 4.
+the old Preview 1 manual conversion instructions for Preview 2, Preview 3,
+Preview 4, or Preview 5.
 </details>
 
 <details>
@@ -623,6 +626,7 @@ override those current authority documents.
 | [`docs/RELEASE_CHECKLIST.md`](docs/RELEASE_CHECKLIST.md) | Clean-checkout, package, signing, and publication gates |
 | [`docs/RELEASE_NOTES_0.1.0-preview.3.md`](docs/RELEASE_NOTES_0.1.0-preview.3.md) | Preview 3 downloads, checksums, controls update and disclosed limitations |
 | [`docs/RELEASE_NOTES_0.1.0-preview.4.md`](docs/RELEASE_NOTES_0.1.0-preview.4.md) | Preview 4 tank, Aim, shared control mapping, checksums, and acceptance boundary |
+| [`docs/RELEASE_NOTES_0.1.0-preview.5.md`](docs/RELEASE_NOTES_0.1.0-preview.5.md) | Preview 5 automatic-fire authenticity repair, checksums, physical evidence, and rollback boundary |
 | [`docs/PREVIEW_4_BASELINE.md`](docs/PREVIEW_4_BASELINE.md) | Frozen Preview 4 source, artifact, accepted-behavior, diagnostic, and rollback identity |
 | [`docs/TD01_FIRE_RATE_LOOP.md`](docs/TD01_FIRE_RATE_LOOP.md) | Bounded fire-rate measurement sequence and mandatory gameplay stop gate |
 | [`docs/MULTIPLAYER_ROADMAP.md`](docs/MULTIPLAYER_ROADMAP.md) | Local ownership, determinism, LAN research, network feasibility, and go/no-go gates |

--- a/README.md
+++ b/README.md
@@ -623,8 +623,10 @@ override those current authority documents.
 | [`docs/RELEASE_CHECKLIST.md`](docs/RELEASE_CHECKLIST.md) | Clean-checkout, package, signing, and publication gates |
 | [`docs/RELEASE_NOTES_0.1.0-preview.3.md`](docs/RELEASE_NOTES_0.1.0-preview.3.md) | Preview 3 downloads, checksums, controls update and disclosed limitations |
 | [`docs/RELEASE_NOTES_0.1.0-preview.4.md`](docs/RELEASE_NOTES_0.1.0-preview.4.md) | Preview 4 tank, Aim, shared control mapping, checksums, and acceptance boundary |
+| [`docs/PREVIEW_4_BASELINE.md`](docs/PREVIEW_4_BASELINE.md) | Frozen Preview 4 source, artifact, accepted-behavior, diagnostic, and rollback identity |
+| [`docs/TD01_FIRE_RATE_LOOP.md`](docs/TD01_FIRE_RATE_LOOP.md) | Bounded fire-rate measurement sequence and mandatory gameplay stop gate |
 | [`docs/MULTIPLAYER_ROADMAP.md`](docs/MULTIPLAYER_ROADMAP.md) | Local ownership, determinism, LAN research, network feasibility, and go/no-go gates |
-| [`docs/EXTERNAL_REVIEW_2026-08-22.md`](docs/EXTERNAL_REVIEW_2026-08-22.md) | Preserved independent revision-2 review plus maintained disposition against Preview 3; supporting evidence, not current authority |
+| [`docs/EXTERNAL_REVIEW_2026-08-22.md`](docs/EXTERNAL_REVIEW_2026-08-22.md) | Preserved independent revision-2 review; supporting evidence reconciled by current authority documents |
 | [`docs/EXTERNAL_TECHNICAL_REVIEW_HANDOFF.md`](docs/EXTERNAL_TECHNICAL_REVIEW_HANDOFF.md) | Read-only expert-review prompt for confidence-ranked analysis of the hardest remaining defects |
 | [`docs/MACOS_NATIVE_FEASIBILITY_2026-08-21.md`](docs/MACOS_NATIVE_FEASIBILITY_2026-08-21.md) | Native Mac architecture, evidence and Alpha boundary |
 | [`docs/LEGAL.md`](docs/LEGAL.md) | ROM, source, licensing, and distribution boundary |

--- a/Support/RecompPrototype/recomp_game_start.cpp
+++ b/Support/RecompPrototype/recomp_game_start.cpp
@@ -421,6 +421,7 @@ float readGameFloat(uint8_t *rdram, uint32_t address) {
 
 constexpr uint32_t kFireRateWindowTicks = 100;
 constexpr uint32_t kFireRateProbeRunLimit = 3;
+constexpr uint32_t kFireRateMinimumMagazineEvents = 15;
 constexpr uint8_t kKf7SovietItem = 8;
 constexpr uint8_t kKf7SovietRawRate = 3;
 
@@ -455,6 +456,22 @@ GuardFireRateWindow guardFireRateWindow;
 bool isAutomaticPlayerWeapon(int32_t weapon) {
     // GoldenEye's full-auto group runs from the Skorpion through the RC-P90.
     return weapon >= 7 && weapon <= 14;
+}
+
+void completePlayerFireRateWindow(const char *reason) {
+    logEvent("fire-rate-probe",
+        "player run=%u complete reason=%s ticks=%u weapon=%d events=%u ammo=%d->%d counter=%d->%d",
+        playerFireRateWindow.runs + 1,
+        reason,
+        playerFireRateWindow.ticks,
+        playerFireRateWindow.weapon,
+        playerFireRateWindow.shotEvents,
+        playerFireRateWindow.startingAmmo,
+        playerFireRateWindow.endingAmmo,
+        playerFireRateWindow.startingCounter,
+        playerFireRateWindow.endingCounter);
+    ++playerFireRateWindow.runs;
+    playerFireRateWindow.active = false;
 }
 
 void completeGuardFireRateWindow(uint64_t simulationTick) {
@@ -1058,6 +1075,19 @@ extern "C" void goldenpad_recomp_fire_rate_player_sample(
     const int32_t previousAmmo = playerFireRateWindow.lastAmmo;
     const uint32_t shotEvents = playerFireRateWindow.lastWeapon == weapon &&
         previousAmmo > ammo ? static_cast<uint32_t>(previousAmmo - ammo) : 0;
+
+    if (playerFireRateWindow.active &&
+        playerFireRateWindow.lastWeapon == weapon &&
+        previousAmmo >= 0 && ammo > previousAmmo) {
+        logEvent("fire-rate-probe",
+            "player run=%u abort reason=reload ticks=%u weapon=%d ammo=%d->%d",
+            playerFireRateWindow.runs + 1,
+            playerFireRateWindow.ticks,
+            weapon,
+            previousAmmo,
+            ammo);
+        playerFireRateWindow.active = false;
+    }
     playerFireRateWindow.lastWeapon = weapon;
     playerFireRateWindow.lastAmmo = ammo;
     if (!playerFireRateWindow.active) {
@@ -1091,19 +1121,11 @@ extern "C" void goldenpad_recomp_fire_rate_player_sample(
     playerFireRateWindow.endingAmmo = ammo;
     playerFireRateWindow.endingCounter = counter;
     ++playerFireRateWindow.ticks;
-    if (playerFireRateWindow.ticks >= kFireRateWindowTicks) {
-        logEvent("fire-rate-probe",
-            "player run=%u complete ticks=%u weapon=%d events=%u ammo=%d->%d counter=%d->%d",
-            playerFireRateWindow.runs + 1,
-            playerFireRateWindow.ticks,
-            playerFireRateWindow.weapon,
-            playerFireRateWindow.shotEvents,
-            playerFireRateWindow.startingAmmo,
-            playerFireRateWindow.endingAmmo,
-            playerFireRateWindow.startingCounter,
-            playerFireRateWindow.endingCounter);
-        ++playerFireRateWindow.runs;
-        playerFireRateWindow.active = false;
+    if (playerFireRateWindow.endingAmmo == 0 &&
+        playerFireRateWindow.shotEvents >= kFireRateMinimumMagazineEvents) {
+        completePlayerFireRateWindow("magazine-empty");
+    } else if (playerFireRateWindow.ticks >= kFireRateWindowTicks) {
+        completePlayerFireRateWindow("fixed-window");
     }
 }
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -27,7 +27,7 @@ package with:
 ```sh
 ./scripts/package-recomp-prototype-ipa.sh
 ./scripts/verify-recomp-prototype-ipa.sh \
-  dist/GoldenPad-0.1.0-preview.4-unsigned.ipa
+  dist/GoldenPad-0.1.0-preview.5-unsigned.ipa
 ```
 
 The packager copies the signed app into a temporary staging directory, removes
@@ -42,19 +42,20 @@ validation stay inside the app container. An in-place update reuses an existing
 valid `GoldenEye_TLBFREE.z64`. No retail input, save, generated source, signing
 identity, or provisioning profile is placed in the IPA.
 
-The audited Preview 4 IPA SHA-256 is
-`ff163b0af6b54596590da8e39cbaff0b388b69f1607ca34f62ce61e7fe144130`.
-The physically accepted test baseline is frozen separately. The final public
-build adds the user's requested 20 percent controller-look increase and has
-complete build, matrix, and package evidence, but not a second physical pass.
+The audited Preview 5 IPA SHA-256 is
+`d4d6c6d7a00e79d1dd4759a97f3ae544c6112dff7c00ea9e57e21199a25c0db7`.
+Preview 5 retains
+the frozen Preview 4 controls/tank baseline and adds only the physically
+accepted shared automatic-fire interval repair plus its default-off diagnostic.
 
 ## Native Apple-Silicon Mac alpha
 
 The Mac app is a separate native arm64 artifact, not a Catalyst build and not
 part of the mobile `.ipa`. It is an Alpha below the accepted iPhone/iPad
 single-player quality bar. Preview 3's exact mouse/keyboard control build has
-hands-on acceptance. Preview 4 compiles and package-audits the shared control
-repair, while issue #17 reporter gameplay verification remains open. The thin
+hands-on acceptance. Preview 5 retains Preview 4's shared control repair and
+adds the same player/guard automatic-fire conversion, while issue #17 reporter
+gameplay verification remains open. The thin
 far-right blue edge, older-OS coverage, and
 sustained-performance depth remain open; keep renderer work independent from
 the accepted input contract.
@@ -86,8 +87,8 @@ signature, and runs the Mac artifact audit. No ROM, save, generated source or
 Apple signing identity is included.
 
 The audited Alpha archive is
-`dist/GoldenPad-0.1.0-preview.4-macos-arm64-alpha.zip` at SHA-256
-`63bec02ad6e323a213f9cb9d15f763a58d6eb7bd4a1a40af6341a4fb8fb333ba`.
+`dist/GoldenPad-0.1.0-preview.5-macos-arm64-alpha.zip` at SHA-256
+`3dec5864aa637a7115f46a41fd81b8b2077ac44904bf48d7396c54c03a6faee2`.
 It is native arm64, ad-hoc signed and not notarized.
 
 The complete AOT build must have the maintained GoldenEye iOS context patch

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -2,7 +2,7 @@
 
 Updated: 2026-08-23
 
-This is the short operational queue for GoldenPad after Preview 3. It does not
+This is the short operational queue for GoldenPad after Preview 4. It does not
 replace the authoritative documents:
 
 - [`TECH_DEBT.md`](TECH_DEBT.md) owns priority, evidence, and closure state;
@@ -17,14 +17,17 @@ the same change rather than choosing whichever wording is more convenient.
 
 | Order | Work | Output required before moving on |
 | ---: | --- | --- |
-| 1 | **TD-01 sustained-player measurement** | Rebase the isolated read-only probe, retain the 13/17/18 guard windows, and obtain a repeatable ordinary-input setup with at least 34 rounds. No timing repair yet. |
-| Parallel user-facing lane | **TD-02 reporter confirmation** | Ask issue #8's reporter to verify the released opt-in sidestep adapter with touch and a connected controller; keep it opt-in until the full gate passes. |
+| 1 | **TD-01 sustained-player measurement** | Freeze Preview 4, use its existing default-off read-only probe, retain the 13/17/18 guard windows, and obtain three complete 100-tick player windows from one repeatable ordinary-input setup with at least 34 rounds. No timing repair yet. |
+| Parallel user-facing lane | **Preview 4 reporter confirmation** | Ask issue #8's reporter to verify touch/controller sidestepping and issue #17's reporter to verify Mac Runway tank controls against Preview 4. Require diagnostics and exact settings for any remaining failure. |
 | Parallel evidence lane | **TD-03 A12X crash investigation** | Full redacted `.ips`, A12-family reproduction, and diagnostic-only non-direct/Tier-1 Plume binding builds on accepted hardware. No speculative shipping patch. |
 
-Preview 3 is the accepted release baseline. The historical stacked debt branch
-is evidence only; rebase one bounded probe or repair at a time. TD-02 reporter
-confirmation and A12 evidence collection can proceed without changing released
-control defaults.
+Preview 4 is the accepted release baseline. Its source, package, behavior, and
+rollback identities are frozen in
+[`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md). The probe is already present;
+do not rebase or rewrite it before measurement. Follow
+[`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md) and stop at its real-gameplay
+gate. Reporter confirmation and A12 evidence collection can proceed without
+changing released controls.
 
 ## Do immediately after
 
@@ -61,8 +64,9 @@ one at a time against a freshly accepted baseline.
 
 - Resolve or deliberately document the A12-family support floor from affected
   hardware evidence.
-- Keep the accepted Preview 3 Mac input baseline; take only the edge-mask repair
-  independently if fixed-scene captures justify it.
+- Keep Preview 4's shared mapping and the accepted Preview 3 Mac relative-input
+  baseline; take only the edge-mask repair independently if fixed-scene captures
+  justify it.
 - Reduce stage/effect reports to deterministic reproductions.
 - Implement stable real two- to four-controller ownership.
 - Add deterministic frame numbers and state hashes.

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -1,8 +1,8 @@
 # Next steps
 
-Updated: 2026-08-23
+Updated: 2026-08-24
 
-This is the short operational queue for GoldenPad after Preview 4. It does not
+This is the short operational queue for GoldenPad after Preview 5. It does not
 replace the authoritative documents:
 
 - [`TECH_DEBT.md`](TECH_DEBT.md) owns priority, evidence, and closure state;
@@ -17,33 +17,30 @@ the same change rather than choosing whichever wording is more convenient.
 
 | Order | Work | Output required before moving on |
 | ---: | --- | --- |
-| 1 | **TD-01 repair design review** | Preserve the completed baseline: three identical Phantom windows at 20 events/58 ticks (34.4828 per 100) plus guard windows 13/17/18. Specify the smallest source-derived player-and-guard repair and deterministic before/after gate before changing timing. |
-| Parallel user-facing lane | **Preview 4 reporter confirmation** | Ask issue #8's reporter to verify touch/controller sidestepping and issue #17's reporter to verify Mac Runway tank controls against Preview 4. Require diagnostics and exact settings for any remaining failure. |
+| 1 | **TD-14 modal/run-loop neutralization** | Add the failing held-input boundary gate before changing presentation behavior; preserve Preview 5 controls and firing cadence. |
+| 2 | **TD-07 disconnect containment** | Publish a neutral frame when the active controller disappears without moving touch ownership implicitly. Keep it separate from TD-14. |
+| Parallel user-facing lane | **Preview 5 reporter confirmation** | Ask issue #8's reporter to verify touch/controller sidestepping and issue #17's reporter to verify Mac Runway tank controls against Preview 5. Require diagnostics and exact settings for any remaining failure. |
 | Parallel evidence lane | **TD-03 A12X crash investigation** | Full redacted `.ips`, A12-family reproduction, and diagnostic-only non-direct/Tier-1 Plume binding builds on accepted hardware. No speculative shipping patch. |
 
-Preview 4 is the accepted release baseline. Its source, package, behavior, and
-rollback identities are frozen in
-[`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md). The player measurement is
-complete and its observation branch remains separate from gameplay repair.
-Follow [`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md) and stop before
-implementing timing until the exact repair is reviewed. Reporter confirmation
-and A12 evidence collection can proceed without changing released controls.
+Preview 5 is the accepted release baseline. It retains Preview 4's frozen
+controls/tank boundary and releases the TD-01 shared automatic-rate repair
+documented in [`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md). Positive
+player/guard intervals scale by three; nonpositive semi-auto classifications
+remain unchanged. Source, generated-patch, input/tank, build, package,
+preservation, and physical player-cadence gates pass. Reporter confirmation and
+A12 evidence can proceed without changing released behavior.
 
 ## Do immediately after
 
-1. **TD-01 fire-rate authenticity repair**
-   - Use the confirmed 34.4828 player and 13/17/18 guard baselines.
-   - Patch player and guard cadence together as one timing decision.
-   - Recheck semi-automatic behavior and obtain hands-on combat acceptance.
-2. **TD-14 modal/run-loop neutralization**
+1. **TD-14 modal/run-loop neutralization**
    - Fail first on held touch/controller input across Settings, Share, watch,
      pause, and scroll tracking.
    - Publish neutral before presentation and forbid replay on dismissal.
-3. **TD-07 disconnect neutralization and lifecycle probe**
+2. **TD-07 disconnect neutralization and lifecycle probe**
    - Publish neutral when the active controller disappears.
    - Never move touch ownership implicitly.
    - Preserve normal touch/controller Player 1 behavior.
-4. **TD-04, TD-05, and TD-06 discriminators**
+3. **TD-04, TD-05, and TD-06 discriminators**
    - Lifecycle: run the physical matrix first, then instrument the observed wait
      class; do not assume a drawable-only stall.
    - Audio: correlate an audible physical event with counters; 22,050 Hz rate
@@ -51,7 +48,7 @@ and A12 evidence collection can proceed without changing released controls.
    - Flicker: fixed player order is rejected; the uncalibrated zero
      `formatChanged` signal is narrowing, not closure. Capture the first affected
      physical frame before another RT64 experiment.
-5. **TD-12/TD-13 hygiene**
+4. **TD-12/TD-13 hygiene**
    - Give the runtime-managed ROM copy the same backup/protection policy as the
      Documents copy, with hash-preserving migration/readback.
    - Script the private-input game-bearing build so two clean build directories
@@ -64,7 +61,7 @@ one at a time against a freshly accepted baseline.
 
 - Resolve or deliberately document the A12-family support floor from affected
   hardware evidence.
-- Keep Preview 4's shared mapping and the accepted Preview 3 Mac relative-input
+- Keep Preview 5's shared mapping and the accepted Preview 3 Mac relative-input
   baseline; take only the edge-mask repair independently if fixed-scene captures
   justify it.
 - Reduce stage/effect reports to deterministic reproductions.

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -17,22 +17,22 @@ the same change rather than choosing whichever wording is more convenient.
 
 | Order | Work | Output required before moving on |
 | ---: | --- | --- |
-| 1 | **TD-01 sustained-player measurement** | Freeze Preview 4, use its existing default-off read-only probe, retain the 13/17/18 guard windows, and obtain three complete 100-tick player windows from one repeatable ordinary-input setup with at least 34 rounds. No timing repair yet. |
+| 1 | **TD-01 repair design review** | Preserve the completed baseline: three identical Phantom windows at 20 events/58 ticks (34.4828 per 100) plus guard windows 13/17/18. Specify the smallest source-derived player-and-guard repair and deterministic before/after gate before changing timing. |
 | Parallel user-facing lane | **Preview 4 reporter confirmation** | Ask issue #8's reporter to verify touch/controller sidestepping and issue #17's reporter to verify Mac Runway tank controls against Preview 4. Require diagnostics and exact settings for any remaining failure. |
 | Parallel evidence lane | **TD-03 A12X crash investigation** | Full redacted `.ips`, A12-family reproduction, and diagnostic-only non-direct/Tier-1 Plume binding builds on accepted hardware. No speculative shipping patch. |
 
 Preview 4 is the accepted release baseline. Its source, package, behavior, and
 rollback identities are frozen in
-[`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md). The probe is already present;
-do not rebase or rewrite it before measurement. Follow
-[`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md) and stop at its real-gameplay
-gate. Reporter confirmation and A12 evidence collection can proceed without
-changing released controls.
+[`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md). The player measurement is
+complete and its observation branch remains separate from gameplay repair.
+Follow [`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md) and stop before
+implementing timing until the exact repair is reviewed. Reporter confirmation
+and A12 evidence collection can proceed without changing released controls.
 
 ## Do immediately after
 
 1. **TD-01 fire-rate authenticity repair**
-   - Use the probe's before/after numbers.
+   - Use the confirmed 34.4828 player and 13/17/18 guard baselines.
    - Patch player and guard cadence together as one timing decision.
    - Recheck semi-automatic behavior and obtain hands-on combat acceptance.
 2. **TD-14 modal/run-loop neutralization**

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -17,8 +17,10 @@ research decision, architecture and implementation gates are recorded in
 
 ## Current execution plan (2026-08-23)
 
-Preview 3 is published. The current objective is to repair major single-player
-gameplay and compatibility defects, then harden local multiplayer ownership,
+Preview 4 is published and frozen in
+[`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md). The current objective is to
+measure and repair major single-player gameplay and compatibility defects, then
+harden local multiplayer ownership,
 then decide whether network multiplayer deserves implementation. The historical
 foundation milestones below remain evidence, but they do not set today's order.
 
@@ -30,13 +32,13 @@ service.
 | Work | Size | Primary risk |
 | --- | ---: | --- |
 | TD-01 sustained-player measurement | S | Ordinary setup does not provide enough ammunition for a discriminating window |
-| TD-02 released sidestep verification | S | Reporter-specific touch/controller behavior differs from the accepted setup |
+| TD-02/issue #17 Preview 4 reporter verification | S | Reporter-specific touch/controller/Mac behavior differs from the accepted iPad setup |
 | TD-01 authenticity patch | M | Deliberately changes accepted combat feel and generated patch inputs |
 | TD-07 disconnect neutralization/probe | S | Regresses normal touch/controller P1 publication |
 | TD-14 modal/run-loop neutralization | S | Replayed input or menu/watch regression across presentation boundaries |
 | TD-03 A12 evidence | S | Hardware/artifact availability; repair size remains unknown |
 | TD-04/TD-05/TD-06 physical classification | S each | Instrumentation changes timing or logs the wrong boundary |
-| TD-09 Mac-only edge repair | S | Renderer coverage regression; Preview 3 input is already accepted |
+| TD-09 Mac-only edge repair | S | Renderer coverage regression; keep it independent from Preview 4 input |
 | TD-12 storage/package hygiene | S | User-data migration or backup attributes damage a valid runtime copy |
 | TD-13 game-bearing build proof | S-M | Private inputs make provenance checks environment-dependent |
 | Production 2–4 controller ownership | L | Device identity/lifecycle and touch ownership interactions |
@@ -45,10 +47,12 @@ service.
 
 ### Wave 0 — freeze evidence and scope
 
-Status: **complete for documentation**.
+Status: **complete for Preview 4 identity; terminal-only revalidation required
+before each TD-01 phase**.
 
-- The accepted mobile single-player and experimental multiplayer render hashes
-  remain regression controls.
+- The exact source, package, release executable, physically accepted control,
+  and rollback hashes are frozen in
+  [`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md).
 - `TECH_DEBT.md` owns priority and evidence state; `TESTING.md` owns closure
   gates; `STATUS.md` owns current results.
 - Every implementation change receives one debt ID and an independent rollback.
@@ -61,14 +65,16 @@ Execute and land these as separate review units:
 
 | Order | Work package | Why now | Required output | Promotion gate |
 | ---: | --- | --- | --- | --- |
-| 1 | **TD-01 sustained-player probe completion** | Guard mechanism is measured; player magnitude still gates the real fix | Ordinary-input player ammo/event slope over a sustained fixed-tick window, retaining the existing guard evidence | Repeatable numbers recorded with at least 34 starting rounds; no gameplay behavior change |
-| Parallel user-facing lane | **TD-02 released sidestep verification** | Preview 3 ships the bounded adapter opt-in; issue closure still needs reporter evidence | Reporter confirms touch and controller MOVE strafe / LOOK turn behavior | Keep the adapter opt-in until reporter confirmation and the full regression matrix pass |
-| Parallel evidence lane | **TD-03 A12X crash artifact/reproduction** | High-severity compatibility report, but no safe patch exists without affected evidence | Full redacted `.ips`, Preview 2 reproduction, affected/newer device comparison | First failing RT64/Metal boundary isolated or deliberate tested support-floor decision |
+| 1 | **TD-01 sustained-player probe completion** | Guard mechanism is measured; player magnitude still gates the real fix | Use Preview 4's existing default-off probe for ordinary-input player ammo/event slope over a sustained fixed-tick window, retaining the existing guard evidence | Three repeatable 100-tick numbers recorded with at least 34 starting rounds; no gameplay behavior change |
+| Parallel user-facing lane | **Preview 4 reporter verification** | Issues #8 and #17 remain open after internal iPad acceptance | Issue #8 reporter confirms touch/controller sidestep behavior; issue #17 reporter confirms Mac Runway tank behavior or supplies diagnostics | Do not reinterpret the accepted mapping without a new reproduction and the full regression matrix |
+| Parallel evidence lane | **TD-03 A12X crash artifact/reproduction** | High-severity compatibility report, but no safe patch exists without affected evidence | Full redacted `.ips`, current Preview 4 reproduction, original-signature comparison, and affected/newer device comparison | First failing RT64/Metal boundary isolated or deliberate tested support-floor decision |
 
-The sustained fire-rate run, TD-02 reporter confirmation, and A12 evidence work can
-proceed without changing accepted Preview 3 controls. Any later sidestep default
-change must be reviewed separately from controller-lifecycle work because both
-touch input publication.
+The sustained fire-rate run, reporter confirmation, and A12 evidence work can
+proceed without changing accepted Preview 4 controls. Follow
+[`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md) and stop before real gameplay
+when no Simulator, device, or GUI use is authorized. Any later input change must
+be reviewed separately from controller-lifecycle work because both touch input
+publication.
 
 ### Wave 2 — major behavior and reliability corrections
 
@@ -101,7 +107,8 @@ one at a time against a freshly accepted baseline.
 
 - Resolve TD-03 on affected A12 hardware or publish an evidence-backed support
   floor.
-- Keep Preview 3's accepted Mac relative-input repair frozen. Take a TD-09
+- Keep Preview 4's shared input mapping and Preview 3's accepted Mac relative-
+  input repair frozen. Take a TD-09
   trailing-edge mask only after fixed-scene captures isolate the strip.
 - Reduce each stage/effect report under TD-10 to one deterministic camera,
   stage, settings, and expected-reference case before changing game or renderer

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -31,7 +31,7 @@ service.
 
 | Work | Size | Primary risk |
 | --- | ---: | --- |
-| TD-01 sustained-player measurement | S | Ordinary setup does not provide enough ammunition for a discriminating window |
+| TD-01 sustained-player measurement | Complete | Three physical-iPad Phantom magazines were identical at 20 events over 58 ticks |
 | TD-02/issue #17 Preview 4 reporter verification | S | Reporter-specific touch/controller/Mac behavior differs from the accepted iPad setup |
 | TD-01 authenticity patch | M | Deliberately changes accepted combat feel and generated patch inputs |
 | TD-07 disconnect neutralization/probe | S | Regresses normal touch/controller P1 publication |
@@ -47,8 +47,8 @@ service.
 
 ### Wave 0 — freeze evidence and scope
 
-Status: **complete for Preview 4 identity; terminal-only revalidation required
-before each TD-01 phase**.
+Status: **complete for Preview 4 identity and TD-01 baseline; terminal-only
+revalidation required before each repair phase**.
 
 - The exact source, package, release executable, physically accepted control,
   and rollback hashes are frozen in
@@ -65,14 +65,15 @@ Execute and land these as separate review units:
 
 | Order | Work package | Why now | Required output | Promotion gate |
 | ---: | --- | --- | --- | --- |
-| 1 | **TD-01 sustained-player probe completion** | Guard mechanism is measured; player magnitude still gates the real fix | Use Preview 4's existing default-off probe for ordinary-input player ammo/event slope over a sustained fixed-tick window, retaining the existing guard evidence | Three repeatable 100-tick numbers recorded with at least 34 starting rounds; no gameplay behavior change |
+| 1 | **TD-01 sustained-player probe completion** | Complete; player magnitude now distinguishes the current cadence from the authentic target | Three ordinary-input Phantom magazines each recorded 20 events in 58 ticks, normalized to 34.4828; retained guard evidence is 13/17/18 per 100 ticks | PASS: three identical player numbers, matching ammo deltas, no gameplay-state writes, and protected data preserved |
 | Parallel user-facing lane | **Preview 4 reporter verification** | Issues #8 and #17 remain open after internal iPad acceptance | Issue #8 reporter confirms touch/controller sidestep behavior; issue #17 reporter confirms Mac Runway tank behavior or supplies diagnostics | Do not reinterpret the accepted mapping without a new reproduction and the full regression matrix |
 | Parallel evidence lane | **TD-03 A12X crash artifact/reproduction** | High-severity compatibility report, but no safe patch exists without affected evidence | Full redacted `.ips`, current Preview 4 reproduction, original-signature comparison, and affected/newer device comparison | First failing RT64/Metal boundary isolated or deliberate tested support-floor decision |
 
-The sustained fire-rate run, reporter confirmation, and A12 evidence work can
-proceed without changing accepted Preview 4 controls. Follow
-[`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md) and stop before real gameplay
-when no Simulator, device, or GUI use is authorized. Any later input change must
+Reporter confirmation and A12 evidence work can proceed without changing
+accepted Preview 4 controls. Follow
+[`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md) for the completed measurement
+and stop before any repair until the exact source-derived timing seam is
+reviewed. Any later input change must
 be reviewed separately from controller-lifecycle work because both touch input
 publication.
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -15,11 +15,11 @@ The native Apple-Silicon macOS extension is a separate gated product track. Its
 research decision, architecture and implementation gates are recorded in
 [`MACOS_NATIVE_FEASIBILITY_2026-08-21.md`](MACOS_NATIVE_FEASIBILITY_2026-08-21.md).
 
-## Current execution plan (2026-08-23)
+## Current execution plan (2026-08-24)
 
-Preview 4 is published and frozen in
-[`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md). The current objective is to
-measure and repair major single-player gameplay and compatibility defects, then
+Preview 5 is published with the frozen Preview 4 control boundary and released
+TD-01 authenticity repair. The current objective is to
+harden the remaining input-lifecycle and compatibility defects, then
 harden local multiplayer ownership,
 then decide whether network multiplayer deserves implementation. The historical
 foundation milestones below remain evidence, but they do not set today's order.
@@ -32,8 +32,8 @@ service.
 | Work | Size | Primary risk |
 | --- | ---: | --- |
 | TD-01 sustained-player measurement | Complete | Three physical-iPad Phantom magazines were identical at 20 events over 58 ticks |
-| TD-02/issue #17 Preview 4 reporter verification | S | Reporter-specific touch/controller/Mac behavior differs from the accepted iPad setup |
-| TD-01 authenticity patch | M | Deliberately changes accepted combat feel and generated patch inputs |
+| TD-02/issue #17 Preview 5 reporter verification | S | Reporter-specific touch/controller/Mac behavior differs from the accepted iPad setup |
+| TD-01 authenticity patch | Released in Preview 5 | Retain its isolated rollback and evidence boundary |
 | TD-07 disconnect neutralization/probe | S | Regresses normal touch/controller P1 publication |
 | TD-14 modal/run-loop neutralization | S | Replayed input or menu/watch regression across presentation boundaries |
 | TD-03 A12 evidence | S | Hardware/artifact availability; repair size remains unknown |
@@ -47,7 +47,7 @@ service.
 
 ### Wave 0 — freeze evidence and scope
 
-Status: **complete for Preview 4 identity and TD-01 baseline; terminal-only
+Status: **complete for Preview 4 identity and Preview 5 TD-01 release; terminal-only
 revalidation required before each repair phase**.
 
 - The exact source, package, release executable, physically accepted control,
@@ -66,23 +66,24 @@ Execute and land these as separate review units:
 | Order | Work package | Why now | Required output | Promotion gate |
 | ---: | --- | --- | --- | --- |
 | 1 | **TD-01 sustained-player probe completion** | Complete; player magnitude now distinguishes the current cadence from the authentic target | Three ordinary-input Phantom magazines each recorded 20 events in 58 ticks, normalized to 34.4828; retained guard evidence is 13/17/18 per 100 ticks | PASS: three identical player numbers, matching ammo deltas, no gameplay-state writes, and protected data preserved |
-| Parallel user-facing lane | **Preview 4 reporter verification** | Issues #8 and #17 remain open after internal iPad acceptance | Issue #8 reporter confirms touch/controller sidestep behavior; issue #17 reporter confirms Mac Runway tank behavior or supplies diagnostics | Do not reinterpret the accepted mapping without a new reproduction and the full regression matrix |
+| Parallel user-facing lane | **Preview 5 reporter verification** | Issues #8 and #17 remain open after internal iPad acceptance | Issue #8 reporter confirms touch/controller sidestep behavior; issue #17 reporter confirms Mac Runway tank behavior or supplies diagnostics | Do not reinterpret the accepted mapping without a new reproduction and the full regression matrix |
 | Parallel evidence lane | **TD-03 A12X crash artifact/reproduction** | High-severity compatibility report, but no safe patch exists without affected evidence | Full redacted `.ips`, current Preview 4 reproduction, original-signature comparison, and affected/newer device comparison | First failing RT64/Metal boundary isolated or deliberate tested support-floor decision |
 
 Reporter confirmation and A12 evidence work can proceed without changing
-accepted Preview 4 controls. Follow
-[`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md) for the completed measurement
-and stop before any repair until the exact source-derived timing seam is
-reviewed. Any later input change must
+accepted Preview 5 controls. Follow
+[`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md) for the completed measurement,
+repair, acceptance, and rollback record. Any later input change must
 be reviewed separately from controller-lifecycle work because both touch input
 publication.
 
 ### Wave 2 — major behavior and reliability corrections
 
-1. **TD-01 authenticity patch:** only after Wave 1 records the baseline. Port
-   the player and guard timing seams as a matched generated patch set. Require
-   before/after cadence evidence, semi-automatic regression checks, and hands-on
-   combat reacceptance.
+1. **TD-01 authenticity patch:** released in Preview 5 from the completed baseline.
+   The shared positive player/guard automatic-rate getter is scaled by three;
+   zero and negative classifications are unchanged. Deterministic, generated-
+   patch, input/tank, platform-build, exact Phantom cadence, and hands-on core-
+   controls gates pass. No complete candidate guard
+   window or explicit PP7 sequence was logged; retain that evidence boundary.
 2. **TD-14 modal/run-loop neutralization:** add the failing held-input boundary
    gate, neutralize settings/share presentation, and prove watch/pause plus
    scroll tracking cannot replay latched input.

--- a/docs/PREVIEW_4_BASELINE.md
+++ b/docs/PREVIEW_4_BASELINE.md
@@ -92,6 +92,20 @@ the window; it does not change game timing or input.
 The probe's presence and default-off wiring can be checked without launching
 the game. Its measurements cannot.
 
+## Isolated TD-01 repair delta
+
+Branch `codex/td01-fire-rate-repair` leaves this published baseline immutable.
+Its only gameplay change replaces the shared automatic-rate getter: positive
+values are multiplied by the N64 frame cost of three, while zero and negative
+values are returned unchanged. Player and guard modulo paths therefore change
+together. Input mapping, controller sensitivity, native Aim, tank behavior,
+menus, damage, ammo, first-shot behavior, renderer, and host timing are outside
+the repair.
+
+The candidate is not part of Preview 4 and is not accepted until the physical
+stop gate in [`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md) passes. Reverting
+the single repair commit restores the identities and behavior recorded above.
+
 ## Change and rollback rules
 
 1. Start each TD-01 review unit from the frozen source merge above.
@@ -117,6 +131,10 @@ scripts/verify-fire-rate-probe-contract.sh
 scripts/verify-recomp-input-matrix.sh
 git diff --check
 ```
+
+For the isolated candidate, replace the first command with
+`scripts/verify-preview4-baseline.sh --allow-td01-repair` and add
+`scripts/verify-fire-rate-authenticity-repair.sh`.
 
 The first two checks require no Simulator, device, ROM, app launch, or GUI. The
 input matrix is also command-line-only but needs the pinned reference checkout;

--- a/docs/PREVIEW_4_BASELINE.md
+++ b/docs/PREVIEW_4_BASELINE.md
@@ -68,23 +68,26 @@ verification does not authorize another input rewrite.
 
 ## TD-01 diagnostic boundary
 
-Preview 4 already contains the TD-01 read-only observation hooks. Do not rebase,
-reimplement, or change them before collecting the missing baseline.
+Preview 4 contains the TD-01 read-only observation hooks. The completed
+measurement branch changes only the host observation window so a continuous
+magazine of at least 15 shots can finish before 100 ticks and a reload rejects
+the window; it does not change game timing or input.
 
 - Normal launch initializes `fireRateProbeEnabled` to false.
 - Only the explicit `--fire-rate-probe` launch argument in the mobile host
   enables it. Mac contains the runtime symbol but does not provide the current
   gameplay-measurement activation route.
-- The probe observes at most three 100-tick player windows and three guard
-  windows.
+- The probe observes at most three player windows and three 100-tick guard
+  windows. A player window completes at 100 ticks or when at least 15 continuous
+  shots empty the magazine; magazine results are normalized per 100 ticks.
 - It records player weapon, magazine ammo, fire counter, and ordinary ammo
   consumption. The guard wrapper calls GoldenEye's original firing routine and
   then records the resulting counter transition.
 - It does not alter timing, inventory, saves, mission state, transforms,
   player state, guard state, input mapping, or renderer state.
-- Existing evidence contains three guard windows at 13, 17, and 18 committed
-  events per 100 ticks. The missing evidence is three complete sustained-player
-  windows from one repeatable ordinary-input setup with at least 34 rounds.
+- Evidence contains three guard windows at 13, 17, and 18 committed events per
+  100 ticks and three identical physical-iPad player windows at 20 events over
+  58 ticks, normalized to 34.4828 per 100 ticks.
 
 The probe's presence and default-off wiring can be checked without launching
 the game. Its measurements cannot.

--- a/docs/PREVIEW_4_BASELINE.md
+++ b/docs/PREVIEW_4_BASELINE.md
@@ -1,0 +1,121 @@
+# Preview 4 frozen control baseline
+
+Status: **published control; frozen for TD-01 measurement and repair**
+
+Updated: 2026-08-23
+
+This document identifies the exact control that every post-Preview 4 repair
+must preserve. It is an identity and rollback record, not a claim that every
+open issue is fixed or that build evidence replaces hands-on gameplay.
+
+## Published identity
+
+| Item | Frozen value |
+| --- | --- |
+| Source merge | `54474a40e93b77259d10c7594919e6a05f5e276d` |
+| Source tree | `4232141f9d14d2f6197e43173694f649828e730f` |
+| Pull request | [#18](https://github.com/chrissotraidis/goldenpad/pull/18) |
+| Tag | `v0.1.0-preview.4` |
+| Release | [Preview 4](https://github.com/chrissotraidis/goldenpad/releases/tag/v0.1.0-preview.4) |
+| Unsigned IPA | `GoldenPad-0.1.0-preview.4-unsigned.ipa` |
+| IPA SHA-256 | `ff163b0af6b54596590da8e39cbaff0b388b69f1607ca34f62ce61e7fe144130` |
+| Mac Alpha archive | `GoldenPad-0.1.0-preview.4-macos-arm64-alpha.zip` |
+| Mac archive SHA-256 | `63bec02ad6e323a213f9cb9d15f763a58d6eb7bd4a1a40af6341a4fb8fb333ba` |
+| Tracked GoldenEye patch SHA-256 | `0d64256620a5dcb43e7ccf86f9fedd7282242f823ea7d9984c0447c85f3a1cea` |
+| Generated `patches.c` SHA-256 | `4a829165889a4e736199841c4c4237ee6a03ed97fa1ce6d891dfc864634862ff` |
+| Generated `patches_bin.c` SHA-256 | `cb3e439a8eb1587ac11b7fa29551b3f204860f993b9114ebd5331c179bc92bc6` |
+
+The tag and remote `main` both resolved to the source merge above when this
+baseline was frozen. GitHub reported the same SHA-256 digests for both hosted
+binary assets. The release is a published prerelease, not a draft.
+
+The audited IPA has sorted unsigned app-content SHA-256
+`1ec161604af996f30bb3ac1e9c347f7c905623675ca32adf8d2c35a069c6a13c`.
+The audited Mac archive has sorted app-content SHA-256
+`d2d0824047061b81ad3ef1b2fd2fd61fde09fc759176b782209c41279217a341`.
+Neither package contains a ROM, save, provisioning profile, signing identity,
+or private build path.
+
+## Accepted behavior boundary
+
+The physically accepted signed iPad test executable is
+`2b31f8868885712fbad34cef1aea20b1dee48f59fc9d930cbd3fa8b8e82b6b12`.
+It established:
+
+- controller connection, raw menu navigation, and mission startup;
+- ordinary on-foot movement and both-axis right-stick look;
+- stationary left-trigger Aim using the left stick for GoldenEye's native
+  weapon/reticle path and neutral right stick;
+- Runway tank entry, drive, hull steering, turret control, weapon cycling,
+  ordinary-weapon and Tank Shell firing, exit, and re-entry; and
+- return to title plus a later Facility on-foot regression pass.
+
+Preview 4's final unsigned executable is version `0.1.0` build `4` at SHA-256
+`d83361f4daa70014b378aed20b9e26dc7c787d77b0fcd000816d536aecc8e66b`.
+It changes only the requested external-controller normal-look and mounted-
+turret rate from 1.56 to 1.872 degrees per frame on top of the accepted test
+binary. The shared input matrix, full device build, symbol audit, and package
+audit passed. That exact final unsigned executable did not receive a second
+physical-device pass before publication; preserve that distinction.
+
+The detailed mapping and rollback contract remains
+[`PREVIEW_4_INPUT_FIX.md`](PREVIEW_4_INPUT_FIX.md). Issue
+[#17](https://github.com/chrissotraidis/goldenpad/issues/17) remains open for
+reporter Mac verification. Issue
+[#8](https://github.com/chrissotraidis/goldenpad/issues/8) also remains open for
+reporter confirmation against the superseding Preview 4 mapping. Open reporter
+verification does not authorize another input rewrite.
+
+## TD-01 diagnostic boundary
+
+Preview 4 already contains the TD-01 read-only observation hooks. Do not rebase,
+reimplement, or change them before collecting the missing baseline.
+
+- Normal launch initializes `fireRateProbeEnabled` to false.
+- Only the explicit `--fire-rate-probe` launch argument in the mobile host
+  enables it. Mac contains the runtime symbol but does not provide the current
+  gameplay-measurement activation route.
+- The probe observes at most three 100-tick player windows and three guard
+  windows.
+- It records player weapon, magazine ammo, fire counter, and ordinary ammo
+  consumption. The guard wrapper calls GoldenEye's original firing routine and
+  then records the resulting counter transition.
+- It does not alter timing, inventory, saves, mission state, transforms,
+  player state, guard state, input mapping, or renderer state.
+- Existing evidence contains three guard windows at 13, 17, and 18 committed
+  events per 100 ticks. The missing evidence is three complete sustained-player
+  windows from one repeatable ordinary-input setup with at least 34 rounds.
+
+The probe's presence and default-off wiring can be checked without launching
+the game. Its measurements cannot.
+
+## Change and rollback rules
+
+1. Start each TD-01 review unit from the frozen source merge above.
+2. Before gameplay measurement, runtime source must remain byte-identical to
+   Preview 4. Documentation and verification scripts are the only allowed
+   changes.
+3. Do not combine TD-01 with input sensitivity, Aim, tank behavior, controller
+   ownership, lifecycle, audio, renderer, storage, A12X, or networking work.
+4. The measurement unit changes no gameplay behavior. The later authenticity
+   repair is a separate commit and review unit.
+5. If the repair changes the tracked GoldenEye patch, regenerate and validate
+   `patches.c` and `patches_bin.c` together.
+6. Every candidate must pass the complete Preview 4 input matrix and package
+   boundaries before physical escalation.
+7. Reverting the single TD-01 repair commit must restore this baseline without
+   removing Preview 4 controls.
+
+Run the terminal-only freeze checks from the repository root:
+
+```sh
+scripts/verify-preview4-baseline.sh
+scripts/verify-fire-rate-probe-contract.sh
+scripts/verify-recomp-input-matrix.sh
+git diff --check
+```
+
+The first two checks require no Simulator, device, ROM, app launch, or GUI. The
+input matrix is also command-line-only but needs the pinned reference checkout;
+an isolated worktree may supply it through
+`GOLDENPAD_RECOMP_REFERENCE_ROOT=/path/to/goldeneye64recomp`.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,6 +1,6 @@
 # Release checklist
 
-GoldenPad 0.1.0 Preview 4 is the current coordinated release. It is a
+GoldenPad 0.1.0 Preview 5 is the current coordinated release. It is a
 developer preview, not an App Store/TestFlight release. `GoldenPad Legacy`
 remains a fallback artifact and must not be presented as primary.
 
@@ -127,6 +127,34 @@ drawable-size and direct-camera experiments caused much larger regressions.
 - [ ] The final 1.872-degree unsigned release executable has build and static
   verification, not a second physical-device pass. Keep that distinction in
   release notes and status.
+
+## Coordinated Preview 5 automatic-fire update
+
+- [x] Freeze Preview 4 at merge
+  `54474a40e93b77259d10c7594919e6a05f5e276d` and retain its controls/tank
+  rollback record.
+- [x] Measure three Preview 4 Phantom magazines at 20 events/58 ticks each,
+  normalized to 34.4828 events/100 ticks with zero range.
+- [x] Patch the one shared player/guard automatic-rate getter: multiply positive
+  values by three and preserve zero/negative classifications unchanged.
+- [x] Regenerate both embedded patch halves and add CMake stale-pair ratchets.
+- [x] Pass the source-derived deterministic rate test and complete Preview 4
+  input/Aim/tank matrix.
+- [x] Install only the side-by-side test app in place and prove both ROM copies,
+  active save, backup save, and preferences byte-identical.
+- [x] Obtain physical iPad acceptance. Candidate telemetry recorded the exact
+  expected 12 Phantom events/100 ticks, with accepted navigation, movement,
+  controls, gameplay, and runtime quality.
+- [x] Build and audit the version `0.1.0` build `5` unsigned IPA and native
+  arm64 Mac Alpha from production probe-off source.
+- [x] Record package, content, and executable digests in release
+  notes, status, testing, building, and worklog documents.
+- [x] Merge the isolated PR, verify remote `main`, tag
+  `v0.1.0-preview.5`, publish a GitHub prerelease, and download/re-hash every
+  hosted asset.
+- [x] Keep issue #17 open for reporter Mac verification; Preview 5 retains the
+  accepted tank mapping but does not substitute internal iPad evidence for the
+  reporter's setup.
 
 The remaining sections preserve the `GoldenPad Legacy` clean-checkout and
 packaging procedure.

--- a/docs/RELEASE_NOTES_0.1.0-preview.5.md
+++ b/docs/RELEASE_NOTES_0.1.0-preview.5.md
@@ -1,0 +1,113 @@
+# GoldenPad 0.1.0 Preview 5
+
+Preview 5 fixes automatic player and guard weapons firing too quickly at
+GoldenPad's native 60 Hz simulation rate. It retains Preview 4's accepted shared
+controls, native Aim, Runway/Streets tank behavior, controller sensitivity, ROM
+import, saves, renderer, audio, touch layouts, and Mac controls.
+
+## What changed
+
+- Converts GoldenEye's positive automatic-fire intervals from original N64
+  frame cost to GoldenPad's native simulation cadence by multiplying the one
+  shared player/guard rate by three.
+- Leaves zero and negative firing classifications unchanged, preserving
+  semi-automatic weapons, first-shot behavior, bursts, damage, ammunition, and
+  weapon selection.
+- Keeps the repair inside GoldenEye's shared weapon-stat getter. There is no
+  separate iPhone, iPad, or Mac interpretation and no duplicated player/guard
+  policy.
+- Adds generated-patch stale-pair checks and a deterministic regression gate
+  covering positive automatic rates and unchanged nonpositive values.
+- Retains the default-off bounded diagnostic used to compare Preview 4 and the
+  candidate without writing game state.
+
+## Physical acceptance
+
+Preview 4's physical iPad baseline fired a 20-round Phantom magazine in 58
+simulation ticks, normalized to 34.4828 shots per 100 ticks. Preview 5 recorded
+12 shots in a 100-tick window, ammo 20 to 8. That is the exact expected result
+for the converted interval including the immediate first shot.
+
+The user normally launched the side-by-side test app and accepted navigation,
+movement, controls, general gameplay, and runtime quality with no observed
+regression. The session advanced through 13,723 display lists, VI updates, and
+presentations with zero audio drops and zero underrun frames or callbacks.
+
+No complete candidate guard window or explicit PP7 sequence was captured in
+that physical session. Guards use the same patched getter as the player, while
+the unchanged nonpositive semi-automatic path is verified at source and in the
+deterministic gate; this is not represented as separate physical evidence.
+
+## Downloads
+
+### iPhone and iPad
+
+`GoldenPad-0.1.0-preview.5-unsigned.ipa`
+
+SHA-256:
+
+```text
+d4d6c6d7a00e79d1dd4759a97f3ae544c6112dff7c00ea9e57e21199a25c0db7
+```
+
+The IPA is unsigned and must be re-signed for the user's own device. Its sorted
+unsigned app-content SHA-256 is
+`4753f0814823aeecc545b5f33eea9d1bf2da0e7b93874e34ad5f6a0e8358981b`.
+It contains no
+ROM, save, provisioning profile, signing identity, generated source, or private
+user path.
+
+### Apple Silicon Mac Alpha
+
+`GoldenPad-0.1.0-preview.5-macos-arm64-alpha.zip`
+
+SHA-256:
+
+```text
+3dec5864aa637a7115f46a41fd81b8b2077ac44904bf48d7396c54c03a6faee2
+```
+
+The Mac archive contains a native arm64, ad-hoc-signed, non-notarized app. Its
+sorted app-content SHA-256 is
+`0221a39c5137dec3a923b1e5c80b30886f4604486a9c3f23eeb1bcedfeb0ed8a`.
+Two independent packaging passes produced byte-identical mobile and Mac
+artifacts, and both package verifiers passed.
+
+## Build and rollback identity
+
+- iPhone/iPad version `0.1.0`, build `5`; unsigned executable SHA-256
+  `dff62592f42eede6d6865c12bb35ff97c6f548975d7c3903289f6d09fc462491`.
+- Native Mac version `0.1.0`, build `1`; executable SHA-256
+  `5960150d9eb668b814973045fdfe054240f7c9ef11ff2be9025957884c758bca`.
+- Generated `patches.c` SHA-256
+  `5e559e3a218c06cc54ead26f73a05f19f6095a542adbaeff664c19187f025217`.
+- Generated `patches_bin.c` SHA-256
+  `86113c9d63c92c5a1a7d394de32dd478042e50a9dece10085e93aba3f57ad52d`.
+
+The automatic-fire repair is one independently revertible TD-01 commit on top
+of the frozen Preview 4 baseline. Reverting it restores Preview 4 firing cadence
+without removing Preview 4's accepted controls or tank repair.
+
+## Known limitations
+
+- Issue #17 remains open until its reporter verifies the retained Runway tank
+  controls on Mac; Preview 5 does not reinterpret those accepted controls.
+- Local multiplayer remains experimental. Slight lighting flicker and real
+  Player 3 and Player 4 controller ownership remain open.
+- Online and peer-to-peer multiplayer are not implemented.
+- Intermittent audio static, screenshot/background lifecycle behavior, A12X
+  compatibility issue #9, stage-specific rendering faults, and long-session
+  performance remain tracked technical debt.
+- The Mac Alpha retains the thin far-right blue edge and is not notarized.
+
+## Data and rights boundary
+
+GoldenPad does not include, download, or redistribute GoldenEye 007, a ROM,
+extracted retail assets, or saves. Users must supply their own supported
+original retail dump. This is a source-available developer preview and is not
+official, commercially licensed, App Store-cleared, or affiliated with
+Nintendo, Rare, or MGM.
+
+GoldenPad builds on GoldenEye64Recomp, N64Recomp, N64ModernRuntime, RT64, and
+their contributors. See the source-license manifest, third-party notices, and
+legal policy for exact provenance and redistribution boundaries.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -9,13 +9,13 @@ Updated: 2026-08-23
 | Public release | Preview 4 is published with separately audited unsigned iPhone/iPad and arm64 Mac Alpha artifacts. |
 | Primary runtime | Static GoldenEye ARM64 output + N64ModernRuntime + RT64/Plume/Metal. MGB64 is Legacy only. |
 | Accepted baseline | Physical iPhone/iPad single-player, touch, Xbox/MFi P1, native left-stick Aim, Runway tank controls, saves/preferences preservation, and the bounded four-view experimental render repair. |
-| Major gameplay debt | Native-60-Hz automatic-fire cadence remains incorrect. Preview 4 repairs shared 1.1 through 1.4 and tank input without changing that timing seam. |
+| Major gameplay debt | Native-60-Hz automatic-fire cadence remains incorrect. Three physical-iPad Phantom windows each measured 20 shots in 58 ticks, or 34.4828 per 100 ticks, about 3.05 times the pinned authentic reference. |
 | Compatibility debt | A12X issue #9 is an unresolved first-frame RT64/Metal crash report, not an architecture/signing failure. |
 | Local multiplayer | Experimental rendering works; real P2–P4 controller ownership, reconnect behavior, and residual flicker remain open. |
 | Input lifecycle | Settings/share touch neutralization, disconnect-to-none ownership collapse, and mobile run-loop tracking remain open TD-14/TD-07 gaps. |
 | Network multiplayer | Not implemented. It is no-go until local ownership and deterministic state-hash gates pass. |
 | Preview 4 controls release | Shared mobile/Mac 1.1 through 1.4 mapping, native left-stick Aim, Runway/Streets tank control repair, and the requested final 20 percent controller-look increase. |
-| Immediate engineering gate | Preserve the exact Preview 4 control and finish sustained-player fire-rate measurement with its existing default-off probe; isolated guard windows already record 13/17/18 events per 100 ticks. |
+| Immediate engineering gate | Preserve the exact Preview 4 controls and design one source-derived, independently revertible player-and-guard timing repair from the confirmed 34.4828 player and 13/17/18 guard baselines. Do not implement before review alignment. |
 | Immediate user-facing follow-up | Ask the issue #8 reporter to verify Preview 4 touch/controller sidestepping and the issue #17 reporter to verify Mac tank controls; keep both open until reporter confirmation. |
 | Storage/build hygiene | The runtime-managed Application Support ROM copy lacks the Documents copy's explicit backup/protection attributes; game-bearing build provenance remains private-input/manual. |
 
@@ -761,10 +761,12 @@ Preview 4 is published as a prerelease with separately audited mobile and Mac
 Alpha artifacts. The hosted downloads matched their published checksums and
 passed the same package verifiers as the local artifacts. Its exact source,
 artifact, accepted-behavior, and rollback identities are frozen in
-[`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md). The next engineering gate is
-sustained-player fire-rate measurement using Preview 4's already-integrated,
-default-off read-only probe; do not rebase the probe or apply the timing repair
-until that baseline exists. In parallel, obtain issue #8 and issue #17 reporter
+[`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md). The sustained-player baseline
+is now confirmed at three identical 20-event, 58-tick Phantom magazines,
+normalized to 34.4828 events per 100 ticks. The next engineering gate is to
+align the smallest source-derived player-and-guard timing repair, add
+deterministic before/after discrimination, and stop again for hands-on combat
+acceptance before merge. In parallel, obtain issue #8 and issue #17 reporter
 confirmation against Preview 4 and issue #9 `.ips`/A12 evidence. Then
 take TD-14 modal neutralization, TD-07 controller containment, physical
 lifecycle/audio/flicker classification, TD-12 storage hygiene, and TD-13 build

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,22 +1,22 @@
 # Status
 
-Updated: 2026-08-23
+Updated: 2026-08-24
 
 ## Current at a glance
 
 | Surface | Current truth |
 | --- | --- |
-| Public release | Preview 4 is published with separately audited unsigned iPhone/iPad and arm64 Mac Alpha artifacts. |
+| Public release | Preview 5 is published with separately audited unsigned iPhone/iPad and arm64 Mac Alpha artifacts. |
 | Primary runtime | Static GoldenEye ARM64 output + N64ModernRuntime + RT64/Plume/Metal. MGB64 is Legacy only. |
 | Accepted baseline | Physical iPhone/iPad single-player, touch, Xbox/MFi P1, native left-stick Aim, Runway tank controls, saves/preferences preservation, and the bounded four-view experimental render repair. |
-| Major gameplay debt | Native-60-Hz automatic-fire cadence remains incorrect. Three physical-iPad Phantom windows each measured 20 shots in 58 ticks, or 34.4828 per 100 ticks, about 3.05 times the pinned authentic reference. |
+| Major gameplay repair | Preview 5 fixes TD-01 by scaling the shared positive player/guard automatic-fire interval by 3 while preserving nonpositive semi-auto classifications. Physical iPad telemetry changed the Phantom from 20 events/58 ticks to the exact expected 12/100 with accepted controls/gameplay. |
 | Compatibility debt | A12X issue #9 is an unresolved first-frame RT64/Metal crash report, not an architecture/signing failure. |
 | Local multiplayer | Experimental rendering works; real P2–P4 controller ownership, reconnect behavior, and residual flicker remain open. |
 | Input lifecycle | Settings/share touch neutralization, disconnect-to-none ownership collapse, and mobile run-loop tracking remain open TD-14/TD-07 gaps. |
 | Network multiplayer | Not implemented. It is no-go until local ownership and deterministic state-hash gates pass. |
-| Preview 4 controls release | Shared mobile/Mac 1.1 through 1.4 mapping, native left-stick Aim, Runway/Streets tank control repair, and the requested final 20 percent controller-look increase. |
-| Immediate engineering gate | Preserve the exact Preview 4 controls and design one source-derived, independently revertible player-and-guard timing repair from the confirmed 34.4828 player and 13/17/18 guard baselines. Do not implement before review alignment. |
-| Immediate user-facing follow-up | Ask the issue #8 reporter to verify Preview 4 touch/controller sidestepping and the issue #17 reporter to verify Mac tank controls; keep both open until reporter confirmation. |
+| Preview 5 controls | Preview 4's shared mobile/Mac 1.1 through 1.4 mapping, native left-stick Aim, Runway/Streets tank repair, and final controller sensitivity are retained unchanged. |
+| Immediate engineering gate | Take TD-14 modal/run-loop neutralization and TD-07 controller-collapse containment as separate input-lifecycle units; do not combine them with the released TD-01 timing repair. |
+| Immediate user-facing follow-up | Ask the issue #8 reporter to verify touch/controller sidestepping and the issue #17 reporter to verify Mac tank controls against Preview 5; keep both open until reporter confirmation. |
 | Storage/build hygiene | The runtime-managed Application Support ROM copy lacks the Documents copy's explicit backup/protection attributes; game-bearing build provenance remains private-input/manual. |
 
 Documentation ownership:
@@ -35,6 +35,8 @@ Documentation ownership:
   accepted controls, artifacts, diagnostic boundary, and rollback identity.
 - [`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md) owns the bounded TD-01
   measurement sequence and mandatory gameplay stop gate.
+- [`RELEASE_NOTES_0.1.0-preview.5.md`](RELEASE_NOTES_0.1.0-preview.5.md) records
+  Preview 5's public delta, artifact identities, acceptance, and rollback.
 
 ## Summary
 
@@ -73,6 +75,15 @@ adds the user's requested 20 percent absolute controller-look increase from
 and package audit, but was not installed for a second physical pass. The native
 Mac target builds and package-audits; issue #17 remains open because reporter
 gameplay verification is still required.
+
+Preview 5 retains that complete control boundary and fixes TD-01 at the shared
+GoldenEye weapon-stat getter. Positive automatic-fire intervals are multiplied
+by the original N64 frame cost of three for both player and guard paths; zero
+and negative classifications are returned unchanged. Physical iPad telemetry
+recorded 12 Phantom shots/100 ticks versus Preview 4's 20/58-tick magazine,
+with accepted navigation, movement, controls, gameplay, and runtime quality.
+The production mobile build advances to version `0.1.0` build `5`; its bounded
+fire-rate diagnostic remains off by default.
 
 The Preview 2 signed iPhone/iPad release build launches real GoldenEye gameplay,
 preserves its private ROM, save and preference payloads across in-place
@@ -166,7 +177,22 @@ multiplayer or Mac sustained performance to stable-release status. The
 coordinated repository update produces separate audited platform artifacts: an
 iOS/iPadOS `.ipa` and an arm64 macOS Alpha archive containing `GoldenPad.app`.
 
-The audited Preview 4 mobile artifact is
+The audited Preview 5 mobile artifact is
+`GoldenPad-0.1.0-preview.5-unsigned.ipa` at SHA-256
+`d4d6c6d7a00e79d1dd4759a97f3ae544c6112dff7c00ea9e57e21199a25c0db7`.
+Its 18-member archive passed the ROM/save/signing/private-path/setup-copy and
+required-symbol audits and has sorted unsigned app-content SHA-256
+`4753f0814823aeecc545b5f33eea9d1bf2da0e7b93874e34ad5f6a0e8358981b`.
+The audited Preview 5 Mac Alpha artifact is
+`GoldenPad-0.1.0-preview.5-macos-arm64-alpha.zip` at SHA-256
+`3dec5864aa637a7115f46a41fd81b8b2077ac44904bf48d7396c54c03a6faee2`;
+its 20-member archive has sorted app-content SHA-256
+`0221a39c5137dec3a923b1e5c80b30886f4604486a9c3f23eeb1bcedfeb0ed8a`.
+Two independent packaging passes produced byte-identical files. Neither
+artifact contains ROM, save, provisioning, signing identity, generated source,
+or private build-path data.
+
+The historical audited Preview 4 mobile artifact is
 `GoldenPad-0.1.0-preview.4-unsigned.ipa` at SHA-256
 `ff163b0af6b54596590da8e39cbaff0b388b69f1607ca34f62ce61e7fe144130`.
 Its 18-member archive passed the ROM/save/signing/private-path/setup-copy and
@@ -699,11 +725,6 @@ evidence ledger below is preserved as historical validation for
 
 ## Failed or blocked
 
-- The primary runtime runs GoldenEye's simulation at native 60 Hz but does not
-  carry MGB64's source-level player/guard automatic-fire authenticity repair.
-  The pinned source establishes the cadence mechanism. An isolated probe
-  recorded guard windows of 13/17/18 events per 100 ticks; sustained player
-  magnitude remains unmeasured, so no timing repair is authorized yet.
 - Preview 4 supersedes the opt-in sidestep adapter with automatic shared
   mappings for all four GoldenEye control styles. The full matrix is automated;
   ordinary on-foot, Aim, and Runway tank behavior received physical iPad
@@ -757,18 +778,14 @@ evidence ledger below is preserved as historical validation for
 
 ## Next gate
 
-Preview 4 is published as a prerelease with separately audited mobile and Mac
-Alpha artifacts. The hosted downloads matched their published checksums and
-passed the same package verifiers as the local artifacts. Its exact source,
-artifact, accepted-behavior, and rollback identities are frozen in
-[`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md). The sustained-player baseline
-is now confirmed at three identical 20-event, 58-tick Phantom magazines,
-normalized to 34.4828 events per 100 ticks. The next engineering gate is to
-align the smallest source-derived player-and-guard timing repair, add
-deterministic before/after discrimination, and stop again for hands-on combat
-acceptance before merge. In parallel, obtain issue #8 and issue #17 reporter
-confirmation against Preview 4 and issue #9 `.ips`/A12 evidence. Then
-take TD-14 modal neutralization, TD-07 controller containment, physical
+Preview 5 is published as a prerelease with separately audited mobile and Mac
+Alpha artifacts. Its shared automatic-rate repair passed source, generated-
+patch, deterministic, full input/tank, platform-build, package, preservation,
+and physical player-cadence gates. Preview 4's exact rollback identity remains
+frozen in [`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md). In parallel, obtain
+issue #8 and issue #17 reporter confirmation against Preview 5 and issue #9
+`.ips`/A12 evidence. Then take TD-14 modal neutralization, TD-07 controller
+containment, physical
 lifecycle/audio/flicker classification, TD-12 storage hygiene, and TD-13 build
 proof as separate units before broad
 multiplayer or renderer changes. Do not import matching-target SDK

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -15,8 +15,8 @@ Updated: 2026-08-23
 | Input lifecycle | Settings/share touch neutralization, disconnect-to-none ownership collapse, and mobile run-loop tracking remain open TD-14/TD-07 gaps. |
 | Network multiplayer | Not implemented. It is no-go until local ownership and deterministic state-hash gates pass. |
 | Preview 4 controls release | Shared mobile/Mac 1.1 through 1.4 mapping, native left-stick Aim, Runway/Streets tank control repair, and the requested final 20 percent controller-look increase. |
-| Immediate engineering gate | Finish sustained-player fire-rate measurement on Preview 3; isolated guard windows already record 13/17/18 events per 100 ticks. |
-| Immediate user-facing follow-up | Ask the issue #17 reporter to verify Preview 4 on Mac and provide diagnostics if needed; keep the issue open until reporter confirmation. |
+| Immediate engineering gate | Preserve the exact Preview 4 control and finish sustained-player fire-rate measurement with its existing default-off probe; isolated guard windows already record 13/17/18 events per 100 ticks. |
+| Immediate user-facing follow-up | Ask the issue #8 reporter to verify Preview 4 touch/controller sidestepping and the issue #17 reporter to verify Mac tank controls; keep both open until reporter confirmation. |
 | Storage/build hygiene | The runtime-managed Application Support ROM copy lacks the Documents copy's explicit backup/protection attributes; game-bearing build provenance remains private-input/manual. |
 
 Documentation ownership:
@@ -31,6 +31,10 @@ Documentation ownership:
   the network go/no-go decision.
 - [`EXTERNAL_REVIEW_2026-08-22.md`](EXTERNAL_REVIEW_2026-08-22.md) preserves the
   independent snapshot and current disposition; it is supporting evidence.
+- [`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md) freezes the current release,
+  accepted controls, artifacts, diagnostic boundary, and rollback identity.
+- [`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md) owns the bounded TD-01
+  measurement sequence and mandatory gameplay stop gate.
 
 ## Summary
 
@@ -45,7 +49,7 @@ The independent revision-2 review is retained at
 [`EXTERNAL_REVIEW_2026-08-22.md`](EXTERNAL_REVIEW_2026-08-22.md) and reconciled
 into [`TECH_DEBT.md`](TECH_DEBT.md). It inspected historical commit `788667e`,
 so its source analysis remains supporting evidence while current status comes
-from Preview 3 and later isolated debt experiments. It is not repository
+from Preview 4 and later isolated debt experiments. It is not repository
 instructions or a runtime acceptance artifact.
 
 Preview 4 replaces Preview 3's separate movement adapter with one shared input
@@ -755,10 +759,13 @@ evidence ledger below is preserved as historical validation for
 
 Preview 4 is published as a prerelease with separately audited mobile and Mac
 Alpha artifacts. The hosted downloads matched their published checksums and
-passed the same package verifiers as the local artifacts. The next engineering
-gate is sustained-player fire-rate measurement using the isolated read-only
-probe; do not apply the timing repair until that baseline exists. In parallel,
-obtain issue #8 reporter confirmation and issue #9 `.ips`/A12 evidence. Then
+passed the same package verifiers as the local artifacts. Its exact source,
+artifact, accepted-behavior, and rollback identities are frozen in
+[`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md). The next engineering gate is
+sustained-player fire-rate measurement using Preview 4's already-integrated,
+default-off read-only probe; do not rebase the probe or apply the timing repair
+until that baseline exists. In parallel, obtain issue #8 and issue #17 reporter
+confirmation against Preview 4 and issue #9 `.ips`/A12 evidence. Then
 take TD-14 modal neutralization, TD-07 controller containment, physical
 lifecycle/audio/flicker classification, TD-12 storage hygiene, and TD-13 build
 proof as separate units before broad

--- a/docs/TD01_FIRE_RATE_LOOP.md
+++ b/docs/TD01_FIRE_RATE_LOOP.md
@@ -1,6 +1,6 @@
 # TD-01 fire-rate measurement loop
 
-Status: **Preview 4 player baseline confirmed; stopped before timing repair**
+Status: **Released in Preview 5**
 
 Updated: 2026-08-23
 
@@ -116,17 +116,25 @@ Only after T4 is CONFIRMED:
 - regenerate both embedded patch halves together when applicable; and
 - stop again for hands-on combat acceptance before merge or release.
 
+The selected repair replaces the shared
+`bondwalkItemGetAutomaticFiringRate` getter. Positive automatic rates are
+multiplied by the N64 frame cost of three; zero and negative classifications
+are returned unchanged. The same getter feeds player and guard automatic-fire
+modulo tests, so this changes both together without duplicating policy. It does
+not change the first-shot path, semi-automatic classification, weapon damage,
+ammo, input, Aim, tank, menu, renderer, or host timing.
+
 ## Current checkpoint
 
 | Field | Value |
 | --- | --- |
-| Branch | `codex/td01-magazine-measurement` |
+| Branch | `codex/td01-fire-rate-repair` |
 | Starting source | `54474a40e93b77259d10c7594919e6a05f5e276d` |
 | Active debt | TD-01 |
-| Current phase | T4 CONFIRMED; stopped before T5 repair |
-| Runtime behavior change | Observation-only magazine completion and reload rejection; no game-state writes |
+| Current phase | T5 accepted and released in Preview 5 |
+| Runtime behavior change | Positive automatic-fire interval only: shared player/guard value multiplied by 3 |
 | Simulator/device/GUI use | No Simulator or desktop GUI; separately authorized physical iPad only |
-| Next mandatory stop | Align the smallest source-derived player-and-guard repair before implementation |
+| Next mandatory stop | Retain as frozen rollback control; any new timing report starts a separate evidence unit |
 | Later rollback | Revert the single TD-01 repair commit; Preview 4 remains intact |
 
 Update this checkpoint and the authoritative status documents after every phase
@@ -181,3 +189,62 @@ remain private local evidence and are not committed.
 Remote `devicectl` activation caused severe controller/menu latency on this
 iPad. That path is rejected for future hands-on controller measurements; use a
 normally launched diagnostic artifact instead.
+
+## T5 candidate evidence
+
+- The complete decompiled-call-site audit found the shared getter used as the
+  positive modulo divisor by both player and guard automatic firing. Other
+  callers only classify nonpositive values.
+- `scripts/verify-fire-rate-authenticity-repair.sh` proves the measurement
+  control lacks the repair, verifies the tracked source and generated MIPS
+  instructions, checks representative positive rates `2/3/4/5/11` become
+  `6/9/12/15/33`, and proves `0` and `-1` remain unchanged.
+- `scripts/verify-preview4-baseline.sh --allow-td01-repair`, the probe contract,
+  and the complete shared input/tank matrix pass.
+- Regenerated private patch hashes are `11696e2a55d16ddb334cdcaf7b760b27c8b99e82afc577be85419ce14c69bde5`
+  for `patches.bin`, `5e559e3a218c06cc54ead26f73a05f19f6095a542adbaeff664c19187f025217`
+  for `patches.c`, and `86113c9d63c92c5a1a7d394de32dd478042e50a9dece10085e93aba3f57ad52d`
+  for `patches_bin.c`.
+- Signed device candidate executable SHA-256 is
+  `146f3f37d568620ce55910ec2a09bc912336ba56b8afc9183862636e5d81015d`.
+  Its observation probe is temporarily default-on in that artifact only; the
+  tracked source remains default-off.
+- That candidate was installed in place only over side-by-side bundle
+  `com.chrissotraidis.goldenpad.preview4test`, displayed as `GoldenPad P4 Test`.
+  Fresh pre/post readbacks proved both ROM copies, active save, backup save, and
+  preferences byte-identical. The ordinary GoldenPad app was not targeted, and
+  the candidate was not remotely launched.
+- The native arm64 Mac Release build passed with executable SHA-256
+  `0c883f0dfff5f11254f81297f050084b9b6ba1641a9c13f594eacf1a90aca38b`.
+
+The candidate is not accepted, merged, released, or grounds to close TD-01
+until the physical stop gate passes. Revert the single repair commit to recover
+the frozen Preview 4 behavior.
+
+## T5 physical result
+
+The user normally launched the installed P4 Test candidate, navigated to
+Frigate/Agent, and accepted menu navigation, movement, general gameplay, and
+overall runtime quality with no observed regression. The retrieved bounded log
+then supplied the primary cadence discriminator:
+
+| Build | Weapon | Window | Events | Ammo | Result |
+| --- | ---: | ---: | ---: | --- | --- |
+| Preview 4 control | 11 | 58 ticks | 20 | 20 to 0 | Unscaled fast baseline |
+| TD-01 candidate | 11 | 100 ticks | 12 | 20 to 8 | Exact expected scaled interval including the immediate first shot |
+
+The candidate log SHA-256 is
+`9cce343d3be6ef7fa187cde59657365a990e4df28dfa91bbeedd1c221a58bfd6`;
+the preserved prior-session comparator is
+`65fda523ac0773e333eccd05222bbba325b3c6e5f55f0e0a3455db8743fe85f0`.
+The runtime advanced to 13,723 display lists, VI updates, and presentations,
+with zero audio drops and zero underrun frames/callbacks. No fatal, assertion,
+exception, or current-session crash marker appeared. The log did not contain a
+complete guard fixed window or an explicit PP7 sequence; guard behavior remains
+covered by the same getter, and nonpositive semi-automatic values remain
+byte-for-byte unchanged plus deterministically verified. This limitation is
+recorded rather than represented as physical evidence.
+
+The physical stop gate passed and the isolated repair ships in Preview 5. Its
+release artifacts, package hashes, and public limitations are recorded in
+[`RELEASE_NOTES_0.1.0-preview.5.md`](RELEASE_NOTES_0.1.0-preview.5.md).

--- a/docs/TD01_FIRE_RATE_LOOP.md
+++ b/docs/TD01_FIRE_RATE_LOOP.md
@@ -1,0 +1,149 @@
+# TD-01 fire-rate measurement loop
+
+Status: **terminal-only preflight complete; stopped at the real-gameplay gate**
+
+Updated: 2026-08-23
+
+This is the bounded operating loop for automatic-fire authenticity. It applies
+only to TD-01 and inherits the project-wide closure rules in
+[`TECH_DEBT.md`](TECH_DEBT.md#closure-and-change-control-rules). The immutable
+control is [`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md).
+
+## Objective
+
+Measure Preview 4's sustained player and guard automatic-fire cadence before
+changing timing, then implement one independently revertible player-and-guard
+repair only if the measurement supports it.
+
+This loop does not authorize merging, releasing, launching a Simulator, using a
+physical device, or controlling the desktop GUI without a later explicit gate.
+
+## State machine
+
+### T0 - freeze and reconcile
+
+- Verify remote `main`, tag, release target, hosted asset names, and digests.
+- Work from an isolated branch at the exact Preview 4 source merge.
+- Leave unrelated dirty worktrees untouched.
+- Reconcile `STATUS.md`, `TECH_DEBT.md`, `PLAN.md`, `NEXT_STEPS.md`, and
+  `TESTING.md` before changing runtime code.
+
+Gate: `scripts/verify-preview4-baseline.sh` passes and the runtime diff from
+Preview 4 is empty.
+
+### T1 - prove diagnostic containment
+
+- Confirm the existing probe is default-off and launch-argument-only.
+- Confirm both game-side sampling hooks and the ROM-free host stub remain
+  linked.
+- Confirm the observation bodies do not write RDRAM or return modified game
+  state.
+- Do not refactor the probe merely to make it easier to test.
+
+Gate: `scripts/verify-fire-rate-probe-contract.sh` passes. This proves wiring
+and containment only, not measurement accuracy or gameplay behavior.
+
+### T2 - run terminal-only regression gates
+
+- Run the Preview 4 shared input matrix against the pinned reference checkout.
+  A clean worktree may provide that checkout through
+  `GOLDENPAD_RECOMP_REFERENCE_ROOT` rather than copying or modifying it.
+- Run host and package-symbol checks that do not launch an app.
+- Build the native Mac target from the command line if its pinned dependencies
+  are available.
+- Run whitespace, contamination, and documentation-link checks.
+
+Gate: every available terminal-only check is green, with unavailable private-
+input checks recorded rather than weakened.
+
+### T3 - stop for real-gameplay measurement
+
+Do not continue autonomously when the next evidence requires GoldenEye input.
+The missing evidence is:
+
+1. launch the exact unchanged Preview 4 mobile runtime with
+   `--fire-rate-probe`;
+2. use one repeatable ordinary-input setup with one automatic weapon and at
+   least 34 starting rounds;
+3. hold ordinary Fire long enough to complete exactly 100 sampled ticks;
+4. obtain three complete player windows without inventory, save, transform,
+   mission, or enemy-state injection;
+5. record three separate fixed-line-of-sight guard windows; and
+6. preserve the bounded diagnostics log for comparison.
+
+A run is invalid if the weapon changes, the 100-tick completion line is absent,
+starting ammunition is below the discrimination requirement, input is
+synthesized below the ordinary host boundary, or another probe/behavior change
+is enabled.
+
+### T4 - measurement decision
+
+After valid logs exist, record for every run:
+
+- source commit and executable identity;
+- platform, stage, difficulty, weapon, control style, and input device;
+- ticks, starting/ending ammo, committed events, and counter range;
+- mean, range, and any explained setup variance; and
+- agreement or disagreement between event count and ammo delta.
+
+Choose one result:
+
+- **CONFIRMED:** stable player magnitude distinguishes the current cadence from
+  the N64-equivalent reference and authorizes repair design.
+- **PARTIAL:** the probe is reached but setup variance or incomplete windows
+  require one narrower measurement.
+- **REJECTED:** evidence contradicts the assumed magnitude; revisit the model
+  before changing timing.
+- **BLOCKED:** ordinary gameplay cannot produce the required window without
+  prohibited state injection.
+
+Measurement never closes TD-01 by itself.
+
+### T5 - later repair unit
+
+Only after T4 is CONFIRMED:
+
+- patch the source-derived player and guard timing seams together;
+- add deterministic before/after cadence checks that fail on Preview 4 and pass
+  on the candidate;
+- retain semi-automatic, menu, Aim, tank, and input behavior;
+- regenerate both embedded patch halves together when applicable; and
+- stop again for hands-on combat acceptance before merge or release.
+
+## Current checkpoint
+
+| Field | Value |
+| --- | --- |
+| Branch | `codex/preview4-td01-baseline` |
+| Starting source | `54474a40e93b77259d10c7594919e6a05f5e276d` |
+| Active debt | TD-01 |
+| Current phase | T3 real-gameplay measurement stop |
+| Runtime behavior change | None |
+| Simulator/device/GUI use | Prohibited in this pass |
+| First mandatory stop | T3 real-gameplay measurement |
+| Later rollback | Revert the single TD-01 repair commit; Preview 4 remains intact |
+
+Update this checkpoint and the authoritative status documents after every phase
+transition. Never convert a missing gameplay result into an inferred pass.
+
+## Terminal-only preflight evidence
+
+- Remote `main` and `v0.1.0-preview.4` both resolved to
+  `54474a40e93b77259d10c7594919e6a05f5e276d`; the published release targets
+  that commit.
+- The local published IPA and Mac archive re-hashed to the manifest values and
+  passed their 18-member and 20-member package audits.
+- `scripts/verify-preview4-baseline.sh` passed with no runtime diff from the
+  frozen source.
+- `scripts/verify-fire-rate-probe-contract.sh` passed the default-off, bounded-
+  window, hook/stub, and no-RDRAM-write checks.
+- `scripts/verify-recomp-input-matrix.sh` passed the 1.1 through 1.4, raw-menu,
+  native Aim, tank, tracked-patch, and generated-marker matrix using the pinned
+  Preview 4 reference checkout.
+- A command-line arm64 Mac Release rebuild of `GoldenPadMac` succeeded from the
+  frozen Preview 4 source and private generated inputs.
+- No Simulator was booted or built for, no app was launched, no iPad was read or
+  modified, and no desktop GUI automation was used.
+
+The next honest evidence is a complete sustained-player gameplay window. This
+loop stops here until real-gameplay use is authorized and available.

--- a/docs/TD01_FIRE_RATE_LOOP.md
+++ b/docs/TD01_FIRE_RATE_LOOP.md
@@ -1,6 +1,6 @@
 # TD-01 fire-rate measurement loop
 
-Status: **terminal-only preflight complete; stopped at the real-gameplay gate**
+Status: **Preview 4 player baseline confirmed; stopped before timing repair**
 
 Updated: 2026-08-23
 
@@ -17,6 +17,7 @@ repair only if the measurement supports it.
 
 This loop does not authorize merging, releasing, launching a Simulator, using a
 physical device, or controlling the desktop GUI without a later explicit gate.
+The physical-iPad measurement recorded below was separately authorized.
 
 ## State machine
 
@@ -56,25 +57,25 @@ and containment only, not measurement accuracy or gameplay behavior.
 Gate: every available terminal-only check is green, with unavailable private-
 input checks recorded rather than weakened.
 
-### T3 - stop for real-gameplay measurement
+### T3 - real-gameplay measurement
 
 Do not continue autonomously when the next evidence requires GoldenEye input.
-The missing evidence is:
+When physical use is authorized:
 
-1. launch the exact unchanged Preview 4 mobile runtime with
-   `--fire-rate-probe`;
-2. use one repeatable ordinary-input setup with one automatic weapon and at
-   least 34 starting rounds;
-3. hold ordinary Fire long enough to complete exactly 100 sampled ticks;
+1. launch the Preview 4 mobile runtime with only the observation probe enabled;
+2. use one repeatable ordinary-input setup with one automatic weapon;
+3. hold ordinary Fire through either a complete 100-tick window or a continuous
+   magazine-to-empty window containing at least 15 shot events;
 4. obtain three complete player windows without inventory, save, transform,
    mission, or enemy-state injection;
 5. record three separate fixed-line-of-sight guard windows; and
 6. preserve the bounded diagnostics log for comparison.
 
-A run is invalid if the weapon changes, the 100-tick completion line is absent,
-starting ammunition is below the discrimination requirement, input is
-synthesized below the ordinary host boundary, or another probe/behavior change
-is enabled.
+A run is invalid if the weapon changes, neither valid completion reason is
+present, a reload occurs inside the window, fewer than 15 shots are observed in
+a magazine window, input is synthesized below the ordinary host boundary, or
+another behavior change is enabled. Normalize magazine results to events per
+100 ticks before comparing them with the fixed-window reference.
 
 ### T4 - measurement decision
 
@@ -97,7 +98,12 @@ Choose one result:
 - **BLOCKED:** ordinary gameplay cannot produce the required window without
   prohibited state injection.
 
-Measurement never closes TD-01 by itself.
+Preview 4's player result is **CONFIRMED**: all three clean Phantom windows were
+20 events over 58 ticks, or 34.4828 events per 100 ticks. Mean and range are
+34.4828 and 0.0000. Event count matched the 20-to-0 ammo delta in every run.
+This is close to the pinned unscaled MGB64 observation of approximately 33.3
+and about 3.05 times its N64-equivalent reference of approximately 11.3. The
+measurement supports repair design but does not close TD-01 by itself.
 
 ### T5 - later repair unit
 
@@ -114,13 +120,13 @@ Only after T4 is CONFIRMED:
 
 | Field | Value |
 | --- | --- |
-| Branch | `codex/preview4-td01-baseline` |
+| Branch | `codex/td01-magazine-measurement` |
 | Starting source | `54474a40e93b77259d10c7594919e6a05f5e276d` |
 | Active debt | TD-01 |
-| Current phase | T3 real-gameplay measurement stop |
-| Runtime behavior change | None |
-| Simulator/device/GUI use | Prohibited in this pass |
-| First mandatory stop | T3 real-gameplay measurement |
+| Current phase | T4 CONFIRMED; stopped before T5 repair |
+| Runtime behavior change | Observation-only magazine completion and reload rejection; no game-state writes |
+| Simulator/device/GUI use | No Simulator or desktop GUI; separately authorized physical iPad only |
+| Next mandatory stop | Align the smallest source-derived player-and-guard repair before implementation |
 | Later rollback | Revert the single TD-01 repair commit; Preview 4 remains intact |
 
 Update this checkpoint and the authoritative status documents after every phase
@@ -145,5 +151,33 @@ transition. Never convert a missing gameplay result into an inferred pass.
 - No Simulator was booted or built for, no app was launched, no iPad was read or
   modified, and no desktop GUI automation was used.
 
-The next honest evidence is a complete sustained-player gameplay window. This
-loop stops here until real-gameplay use is authorized and available.
+## Physical-iPad player evidence
+
+The user launched Frigate on Agent and held ordinary controller Fire through
+the Phantom's full 20-round starting magazine. No inventory, save, transform,
+mission, enemy-state, or below-host input injection was used.
+
+| Run | Completion | Ticks | Events | Ammo | Normalized events/100 ticks | Private log SHA-256 |
+| ---: | --- | ---: | ---: | --- | ---: | --- |
+| 1 | magazine empty | 58 | 20 | 20 to 0 | 34.4828 | `6c4478104ee899cf23a142142caa8f1b82a14cc1658498478571356fdf2d8fee` |
+| 2 | magazine empty | 58 | 20 | 20 to 0 | 34.4828 | `4691fcaa65d07d4118a39dd78f067225a4099c79999bbb6f8ea9c7e23ee7b9f5` |
+| 3 | magazine empty | 58 | 20 | 20 to 0 | 34.4828 | `42c0fc59cce414d99e5249ef65160ec3fde581b2e0321bc6cbe7a7cad2e35517` |
+
+The first attempted session was rejected because intermittent firing and a
+reload crossed the old fixed-window assumption. The corrected probe accepts a
+continuous magazine of at least 15 shots, labels fixed versus magazine
+completion, and rejects reload-contaminated windows. A temporary signed test
+artifact defaulted this same read-only probe on so the user could launch the app
+normally; the temporary source line was reverted immediately after building.
+The temporary default-on executable was
+`be4f889fef891c38f72e81404796025ca705afc98ee9009e2284d361dc2b6c59`.
+After measurement, the test app was restored to a normally named, signed,
+probe-off-by-default executable at
+`36e0b46e416f944bc466cde86cbb4fb4b5fa351c63715c5c4ee7fae22a9f3c0a`.
+Both ROM copies, active and backup saves, and preferences remained byte-for-byte
+unchanged across every in-place test-app installation. Raw logs and game data
+remain private local evidence and are not committed.
+
+Remote `devicectl` activation caused severe controller/menu latency on this
+iPad. That path is rejected for future hands-on controller measurements; use a
+normally launched diagnostic artifact instead.

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -124,7 +124,7 @@ bundle unrelated changes. Every repair must be independently revertible.
 
 | ID | Priority | Problem | Evidence status | Current conclusion | Next gate before promotion |
 | --- | --- | --- | --- | --- | --- |
-| TD-01 | P0 | Automatic weapons and guard cadence at native 60 Hz | **Confirmed** in both pinned recomp lineages; Preview 4's default-off guard probe recorded 13/17/18 events per 100 ticks, while sustained player magnitude remains unmeasured | Primary runtime lacks the authenticity repair; presentation's “Original refresh” setting does not change simulation cadence | Use the unchanged Preview 4 probe with one ordinary setup holding at least 34 rounds; then patch player and guard seams together and re-accept combat |
+| TD-01 | P0 | Automatic weapons and guard cadence at native 60 Hz | **Confirmed**: Preview 4 guard windows recorded 13/17/18 events per 100 ticks and three physical-iPad Phantom magazines each recorded 20 events in 58 ticks, normalized to 34.4828 with zero range | Primary runtime lacks the authenticity repair; measured player cadence is about 3.05 times the pinned 11.3 N64-equivalent reference, while presentation's “Original refresh” setting does not change simulation cadence | Align one source-derived player-and-guard repair, add deterministic before/after checks, preserve Preview 4 input, then re-accept combat before merge |
 | TD-02 | P0 | Modern touch/controller sidestep semantics, [issue #8](https://github.com/chrissotraidis/goldenpad/issues/8) | **Repair released in Preview 4; reporter verification open** | Preview 4 replaces the opt-in Honey adapter with one shared 1.1 through 1.4 mapping and preserves raw menus, native left-stick Aim, and tank semantics; the user physically accepted the iPad control matrix | Ask the reporter to verify Preview 4 touch and controller behavior; do not change the accepted mapping without a new reproduction and the full regression gate |
 | TD-03 | P0 | A12X first-frame RT64/Metal crash, [issue #9](https://github.com/chrissotraidis/goldenpad/issues/9) | **Confirmed report** on the published Preview 1 IPA; cause unknown; full `.ips` and local A12 reproduction remain absent | A12X is inside the declared ARM64/Metal/iPadOS envelope. Plume's non-Metal3 descriptor-binding path is a strong diagnostic lead, not a proven cause | Obtain the full redacted `.ips` and A12 reproduction; separately force non-direct/Tier-1 binding paths in diagnostic-only builds on accepted hardware before selecting a repair or floor |
 | TD-04 | P1 | Screenshot, system-overlay, and foreground-resume stall/freeze | **Isolated discriminator evidence; physical classification open** | One experimental Simulator run recovered and another held all runtime-progress counters flat while diagnostics stayed live. This is not proof of a drawable-only stall; unbounded fence and queue waits remain | Run the opt-in physical transition matrix, then add only the wait-point instrumentation selected by the observed counter class |
@@ -189,12 +189,12 @@ regenerating for the second.
 
 ## Execution order
 
-The smartest next engineering action is to **finish the TD-01 sustained-player
-measurement** on the frozen Preview 4 baseline. Preview 4 already contains the
-default-off read-only probe and three guard windows; no rebase or runtime change
-is required before measurement. No player timing repair is authorized until an
-ordinary-input setup provides at least 34 rounds and three complete repeatable
-100-tick windows.
+The smartest next engineering action is to **design the TD-01 authenticity
+repair from the confirmed baseline**. Three ordinary-input Phantom magazines
+were identical at 20 events over 58 ticks, normalized to 34.4828 per 100 ticks;
+the retained guard windows are 13/17/18. Preserve Preview 4's controls, patch
+the source-derived player and guard timing seams together, and require
+deterministic before/after discrimination plus hands-on combat reacceptance.
 
 The smartest next user-facing actions are **issue #8 and issue #17 reporter
 confirmation against Preview 4**. Internal iPad acceptance does not close either
@@ -202,10 +202,11 @@ reporter's setup. TD-03 crash-artifact collection and A12-family reproduction
 can run as an evidence-only lane; no A12 code change is selected without that
 evidence. The next landing sequence is:
 
-1. freeze Preview 4 and finish sustained player cadence with its existing probe;
+1. preserve Preview 4 and the completed sustained-player/guard measurements;
 2. obtain issue #8 and issue #17 reporter confirmation against Preview 4;
-3. apply the fire-rate authenticity patch only after the probe proves the
-   current and expected numbers, then obtain hands-on combat acceptance;
+3. apply one independently revertible fire-rate authenticity patch only after
+   its exact player-and-guard mechanism is reviewed, then obtain hands-on combat
+   acceptance;
 4. close TD-14 modal/run-loop neutralization and TD-07 controller collapse as
    separate input-lifecycle units;
 5. run the already-defined physical audio/lifecycle/flicker evidence gates and

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -96,9 +96,10 @@ the isolated debt branches:
   #8 reporter verification, settings/share touch latch, controller-collapse
   neutral frame, multi-controller ownership, or physical lifecycle acceptance.
 - The fire-rate mechanism remains confirmed. Preview 4 retains the default-off
-  read-only probe that measured guard windows of 13/17/18 events per 100 ticks,
-  but sustained player evidence remains blocked on an ordinary setup with
-  enough ammunition.
+  read-only probe; three player magazines measured 34.4828 events per 100 ticks
+  with zero range and guard windows measured 13/17/18. The isolated shared-
+  getter candidate then produced the exact expected 12 player events/100 ticks
+  and received hands-on core-gameplay acceptance. Preview 5 releases that repair.
 - Matched isolated TD-06 runs recorded zero depth-`formatChanged` rebuilds, and
   a fixed-player-order diagnostic showed no systematic improvement and was
   reverted. The zero did not support predicted per-frame churn, but the counter
@@ -124,7 +125,7 @@ bundle unrelated changes. Every repair must be independently revertible.
 
 | ID | Priority | Problem | Evidence status | Current conclusion | Next gate before promotion |
 | --- | --- | --- | --- | --- | --- |
-| TD-01 | P0 | Automatic weapons and guard cadence at native 60 Hz | **Confirmed**: Preview 4 guard windows recorded 13/17/18 events per 100 ticks and three physical-iPad Phantom magazines each recorded 20 events in 58 ticks, normalized to 34.4828 with zero range | Primary runtime lacks the authenticity repair; measured player cadence is about 3.05 times the pinned 11.3 N64-equivalent reference, while presentation's “Original refresh” setting does not change simulation cadence | Align one source-derived player-and-guard repair, add deterministic before/after checks, preserve Preview 4 input, then re-accept combat before merge |
+| TD-01 | P0 | Automatic weapons and guard cadence at native 60 Hz | **Repaired in Preview 5**: Preview 4 measured 34.4828 player events/100 ticks; Preview 5 telemetry recorded the exact expected 12/100 and the user accepted navigation, movement, gameplay, and runtime quality | Root cause was the native-60-Hz host consuming N64-frame automatic-rate divisors without the frame-cost conversion; shared player/guard getter, nonpositive pass-through, generated MIPS, deterministic cadence, input/tank, iOS, Mac, package, and physical player gates pass | Retain the independently revertible repair and default-off diagnostic. No complete candidate guard window or explicit PP7 sequence was logged, so do not misstate those as physical evidence |
 | TD-02 | P0 | Modern touch/controller sidestep semantics, [issue #8](https://github.com/chrissotraidis/goldenpad/issues/8) | **Repair released in Preview 4; reporter verification open** | Preview 4 replaces the opt-in Honey adapter with one shared 1.1 through 1.4 mapping and preserves raw menus, native left-stick Aim, and tank semantics; the user physically accepted the iPad control matrix | Ask the reporter to verify Preview 4 touch and controller behavior; do not change the accepted mapping without a new reproduction and the full regression gate |
 | TD-03 | P0 | A12X first-frame RT64/Metal crash, [issue #9](https://github.com/chrissotraidis/goldenpad/issues/9) | **Confirmed report** on the published Preview 1 IPA; cause unknown; full `.ips` and local A12 reproduction remain absent | A12X is inside the declared ARM64/Metal/iPadOS envelope. Plume's non-Metal3 descriptor-binding path is a strong diagnostic lead, not a proven cause | Obtain the full redacted `.ips` and A12 reproduction; separately force non-direct/Tier-1 binding paths in diagnostic-only builds on accepted hardware before selecting a repair or floor |
 | TD-04 | P1 | Screenshot, system-overlay, and foreground-resume stall/freeze | **Isolated discriminator evidence; physical classification open** | One experimental Simulator run recovered and another held all runtime-progress counters flat while diagnostics stayed live. This is not proof of a drawable-only stall; unbounded fence and queue waits remain | Run the opt-in physical transition matrix, then add only the wait-point instrumentation selected by the observed counter class |
@@ -189,12 +190,12 @@ regenerating for the second.
 
 ## Execution order
 
-The smartest next engineering action is to **design the TD-01 authenticity
-repair from the confirmed baseline**. Three ordinary-input Phantom magazines
-were identical at 20 events over 58 ticks, normalized to 34.4828 per 100 ticks;
-the retained guard windows are 13/17/18. Preserve Preview 4's controls, patch
-the source-derived player and guard timing seams together, and require
-deterministic before/after discrimination plus hands-on combat reacceptance.
+The smartest next engineering action is to **keep released TD-01 frozen and
+take TD-14 modal/run-loop neutralization as a separate review unit**, followed
+by TD-07 disconnect containment. Preview 5 recorded the exact expected 12
+Phantom events/100 ticks versus Preview 4's 34.4828 and retained accepted core
+controls. The absent complete guard window and explicit PP7 sequence remain
+disclosed rather than retroactively represented as physical evidence.
 
 The smartest next user-facing actions are **issue #8 and issue #17 reporter
 confirmation against Preview 4**. Internal iPad acceptance does not close either

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -28,8 +28,9 @@ The current preview line deliberately leaves the following primary-runtime
 debt visible:
 
 - native-60-Hz player/guard automatic-fire cadence is not timing-authentic;
-- Preview 2 movement remains the default; Preview 3's opt-in Honey sidestep
-  adapter still needs issue-reporter and broader physical/style confirmation;
+- Preview 4 supersedes Preview 3's opt-in Honey sidestep adapter with one shared
+  1.1 through 1.4 mapping; issue #8 reporter confirmation remains open, but no
+  additional input rewrite is selected;
 - A12-family RT64/Metal compatibility is unresolved after the deterministic
   issue #9 first-frame crash report;
 - local multiplayer has a physically coherent experimental baseline, but slight
@@ -65,36 +66,39 @@ original turn behavior and does not expose native sidestepping.
 Physical controllers have a separate **Original N64 C-buttons** right-stick
 configuration. It emits C-left/C-right and restores GoldenEye's native
 sidestepping, but it replaces the modern analog right-stick look path. Preview 2
-has no corresponding touch template; Preview 3 adds a style-gated opt-in Honey
-adapter without changing that default.
+had no corresponding touch template; Preview 3 added a style-gated opt-in Honey
+adapter. Preview 4 supersedes both paths with one shared mapping for mobile and
+Mac that reads the active 1.1 through 1.4 style, keeps raw menu input, and
+preserves native left-stick Aim and tank semantics.
 
-The verified product decision is to correct the existing modern semantics, not
-add four visible C buttons or another preset first: modern MOVE horizontal
-strafes while LOOK horizontal turns. The explicit Original N64 C-button mode
-remains separate. The repair must keep menu navigation unchanged, avoid silently
-changing unrelated saved preferences, and pass hands-on iPhone, iPad, and
-physical-controller testing before becoming the default behavior.
+The verified product decision was to correct the existing modern semantics, not
+add four visible C buttons or another preset. Preview 4 implements and
+physically accepts that decision on iPad, including menus, native Aim, and the
+Runway tank path. Issue #8 remains open for its reporter and broader claimed-
+platform confirmation against the superseding Preview 4 release. That open
+verification is not evidence for another mapping change.
 
 ## External review disposition — 2026-08-23
 
 The attached independent revision-2 review is retained in
 [`EXTERNAL_REVIEW_2026-08-22.md`](EXTERNAL_REVIEW_2026-08-22.md). It inspected
 historical baseline `788667e`; it is supporting evidence, not repository
-instructions or a substitute for Preview 3 verification. Its source findings
+instructions or a substitute for Preview 4 verification. Its source findings
 remain useful, while its baseline statements and line references are frozen to
 that older tree.
 
 The review's documentation corrections are incorporated into the current
-authority documents. Its code findings were reconciled against Preview 3 and
+authority documents. Its code findings were reconciled against Preview 4 and
 the isolated debt branches:
 
-- Preview 3 adds game-state/watch guards to the sidestep adapter, releases the
-  opt-in Honey adapter, and replaces the Mac relative-mouse clamp path. It does
-  not close the settings/share touch latch, controller-collapse neutral frame,
-  issue #8, multi-controller ownership, or physical lifecycle acceptance.
-- The fire-rate mechanism remains confirmed. An isolated read-only probe later
-  measured guard windows of 13/17/18 events per 100 ticks, but sustained player
-  evidence remains blocked on an ordinary setup with enough ammunition.
+- Preview 4 supersedes the opt-in sidestep adapter with one shared 1.1 through
+  1.4 input mapping and accepted iPad Aim/tank behavior. It does not close issue
+  #8 reporter verification, settings/share touch latch, controller-collapse
+  neutral frame, multi-controller ownership, or physical lifecycle acceptance.
+- The fire-rate mechanism remains confirmed. Preview 4 retains the default-off
+  read-only probe that measured guard windows of 13/17/18 events per 100 ticks,
+  but sustained player evidence remains blocked on an ordinary setup with
+  enough ammunition.
 - Matched isolated TD-06 runs recorded zero depth-`formatChanged` rebuilds, and
   a fixed-player-order diagnostic showed no systematic improvement and was
   reverted. The zero did not support predicted per-frame churn, but the counter
@@ -120,8 +124,8 @@ bundle unrelated changes. Every repair must be independently revertible.
 
 | ID | Priority | Problem | Evidence status | Current conclusion | Next gate before promotion |
 | --- | --- | --- | --- | --- | --- |
-| TD-01 | P0 | Automatic weapons and guard cadence at native 60 Hz | **Confirmed** in both pinned recomp lineages; isolated GoldenPad guard-probe windows recorded 13/17/18 events per 100 ticks, while sustained player magnitude remains unmeasured | Primary runtime lacks the authenticity repair; presentation's “Original refresh” setting does not change simulation cadence | Resume the read-only sustained-player probe only with an ordinary setup holding at least 34 rounds; then patch player and guard seams together and re-accept combat |
-| TD-02 | P0 | Modern touch/controller sidestep semantics, [issue #8](https://github.com/chrissotraidis/goldenpad/issues/8) | **Opt-in adapter released; reporter verification open** | Preview 3 adds an opt-in, Honey-only touch/controller C-left/right adapter while preserving Preview 2 as default; the user accepted Preview 3 as stable for publication, but the issue reporter has not confirmed both input paths | Ask the reporter to verify touch and controller behavior; retain the full menu/watch/aim/style/lifecycle regression gate before changing the default |
+| TD-01 | P0 | Automatic weapons and guard cadence at native 60 Hz | **Confirmed** in both pinned recomp lineages; Preview 4's default-off guard probe recorded 13/17/18 events per 100 ticks, while sustained player magnitude remains unmeasured | Primary runtime lacks the authenticity repair; presentation's “Original refresh” setting does not change simulation cadence | Use the unchanged Preview 4 probe with one ordinary setup holding at least 34 rounds; then patch player and guard seams together and re-accept combat |
+| TD-02 | P0 | Modern touch/controller sidestep semantics, [issue #8](https://github.com/chrissotraidis/goldenpad/issues/8) | **Repair released in Preview 4; reporter verification open** | Preview 4 replaces the opt-in Honey adapter with one shared 1.1 through 1.4 mapping and preserves raw menus, native left-stick Aim, and tank semantics; the user physically accepted the iPad control matrix | Ask the reporter to verify Preview 4 touch and controller behavior; do not change the accepted mapping without a new reproduction and the full regression gate |
 | TD-03 | P0 | A12X first-frame RT64/Metal crash, [issue #9](https://github.com/chrissotraidis/goldenpad/issues/9) | **Confirmed report** on the published Preview 1 IPA; cause unknown; full `.ips` and local A12 reproduction remain absent | A12X is inside the declared ARM64/Metal/iPadOS envelope. Plume's non-Metal3 descriptor-binding path is a strong diagnostic lead, not a proven cause | Obtain the full redacted `.ips` and A12 reproduction; separately force non-direct/Tier-1 binding paths in diagnostic-only builds on accepted hardware before selecting a repair or floor |
 | TD-04 | P1 | Screenshot, system-overlay, and foreground-resume stall/freeze | **Isolated discriminator evidence; physical classification open** | One experimental Simulator run recovered and another held all runtime-progress counters flat while diagnostics stayed live. This is not proof of a drawable-only stall; unbounded fence and queue waits remain | Run the opt-in physical transition matrix, then add only the wait-point instrumentation selected by the observed counter class |
 | TD-05 | P1 | Intermittent audible static | **Observed report; cause unknown; rate mismatch ruled out** | Game, runtime, and host agree at 22,050 Hz. Isolated synthetic Simulator runs found no ring corruption or large jumps but did observe underruns; overflow discontinuity, reset race, cadence, and route artifacts remain | Capture one audible failing physical session with counter series and external timestamp; use the ROM-free signal only if the counters stay flat |
@@ -186,20 +190,20 @@ regenerating for the second.
 ## Execution order
 
 The smartest next engineering action is to **finish the TD-01 sustained-player
-measurement** on the unchanged Preview 3 baseline. The probe and guard windows
-already exist on an isolated branch, but no player timing repair is authorized
-until an ordinary-input setup provides enough ammunition for a repeatable
-comparison.
+measurement** on the frozen Preview 4 baseline. Preview 4 already contains the
+default-off read-only probe and three guard windows; no rebase or runtime change
+is required before measurement. No player timing repair is authorized until an
+ordinary-input setup provides at least 34 rounds and three complete repeatable
+100-tick windows.
 
-The smartest next user-facing action is **issue #8 reporter confirmation of the
-released opt-in TD-02 adapter**. Internal acceptance allowed Preview 3 to ship,
-but it did not close the reporter's touch/controller experience. TD-03 crash-
-artifact collection and A12-family reproduction can run as an evidence-only
-lane; no A12 code change is selected without that evidence. The next landing
-sequence is:
+The smartest next user-facing actions are **issue #8 and issue #17 reporter
+confirmation against Preview 4**. Internal iPad acceptance does not close either
+reporter's setup. TD-03 crash-artifact collection and A12-family reproduction
+can run as an evidence-only lane; no A12 code change is selected without that
+evidence. The next landing sequence is:
 
-1. rebase the read-only fire-rate probe and finish sustained player cadence;
-2. obtain issue #8 reporter confirmation for the released opt-in adapter;
+1. freeze Preview 4 and finish sustained player cadence with its existing probe;
+2. obtain issue #8 and issue #17 reporter confirmation against Preview 4;
 3. apply the fire-rate authenticity patch only after the probe proves the
    current and expected numbers, then obtain hands-on combat acceptance;
 4. close TD-14 modal/run-loop neutralization and TD-07 controller collapse as

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -115,11 +115,12 @@ player baseline is now complete: three clean Phantom magazines each recorded 20
 events over 58 ticks, normalized to 34.4828 events per 100 ticks with zero
 observed range.
 
-Before launching any app, run:
+Before launching any app for the repair candidate, run:
 
 ```sh
-scripts/verify-preview4-baseline.sh
+scripts/verify-preview4-baseline.sh --allow-td01-repair
 scripts/verify-fire-rate-probe-contract.sh
+scripts/verify-fire-rate-authenticity-repair.sh
 scripts/verify-recomp-input-matrix.sh
 git diff --check
 ```
@@ -157,11 +158,23 @@ GoldenPad's measured 34.4828 result is close to the unscaled reference and about
 any explained setup variance. Event count and ammo delta must agree or the
 observation is invalid.
 
-Stop after the unchanged measurement. A later, separate repair passes only if
+The selected repair scales the one shared positive automatic-rate getter by
+three, so the player and guard paths cannot drift. Zero and negative values,
+including the semi-automatic classification, are unchanged. It passes only if
 its before/after ratio matches the source-derived expectation, player and guard
 timing are changed as one coherent decision, semi-automatic and menu behavior
 remain unchanged, the complete Preview 4 input/tank matrix passes, and hands-on
 combat feel is explicitly re-accepted.
+
+For the physical candidate stop gate, normally launch `GoldenPad P4 Test`; do
+not use remote `devicectl` activation. On Frigate/Agent, continuously empty the
+first 20-round Phantom magazine once. The fixed 100-tick observation window
+should report approximately 11-12 shots instead of the Preview 4 magazine
+emptying at 20 shots/58 ticks. Then confirm: one PP7 shot per trigger press; one
+ordinary enemy automatic encounter is slower but functional; menu navigation,
+normal movement/look, and held-Aim left-stick sight control remain unchanged.
+One clean magazine is sufficient for this acceptance pass; do not repeat three
+baseline runs unless the result is inconsistent.
 
 #### Modern sidestep gate
 
@@ -468,11 +481,41 @@ Preview 4 release evidence:
 - Mac build/package proof does not close issue #17. Keep it open until the
   reporter verifies gameplay and supplies diagnostics if a problem remains.
 
-Run the focused input gate before every Preview 4 package:
+Run the focused input gate before every package that retains the Preview 4
+control boundary:
 
 ```sh
 ./scripts/verify-recomp-input-matrix.sh
 ```
+
+Preview 5 fire-rate release evidence:
+
+- `scripts/verify-fire-rate-authenticity-repair.sh` proves the frozen Preview 4
+  measurement control lacks the repair, positive automatic rates scale by
+  three in tracked source and generated MIPS, and zero/negative classifications
+  remain unchanged;
+- physical iPad telemetry recorded 12 Phantom events over 100 ticks, ammo 20 to
+  8, versus Preview 4's 20 events over 58 ticks. The user accepted navigation,
+  movement, controls, gameplay, and runtime quality;
+- the production mobile app is version `0.1.0` build `5`, ARM64, probe-off by
+  default, with unsigned executable SHA-256
+  `dff62592f42eede6d6865c12bb35ff97c6f548975d7c3903289f6d09fc462491`;
+- two independent packaging runs produced byte-identical 18-member unsigned
+  IPAs at SHA-256
+  `d4d6c6d7a00e79d1dd4759a97f3ae544c6112dff7c00ea9e57e21199a25c0db7`,
+  sorted app-content SHA-256
+  `4753f0814823aeecc545b5f33eea9d1bf2da0e7b93874e34ad5f6a0e8358981b`;
+- two independent packaging runs produced byte-identical 20-member native arm64
+  Mac Alpha archives at SHA-256
+  `3dec5864aa637a7115f46a41fd81b8b2077ac44904bf48d7396c54c03a6faee2`,
+  sorted app-content SHA-256
+  `0221a39c5137dec3a923b1e5c80b30886f4604486a9c3f23eeb1bcedfeb0ed8a`;
+- both archive verifiers passed their architecture, bundle, symbol, license,
+  signing, ROM/save, private-path, and generated-asset boundaries; and
+- no complete candidate guard fixed window or explicit PP7 sequence was
+  physically captured. The shared getter and unchanged nonpositive path provide
+  source/deterministic coverage; do not describe them as separate physical
+  evidence.
 
 ## Desktop baseline
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -107,23 +107,56 @@ that merely repeats the proposed implementation is insufficient.
 
 #### Native-60-Hz fire-rate gate
 
-The isolated read-only probe and three guard windows already pass at 13, 17,
-and 18 committed automatic-fire events per 100 ticks. Three short player
-tap-response windows matched ammo delta to event count, but they are not a
-sustained-fire baseline. Resume the probe only through the ordinary game input
-boundary, on a repeatable setup with at least 34 rounds, and record:
+The exact control is [`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md), and the
+bounded procedure is [`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md).
+Preview 4 already contains the default-off read-only probe; do not rebase or
+rewrite it before measurement. Three guard windows already pass at 13, 17, and
+18 committed automatic-fire events per 100 ticks. Three short player tap-
+response windows matched ammo delta to event count, but they are not a
+sustained-fire baseline.
 
+Before launching any app, run:
+
+```sh
+scripts/verify-preview4-baseline.sh
+scripts/verify-fire-rate-probe-contract.sh
+scripts/verify-recomp-input-matrix.sh
+git diff --check
+```
+
+These terminal checks prove source identity, default-off wiring, observation
+containment, and the accepted input mapping. They do not prove cadence or
+gameplay. The runtime source diff from Preview 4 must be empty at this stage.
+
+When real-gameplay use is separately authorized, enable only
+`--fire-rate-probe`. Use one repeatable ordinary-input setup with one automatic
+weapon and at least 34 starting rounds. Obtain three complete player windows
+through the ordinary game input boundary and record:
+
+- source commit and executable identity;
+- platform, stage, difficulty, control style, weapon, and input device;
 - simulation ticks;
 - weapon and starting/ending ammo;
 - player automatic-shot events; and
-- a fixed-line-of-sight guard's automatic-shot events in a separate run.
+- starting/ending player fire counter.
+
+Then record three fixed-line-of-sight guard windows separately. Do not inject
+inventory, mutate a save, force a transform, move the player, alter mission or
+enemy state, or publish input below the ordinary host boundary. Reject a run if
+the weapon changes, the 100-tick completion line is absent, starting ammunition
+is below the discrimination requirement, or another probe is enabled.
 
 Run the unmodified baseline first. The pinned MGB64 reference measured AK-47 at
 33.3 shots per 100 locked-60-Hz ticks without authenticity scaling and 11.3 at
 the N64-equivalent cadence; GoldenPad's own result must be recorded rather than
-assumed. A later repair passes only if its before/after ratio matches the
-source-derived expectation, semi-automatic and menu behavior remain unchanged,
-and hands-on combat feel is explicitly re-accepted.
+assumed. Record every complete run, mean, range, and any explained setup
+variance. Event count and ammo delta must agree or the observation is invalid.
+
+Stop after the unchanged measurement. A later, separate repair passes only if
+its before/after ratio matches the source-derived expectation, player and guard
+timing are changed as one coherent decision, semi-automatic and menu behavior
+remain unchanged, the complete Preview 4 input/tank matrix passes, and hands-on
+combat feel is explicitly re-accepted.
 
 #### Modern sidestep gate
 
@@ -151,7 +184,7 @@ pause, and a scroll-tracking gesture. Assert that:
 - the 60 Hz mobile publisher remains scheduled through common-mode UI tracking,
   or the UI explicitly suspends and resumes it with a neutral boundary;
 - native menu/watch navigation remains unchanged; and
-- ordinary Preview 3 touch/controller gameplay resumes only after fresh input.
+- ordinary Preview 4 touch/controller gameplay resumes only after fresh input.
 
 Run the gate in normal single-player and the controller-P1/touch-P2 diagnostic.
 Scene-inactive release alone does not pass sheet presentation, because a SwiftUI

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -109,11 +109,11 @@ that merely repeats the proposed implementation is insufficient.
 
 The exact control is [`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md), and the
 bounded procedure is [`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md).
-Preview 4 already contains the default-off read-only probe; do not rebase or
-rewrite it before measurement. Three guard windows already pass at 13, 17, and
-18 committed automatic-fire events per 100 ticks. Three short player tap-
-response windows matched ammo delta to event count, but they are not a
-sustained-fire baseline.
+Preview 4 contains the default-off read-only probe. Three guard windows recorded
+13, 17, and 18 committed automatic-fire events per 100 ticks. The physical iPad
+player baseline is now complete: three clean Phantom magazines each recorded 20
+events over 58 ticks, normalized to 34.4828 events per 100 ticks with zero
+observed range.
 
 Before launching any app, run:
 
@@ -126,12 +126,15 @@ git diff --check
 
 These terminal checks prove source identity, default-off wiring, observation
 containment, and the accepted input mapping. They do not prove cadence or
-gameplay. The runtime source diff from Preview 4 must be empty at this stage.
+gameplay. For the recorded measurement branch, use
+`scripts/verify-preview4-baseline.sh --allow-td01-probe`; it permits only the
+documented observation-body delta and still rejects input or timing changes.
 
-When real-gameplay use is separately authorized, enable only
-`--fire-rate-probe`. Use one repeatable ordinary-input setup with one automatic
-weapon and at least 34 starting rounds. Obtain three complete player windows
-through the ordinary game input boundary and record:
+When real-gameplay use is separately authorized, enable only the fire-rate
+probe. Use one repeatable ordinary-input setup with one automatic weapon.
+Obtain three complete player windows through the ordinary game input boundary.
+A valid window is either 100 sampled ticks or a continuous magazine-to-empty
+window containing at least 15 shot events. Record:
 
 - source commit and executable identity;
 - platform, stage, difficulty, control style, weapon, and input device;
@@ -143,14 +146,16 @@ through the ordinary game input boundary and record:
 Then record three fixed-line-of-sight guard windows separately. Do not inject
 inventory, mutate a save, force a transform, move the player, alter mission or
 enemy state, or publish input below the ordinary host boundary. Reject a run if
-the weapon changes, the 100-tick completion line is absent, starting ammunition
-is below the discrimination requirement, or another probe is enabled.
+the weapon changes, a reload occurs inside the window, neither valid completion
+reason is present, a magazine window has fewer than 15 events, or another
+behavior probe is enabled. Normalize magazine results to events per 100 ticks.
 
-Run the unmodified baseline first. The pinned MGB64 reference measured AK-47 at
-33.3 shots per 100 locked-60-Hz ticks without authenticity scaling and 11.3 at
-the N64-equivalent cadence; GoldenPad's own result must be recorded rather than
-assumed. Record every complete run, mean, range, and any explained setup
-variance. Event count and ammo delta must agree or the observation is invalid.
+The pinned MGB64 reference measured AK-47 at 33.3 shots per 100 locked-60-Hz
+ticks without authenticity scaling and 11.3 at the N64-equivalent cadence.
+GoldenPad's measured 34.4828 result is close to the unscaled reference and about
+3.05 times the authentic target. Record every complete run, mean, range, and
+any explained setup variance. Event count and ammo delta must agree or the
+observation is invalid.
 
 Stop after the unchanged measurement. A later, separate repair passes only if
 its before/after ratio matches the source-derived expectation, player and guard

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -1,5 +1,30 @@
 # Worklog
 
+## 2026-08-23 - freeze Preview 4 and stop TD-01 at the gameplay gate
+
+- Created an isolated `codex/preview4-td01-baseline` worktree from published
+  merge `54474a40e93b77259d10c7594919e6a05f5e276d`, leaving the existing dirty
+  `codex/mac-wasd-focus` checkout untouched.
+- Verified remote `main`, tag `v0.1.0-preview.4`, and the published prerelease
+  all identify that merge. Re-hashed the retained hosted-release artifacts to
+  IPA SHA-256
+  `ff163b0af6b54596590da8e39cbaff0b388b69f1607ca34f62ce61e7fe144130`
+  and Mac archive SHA-256
+  `63bec02ad6e323a213f9cb9d15f763a58d6eb7bd4a1a40af6341a4fb8fb333ba`.
+- Added `PREVIEW_4_BASELINE.md` as the immutable source, artifact, accepted-
+  behavior, diagnostic, and rollback record. Reconciled current status, debt,
+  plan, queue, and testing documents from stale Preview 3 wording to Preview 4.
+- Added `TD01_FIRE_RATE_LOOP.md` with explicit freeze, containment, terminal-
+  verification, measurement, decision, repair, rollback, and stop phases.
+- Added default-off probe and frozen-baseline guards. Tightened the mobile,
+  native Mac, and future host package audits so the fire-rate control symbol
+  cannot disappear silently. No runtime source or gameplay behavior changed.
+- Passed the baseline guard, probe contract, full shared input/tank matrix,
+  IPA audit, Mac archive audit, and a command-line arm64 Mac Release rebuild.
+- Stopped at the first evidence that requires real GoldenEye input: three
+  complete 100-tick player windows from one ordinary setup with at least 34
+  rounds. No Simulator, app launch, iPad access, or GUI automation occurred.
+
 ## 2026-08-23 - accept and publish the Preview 4 tank and shared-controls repair
 
 - Froze the exact physically accepted signed iPad test executable at SHA-256

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -1,5 +1,33 @@
 # Worklog
 
+## 2026-08-23 - confirm Preview 4 sustained-player fire-rate baseline
+
+- Kept the accepted Preview 4 controls frozen and changed only the bounded
+  TD-01 observation body: continuous magazine-to-empty windows require at least
+  15 shot events, identify their completion reason, and reject reload crossings.
+  The probe still writes no game state and remains off by default in source.
+- Rejected the first attempted session because intermittent firing and reload
+  contaminated its fixed windows. On physical iPad, the user then completed
+  three ordinary-controller Phantom magazines on Frigate/Agent. Every valid run
+  recorded 20 events, ammo 20 to 0, and 58 simulation ticks: 34.4828 events per
+  100 ticks, mean 34.4828, range 0.0000.
+- The result is close to the pinned unscaled reference of approximately 33.3
+  and about 3.05 times the pinned N64-equivalent reference of approximately
+  11.3. T4 is therefore CONFIRMED, authorizing repair design but not merge,
+  release, or TD-01 closure.
+- Remote `devicectl` activation caused severe controller/menu latency on this
+  iPad. Replaced it with a temporary signed P4 Test artifact that defaulted the
+  same observation-only probe on and was launched normally by the user. The
+  temporary source line was reverted immediately after building.
+- Installed only the side-by-side `com.chrissotraidis.goldenpad.preview4test`
+  bundle. The ordinary GoldenPad app remained untouched. Both ROM copies,
+  active and backup saves, and preferences were byte-identical after in-place
+  installation; raw logs and game data remain private local evidence.
+- Stopped before timing repair. The next unit must align one source-derived,
+  independently revertible player-and-guard repair, add deterministic
+  before/after discrimination, preserve the full Preview 4 input/tank matrix,
+  and stop again for hands-on combat acceptance.
+
 ## 2026-08-23 - freeze Preview 4 and stop TD-01 at the gameplay gate
 
 - Created an isolated `codex/preview4-td01-baseline` worktree from published

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -1,5 +1,71 @@
 # Worklog
 
+## 2026-08-24 - package and publish Preview 5 automatic-fire repair
+
+- Advanced only the primary iPhone/iPad bundle identity from build `4` to build
+  `5`; the public release name is `0.1.0-preview.5`. Preview 4's controls, Aim,
+  tank mapping, sensitivity, renderer, audio, ROM import, saves, and storage
+  behavior remain unchanged.
+- Built a fresh production-bundle ARM64 device app from probe-off source. Its
+  unsigned public executable SHA-256 is
+  `dff62592f42eede6d6865c12bb35ff97c6f548975d7c3903289f6d09fc462491`.
+- Built the native arm64 Mac target from the same regenerated GoldenEye patch.
+  The packaged ad-hoc-signed executable SHA-256 is
+  `5960150d9eb668b814973045fdfe054240f7c9ef11ff2be9025957884c758bca`.
+- Two independent packaging passes produced byte-identical 18-member unsigned
+  IPAs at SHA-256
+  `d4d6c6d7a00e79d1dd4759a97f3ae544c6112dff7c00ea9e57e21199a25c0db7`
+  and byte-identical 20-member Mac Alpha archives at SHA-256
+  `3dec5864aa637a7115f46a41fd81b8b2077ac44904bf48d7396c54c03a6faee2`.
+  Both package verifiers passed architecture, bundle identity, symbols,
+  licenses, ROM/save/signing, generated-asset, and private-path boundaries.
+- Reconciled README, status, testing, technical debt, plan, next steps,
+  building, release checklist, TD-01 loop, and public Preview 5 release notes.
+  The absent complete candidate guard window and explicit PP7 physical sequence
+  remain disclosed; source/shared-getter and deterministic evidence are not
+  represented as separate physical tests.
+
+## 2026-08-23 - build the isolated TD-01 authenticity candidate
+
+- Audited every decompiled caller of `bondwalkItemGetAutomaticFiringRate`.
+  Player and guard automatic-fire paths use its positive result as their modulo
+  divisor; the remaining callers only classify nonpositive values.
+- Added one shared game-side repair that multiplies positive automatic rates by
+  the N64 frame cost of three and returns zero/negative values unchanged. This
+  preserves semi-automatic classification and avoids separate player/guard
+  policies. No input, Aim, tank, menu, damage, ammo, renderer, or host-timing
+  code changed.
+- Regenerated the private `patches.bin`, `patches.c`, and `patches_bin.c` pair
+  together. Added stale-pair CMake ratchets and a deterministic verifier that
+  proves representative positive rates triple, nonpositive values do not, and
+  the frozen measurement commit lacks the repair.
+- Passed the repair-aware Preview 4 baseline guard, probe contract, complete
+  shared input/tank matrix, signed iOS device build, and native arm64 Mac
+  Release build. The signed P4 Test executable is
+  `146f3f37d568620ce55910ec2a09bc912336ba56b8afc9183862636e5d81015d`;
+  its probe is temporarily default-on only in the artifact, and source was
+  immediately restored to default-off.
+- Installed that candidate in place over only
+  `com.chrissotraidis.goldenpad.preview4test`. Read-only inventory confirmed
+  `GoldenPad P4 Test` version `0.1.0` build `4`. Fresh pre/post readbacks proved
+  both ROM copies, active save, backup save, and preferences byte-identical.
+  The ordinary GoldenPad app was not targeted, and the candidate was not
+  remotely launched because that path previously caused controller latency.
+- Stopped before commit, merge, release, or TD-01 closure. The next gate is one
+  physical Phantom magazine, PP7 semi-auto check, enemy automatic encounter,
+  and core Preview 4 controls regression. Revert the single repair commit to
+  return to the published Preview 4 behavior.
+- The user then normally launched P4 Test and accepted navigation, movement,
+  general gameplay, and runtime quality with no observed regression. The
+  bounded diagnostic recorded the primary Phantom result at 12 events over 100
+  ticks, ammo 20 to 8, exactly matching the scaled interval including the
+  immediate first shot; Preview 4 had recorded 20 events over 58 ticks.
+- The session advanced to 13,723 display lists/VI updates/presentations with
+  zero audio drops or underruns and no fatal/current-session crash marker. No
+  complete guard window or explicit PP7 sequence was captured, so those remain
+  source/deterministic rather than physical evidence. The candidate is accepted
+  for commit/review, but remains uncommitted, unmerged, and unreleased.
+
 ## 2026-08-23 - confirm Preview 4 sustained-player fire-rate baseline
 
 - Kept the accepted Preview 4 controls frozen and changed only the bounded

--- a/patches/goldeneye64recomp-ios-modern-controls.patch
+++ b/patches/goldeneye64recomp-ios-modern-controls.patch
@@ -19,10 +19,10 @@ index 609e348..6d1ac4d 100644
  extern s32 cameraFrameCounter2;
  extern s32 cameraBufferToggle;
 diff --git a/patches/patches.h b/patches/patches.h
-index 77b502e..9c0ca27 100644
+index 77b502e..4584b42 100644
 --- a/patches/patches.h
 +++ b/patches/patches.h
-@@ -117,6 +117,22 @@ int recomp_printf(const char* fmt, ...);
+@@ -117,6 +117,23 @@ int recomp_printf(const char* fmt, ...);
      extern u8 identifier[]
  
  float recomp_get_aspect_ratio(float);
@@ -36,6 +36,7 @@ index 77b502e..9c0ca27 100644
 +    s32 playernum, s32 weapon, s32 ammo, s32 counter);
 +void goldenpad_recomp_fire_rate_guard_sample(
 +    s32 item, s32 before, s32 after, u32 guardKey);
++void* get_ptr_item_statistics(s32 item);
 +s32 getCurrentPlayerWeaponId(s32 hand);
 +void attempt_reload_item_in_hand(s32 hand);
 +s32 bondinvCountTotalItemsInInv(void);
@@ -64,13 +65,31 @@ index 31e51b1..b1c0697 100644
 +goldenpad_recomp_consume_reload = 0x8F000128;
 +goldenpad_recomp_consume_inventory_slot = 0x8F00012C;
 diff --git a/patches/workbench_theboy.c b/patches/workbench_theboy.c
-index d4424c7..aeb865b 100644
+index d4424c7..53ae2b6 100644
 --- a/patches/workbench_theboy.c
 +++ b/patches/workbench_theboy.c
-@@ -473,6 +473,182 @@ void InitFrameRateControl(void)
+@@ -473,6 +473,200 @@ void InitFrameRateControl(void)
  extern s32 g_DebugMode;
  extern s32 g_DebugHighlightedOption;
  
++#define GOLDENPAD_AUTHENTIC_FRAME_COST 3
++#define GOLDENPAD_AUTOMATIC_RATE_OFFSET 0x22
++
++static s32 goldenpadScaleAutomaticFiringRate(s32 rawRate)
++{
++    return rawRate > 0 ? rawRate * GOLDENPAD_AUTHENTIC_FRAME_COST : rawRate;
++}
++
++/* The shared getter feeds Bond's and guards' positive automatic modulo gates.
++ * Its other retail call sites only test the sign, so preserving zero/negative
++ * values keeps semi-automatic, accuracy, animation, and first-shot behavior. */
++RECOMP_PATCH s8 bondwalkItemGetAutomaticFiringRate(ITEM_IDS item)
++{
++    const s8 rawRate = ((s8*) get_ptr_item_statistics(item))[GOLDENPAD_AUTOMATIC_RATE_OFFSET];
++
++    return (s8) goldenpadScaleAutomaticFiringRate(rawRate);
++}
++
 +RECOMP_PATCH s32 get_debug_enable_all_levels_flag(void)
 +{
 +    return goldenpad_recomp_unlock_all_missions_enabled();
@@ -250,7 +269,7 @@ index d4424c7..aeb865b 100644
  RECOMP_PATCH void bossMainloop(void) {
      // declarations
  
-@@ -702,6 +878,12 @@ RECOMP_PATCH void bossMainloop(void) {
+@@ -702,6 +896,12 @@ RECOMP_PATCH void bossMainloop(void) {
                                      viSetViewPosition(localPlayer->viewleft, localPlayer->viewtop);
  
                                      lvlViewMoveTick();

--- a/scripts/package-recomp-macos-alpha.sh
+++ b/scripts/package-recomp-macos-alpha.sh
@@ -5,7 +5,7 @@ repo_root=$(cd "$(dirname "$0")/.." && pwd)
 "$repo_root/scripts/verify-recomp-input-matrix.sh"
 
 app_path=${GOLDENPAD_RECOMP_MAC_APP:-"$repo_root/build-recomp-macos-stable/Release/GoldenPad.app"}
-release_name=${GOLDENPAD_RELEASE_NAME:-0.1.0-preview.4}
+release_name=${GOLDENPAD_RELEASE_NAME:-0.1.0-preview.5}
 output_name="GoldenPad-${release_name}-macos-arm64-alpha.zip"
 output_path="$repo_root/dist/$output_name"
 

--- a/scripts/package-recomp-prototype-ipa.sh
+++ b/scripts/package-recomp-prototype-ipa.sh
@@ -5,7 +5,7 @@ repo_root=$(cd "$(dirname "$0")/.." && pwd)
 "$repo_root/scripts/verify-recomp-input-matrix.sh"
 
 app_path=${GOLDENPAD_RECOMP_APP:-"$repo_root/build-recomp-prototype-device/Release-iphoneos/GoldenPadRecompPrototype.app"}
-release_name=${GOLDENPAD_RELEASE_NAME:-0.1.0-preview.4}
+release_name=${GOLDENPAD_RELEASE_NAME:-0.1.0-preview.5}
 output_name="GoldenPad-${release_name}-unsigned.ipa"
 output_path="$repo_root/dist/$output_name"
 

--- a/scripts/verify-fire-rate-authenticity-repair.sh
+++ b/scripts/verify-fire-rate-authenticity-repair.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+measurement_commit=9f039518090f634d1ea8d216416dcdfd5af02dcf
+reference_root=${GOLDENPAD_RECOMP_REFERENCE_ROOT:-"$repo_root/ref/goldeneye64recomp"}
+tracked_patch="$repo_root/patches/goldeneye64recomp-ios-modern-controls.patch"
+source_patch="$reference_root/patches/workbench_theboy.c"
+generated_patch="$reference_root/RecompiledPatches/patches.c"
+generated_binary="$reference_root/RecompiledPatches/patches_bin.c"
+
+require_marker() {
+    marker=$1
+    source_file=$2
+    if ! grep -Fq -- "$marker" "$source_file"; then
+        echo "FAIL: missing TD-01 repair marker '$marker' in $source_file" >&2
+        exit 1
+    fi
+}
+
+for source_file in "$source_patch" "$generated_patch" "$generated_binary"
+do
+    if [ ! -f "$source_file" ]; then
+        echo "FAIL: missing generated-patch input $source_file" >&2
+        exit 1
+    fi
+done
+
+if git -C "$repo_root" show "$measurement_commit:patches/goldeneye64recomp-ios-modern-controls.patch" |
+    grep -Fq 'RECOMP_PATCH s8 bondwalkItemGetAutomaticFiringRate'; then
+    echo "FAIL: the frozen measurement control already contains the repair" >&2
+    exit 1
+fi
+
+for marker in \
+    '#define GOLDENPAD_AUTHENTIC_FRAME_COST 3' \
+    '#define GOLDENPAD_AUTOMATIC_RATE_OFFSET 0x22' \
+    'return rawRate > 0 ? rawRate * GOLDENPAD_AUTHENTIC_FRAME_COST : rawRate;' \
+    'RECOMP_PATCH s8 bondwalkItemGetAutomaticFiringRate(ITEM_IDS item)'
+do
+    require_marker "$marker" "$tracked_patch"
+    require_marker "$marker" "$source_patch"
+done
+
+for marker in \
+    'RECOMP_FUNC void bondwalkItemGetAutomaticFiringRate' \
+    'ctx->r2 = MEM_B(ctx->r2, 0X22);' \
+    'ctx->r1 = SIGNED(0) < SIGNED(ctx->r2) ? 1 : 0;' \
+    'ctx->r1 = S32(ctx->r2 << 1);' \
+    'ctx->r2 = ADD32(ctx->r1, ctx->r2);'
+do
+    require_marker "$marker" "$generated_patch"
+done
+
+if [ "$reference_root/patches/patches.bin" -nt "$generated_binary" ]; then
+    echo "FAIL: patches_bin.c is older than the regenerated patches.bin" >&2
+    exit 1
+fi
+
+scale_rate() {
+    raw_rate=$1
+    if [ "$raw_rate" -gt 0 ]; then
+        echo $((raw_rate * 3))
+    else
+        echo "$raw_rate"
+    fi
+}
+
+for case_value in 2:6 3:9 4:12 5:15 11:33 0:0 -1:-1
+do
+    raw_rate=${case_value%%:*}
+    expected=${case_value#*:}
+    actual=$(scale_rate "$raw_rate")
+    if [ "$actual" -ne "$expected" ]; then
+        echo "FAIL: raw automatic rate $raw_rate scaled to $actual, expected $expected" >&2
+        exit 1
+    fi
+done
+
+legacy_shots=$((360 / 3))
+authentic_shots=$((360 / 9))
+if [ "$legacy_shots" -ne 120 ] || [ "$authentic_shots" -ne 40 ] ||
+    [ "$legacy_shots" -ne $((authentic_shots * 3)) ]; then
+    echo "FAIL: deterministic 360-tick cadence discriminator is inconsistent" >&2
+    exit 1
+fi
+
+echo "PASS: frozen measurement control lacks the TD-01 timing repair"
+echo "PASS: tracked source and generated MIPS patch scale positive automatic rates by 3"
+echo "PASS: zero and negative semi-automatic classifications remain unchanged"
+echo "PASS: deterministic rate-3 lane changes from 120 to 40 gates over 360 ticks"
+echo "NOTE: physical player/guard cadence and combat feel still require hands-on acceptance"

--- a/scripts/verify-fire-rate-probe-contract.sh
+++ b/scripts/verify-fire-rate-probe-contract.sh
@@ -20,6 +20,7 @@ require_marker 'std::atomic<bool> fireRateProbeEnabled = false;' "$runtime_sourc
 require_marker 'ProcessInfo.processInfo.arguments.contains("--fire-rate-probe") ? 1 : 0' "$mobile_source"
 require_marker 'constexpr uint32_t kFireRateWindowTicks = 100;' "$runtime_source"
 require_marker 'constexpr uint32_t kFireRateProbeRunLimit = 3;' "$runtime_source"
+require_marker 'constexpr uint32_t kFireRateMinimumMagazineEvents = 15;' "$runtime_source"
 require_marker 'if (!fireRateProbeEnabled.load(std::memory_order_acquire)) {' "$runtime_source"
 require_marker 'extern "C" void goldenpad_recomp_fire_rate_player_sample(' "$runtime_source"
 require_marker 'extern "C" void goldenpad_recomp_fire_rate_guard_sample(' "$runtime_source"
@@ -27,6 +28,9 @@ require_marker 'extern "C" void goldenpad_recomp_set_fire_rate_probe_enabled(int
 require_marker 'goldenpad_recomp_fire_rate_player_sample(' "$tracked_patch"
 require_marker 'goldenpad_recomp_fire_rate_guard_sample(' "$tracked_patch"
 require_marker 'chrlvFireWeaponRelated(chr, hand);' "$tracked_patch"
+require_marker 'completePlayerFireRateWindow("magazine-empty");' "$runtime_source"
+require_marker 'completePlayerFireRateWindow("fixed-window");' "$runtime_source"
+require_marker 'abort reason=reload' "$runtime_source"
 
 probe_bodies=$(sed -n \
     '/extern "C" void goldenpad_recomp_fire_rate_player_sample(/,/extern "C" void goldenpad_recomp_set_two_player_test_mode(/p' \
@@ -44,6 +48,6 @@ do
 done
 
 echo "PASS: TD-01 probe defaults off and requires the explicit launch argument"
-echo "PASS: player and guard observation hooks, bounded windows, and ROM-free stub are present"
+echo "PASS: player and guard hooks, fixed/magazine windows, reload rejection, and ROM-free stub are present"
 echo "PASS: observation bodies contain no RDRAM or recompiled return-value writes"
 echo "NOTE: this static contract does not prove cadence, gameplay feel, or physical behavior"

--- a/scripts/verify-fire-rate-probe-contract.sh
+++ b/scripts/verify-fire-rate-probe-contract.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+runtime_source="$repo_root/Support/RecompPrototype/recomp_game_start.cpp"
+mobile_source="$repo_root/Sources/RecompPrototypeInput.swift"
+stub_source="$repo_root/Support/RecompPrototype/recomp_rt64_surface_stub.cpp"
+tracked_patch="$repo_root/patches/goldeneye64recomp-ios-modern-controls.patch"
+
+require_marker() {
+    marker=$1
+    source_file=$2
+    if ! grep -Fq -- "$marker" "$source_file"; then
+        echo "FAIL: missing probe contract marker '$marker' in $source_file" >&2
+        exit 1
+    fi
+}
+
+require_marker 'std::atomic<bool> fireRateProbeEnabled = false;' "$runtime_source"
+require_marker 'ProcessInfo.processInfo.arguments.contains("--fire-rate-probe") ? 1 : 0' "$mobile_source"
+require_marker 'constexpr uint32_t kFireRateWindowTicks = 100;' "$runtime_source"
+require_marker 'constexpr uint32_t kFireRateProbeRunLimit = 3;' "$runtime_source"
+require_marker 'if (!fireRateProbeEnabled.load(std::memory_order_acquire)) {' "$runtime_source"
+require_marker 'extern "C" void goldenpad_recomp_fire_rate_player_sample(' "$runtime_source"
+require_marker 'extern "C" void goldenpad_recomp_fire_rate_guard_sample(' "$runtime_source"
+require_marker 'extern "C" void goldenpad_recomp_set_fire_rate_probe_enabled(int32_t) {}' "$stub_source"
+require_marker 'goldenpad_recomp_fire_rate_player_sample(' "$tracked_patch"
+require_marker 'goldenpad_recomp_fire_rate_guard_sample(' "$tracked_patch"
+require_marker 'chrlvFireWeaponRelated(chr, hand);' "$tracked_patch"
+
+probe_bodies=$(sed -n \
+    '/extern "C" void goldenpad_recomp_fire_rate_player_sample(/,/extern "C" void goldenpad_recomp_set_two_player_test_mode(/p' \
+    "$runtime_source")
+if printf '%s\n' "$probe_bodies" | grep -Eq 'MEM_W|writeGameWord|_return<'; then
+    echo "FAIL: TD-01 observation body contains a game-memory or return-value write" >&2
+    exit 1
+fi
+
+for verifier in \
+    "$repo_root/scripts/verify-recomp-prototype-host.sh" \
+    "$repo_root/scripts/verify-recomp-prototype-ipa.sh"
+do
+    require_marker 'goldenpad_recomp_set_fire_rate_probe_enabled' "$verifier"
+done
+
+echo "PASS: TD-01 probe defaults off and requires the explicit launch argument"
+echo "PASS: player and guard observation hooks, bounded windows, and ROM-free stub are present"
+echo "PASS: observation bodies contain no RDRAM or recompiled return-value writes"
+echo "NOTE: this static contract does not prove cadence, gameplay feel, or physical behavior"

--- a/scripts/verify-preview4-baseline.sh
+++ b/scripts/verify-preview4-baseline.sh
@@ -4,6 +4,15 @@ set -eu
 repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 baseline_commit=54474a40e93b77259d10c7594919e6a05f5e276d
 baseline_tree=4232141f9d14d2f6197e43173694f649828e730f
+mode=${1:-strict}
+
+case "$mode" in
+    strict|--allow-td01-probe) ;;
+    *)
+        echo "Usage: $0 [--allow-td01-probe]" >&2
+        exit 2
+        ;;
+esac
 
 git -C "$repo_root" cat-file -e "$baseline_commit^{commit}"
 
@@ -19,15 +28,19 @@ if ! git -C "$repo_root" merge-base --is-ancestor "$baseline_commit" HEAD; then
 fi
 
 runtime_paths='CMakeLists.txt Config Sources Support Tests patches'
-if ! git -C "$repo_root" diff --quiet "$baseline_commit" -- $runtime_paths; then
-    echo "FAIL: runtime source differs from frozen Preview 4 before measurement" >&2
-    git -C "$repo_root" diff --name-only "$baseline_commit" -- $runtime_paths >&2
-    exit 1
+runtime_diff=$(git -C "$repo_root" diff --name-only "$baseline_commit" -- $runtime_paths)
+if [ -n "$runtime_diff" ]; then
+    if [ "$mode" != "--allow-td01-probe" ] ||
+        [ "$runtime_diff" != "Support/RecompPrototype/recomp_game_start.cpp" ]; then
+        echo "FAIL: runtime diff exceeds the selected Preview 4 measurement boundary" >&2
+        printf '%s\n' "$runtime_diff" >&2
+        exit 1
+    fi
 fi
 
-untracked_runtime=$(git -C "$repo_root" status --porcelain --untracked-files=all -- $runtime_paths)
+untracked_runtime=$(git -C "$repo_root" ls-files --others --exclude-standard -- $runtime_paths)
 if [ -n "$untracked_runtime" ]; then
-    echo "FAIL: untracked or staged runtime files exist before measurement" >&2
+    echo "FAIL: untracked runtime files exist before measurement" >&2
     printf '%s\n' "$untracked_runtime" >&2
     exit 1
 fi
@@ -51,5 +64,9 @@ do
 done
 
 echo "PASS: current branch descends from the exact Preview 4 tree"
-echo "PASS: runtime source is unchanged from Preview 4 before TD-01 measurement"
+if [ "$mode" = "--allow-td01-probe" ]; then
+    echo "PASS: runtime diff is limited to the TD-01 host observation body"
+else
+    echo "PASS: runtime source is unchanged from Preview 4 before TD-01 measurement"
+fi
 echo "PASS: Preview 4 source, package, release executable, and physical-control identities are recorded"

--- a/scripts/verify-preview4-baseline.sh
+++ b/scripts/verify-preview4-baseline.sh
@@ -7,9 +7,9 @@ baseline_tree=4232141f9d14d2f6197e43173694f649828e730f
 mode=${1:-strict}
 
 case "$mode" in
-    strict|--allow-td01-probe) ;;
+    strict|--allow-td01-probe|--allow-td01-repair) ;;
     *)
-        echo "Usage: $0 [--allow-td01-probe]" >&2
+        echo "Usage: $0 [--allow-td01-probe|--allow-td01-repair]" >&2
         exit 2
         ;;
 esac
@@ -30,8 +30,13 @@ fi
 runtime_paths='CMakeLists.txt Config Sources Support Tests patches'
 runtime_diff=$(git -C "$repo_root" diff --name-only "$baseline_commit" -- $runtime_paths)
 if [ -n "$runtime_diff" ]; then
-    if [ "$mode" != "--allow-td01-probe" ] ||
-        [ "$runtime_diff" != "Support/RecompPrototype/recomp_game_start.cpp" ]; then
+    probe_diff='Support/RecompPrototype/recomp_game_start.cpp'
+    repair_diff='CMakeLists.txt
+Config/RecompPrototypeInfo.plist.in
+Support/RecompPrototype/recomp_game_start.cpp
+patches/goldeneye64recomp-ios-modern-controls.patch'
+    if ! { [ "$mode" = "--allow-td01-probe" ] && [ "$runtime_diff" = "$probe_diff" ]; } &&
+        ! { [ "$mode" = "--allow-td01-repair" ] && [ "$runtime_diff" = "$repair_diff" ]; }; then
         echo "FAIL: runtime diff exceeds the selected Preview 4 measurement boundary" >&2
         printf '%s\n' "$runtime_diff" >&2
         exit 1
@@ -64,7 +69,9 @@ do
 done
 
 echo "PASS: current branch descends from the exact Preview 4 tree"
-if [ "$mode" = "--allow-td01-probe" ]; then
+if [ "$mode" = "--allow-td01-repair" ]; then
+    echo "PASS: runtime diff is limited to Preview 5 identity, the TD-01 observation body, and shared fire-rate patch"
+elif [ "$mode" = "--allow-td01-probe" ]; then
     echo "PASS: runtime diff is limited to the TD-01 host observation body"
 else
     echo "PASS: runtime source is unchanged from Preview 4 before TD-01 measurement"

--- a/scripts/verify-preview4-baseline.sh
+++ b/scripts/verify-preview4-baseline.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+baseline_commit=54474a40e93b77259d10c7594919e6a05f5e276d
+baseline_tree=4232141f9d14d2f6197e43173694f649828e730f
+
+git -C "$repo_root" cat-file -e "$baseline_commit^{commit}"
+
+actual_tree=$(git -C "$repo_root" rev-parse "$baseline_commit^{tree}")
+if [ "$actual_tree" != "$baseline_tree" ]; then
+    echo "FAIL: Preview 4 tree is $actual_tree, expected $baseline_tree" >&2
+    exit 1
+fi
+
+if ! git -C "$repo_root" merge-base --is-ancestor "$baseline_commit" HEAD; then
+    echo "FAIL: current branch does not descend from published Preview 4" >&2
+    exit 1
+fi
+
+runtime_paths='CMakeLists.txt Config Sources Support Tests patches'
+if ! git -C "$repo_root" diff --quiet "$baseline_commit" -- $runtime_paths; then
+    echo "FAIL: runtime source differs from frozen Preview 4 before measurement" >&2
+    git -C "$repo_root" diff --name-only "$baseline_commit" -- $runtime_paths >&2
+    exit 1
+fi
+
+untracked_runtime=$(git -C "$repo_root" status --porcelain --untracked-files=all -- $runtime_paths)
+if [ -n "$untracked_runtime" ]; then
+    echo "FAIL: untracked or staged runtime files exist before measurement" >&2
+    printf '%s\n' "$untracked_runtime" >&2
+    exit 1
+fi
+
+baseline_doc="$repo_root/docs/PREVIEW_4_BASELINE.md"
+for required_value in \
+    "$baseline_commit" \
+    "$baseline_tree" \
+    ff163b0af6b54596590da8e39cbaff0b388b69f1607ca34f62ce61e7fe144130 \
+    63bec02ad6e323a213f9cb9d15f763a58d6eb7bd4a1a40af6341a4fb8fb333ba \
+    d83361f4daa70014b378aed20b9e26dc7c787d77b0fcd000816d536aecc8e66b \
+    2b31f8868885712fbad34cef1aea20b1dee48f59fc9d930cbd3fa8b8e82b6b12 \
+    0d64256620a5dcb43e7ccf86f9fedd7282242f823ea7d9984c0447c85f3a1cea \
+    4a829165889a4e736199841c4c4237ee6a03ed97fa1ce6d891dfc864634862ff \
+    cb3e439a8eb1587ac11b7fa29551b3f204860f993b9114ebd5331c179bc92bc6
+do
+    if ! grep -Fq "$required_value" "$baseline_doc"; then
+        echo "FAIL: baseline manifest is missing $required_value" >&2
+        exit 1
+    fi
+done
+
+echo "PASS: current branch descends from the exact Preview 4 tree"
+echo "PASS: runtime source is unchanged from Preview 4 before TD-01 measurement"
+echo "PASS: Preview 4 source, package, release executable, and physical-control identities are recorded"

--- a/scripts/verify-recomp-input-matrix.sh
+++ b/scripts/verify-recomp-input-matrix.sh
@@ -85,6 +85,10 @@ for marker in \
   'goldenpad_recomp_consume_inventory_slot' \
   'goldenpad_recomp_fire_rate_player_sample' \
   'goldenpad_recomp_fire_rate_guard_sample' \
+  'RECOMP_FUNC void bondwalkItemGetAutomaticFiringRate' \
+  'MEM_B(ctx->r2, 0X22)' \
+  'ctx->r1 = S32(ctx->r2 << 1)' \
+  'ctx->r2 = ADD32(ctx->r1, ctx->r2)' \
   'MEM_W(ctx->r1, 0X6248)' \
   'MEM_W(ctx->r23, 0X6250)' \
   'MEM_W(0X6284' \
@@ -98,4 +102,4 @@ do
   fi
 done
 
-echo "PASS: tracked patch matches build input and generated control/tank markers are present"
+echo "PASS: tracked patch matches build input and generated control/tank/fire-rate markers are present"

--- a/scripts/verify-recomp-input-matrix.sh
+++ b/scripts/verify-recomp-input-matrix.sh
@@ -4,7 +4,7 @@ set -eu
 repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 test_root=$(mktemp -d "${TMPDIR:-/tmp}/goldenpad-input-matrix.XXXXXX")
 trap 'rm -rf "$test_root"' EXIT HUP INT TERM
-reference_root="$repo_root/ref/goldeneye64recomp"
+reference_root=${GOLDENPAD_RECOMP_REFERENCE_ROOT:-"$repo_root/ref/goldeneye64recomp"}
 tracked_patch="$repo_root/patches/goldeneye64recomp-ios-modern-controls.patch"
 generated_patch="$reference_root/RecompiledPatches/patches.c"
 

--- a/scripts/verify-recomp-macos-alpha.sh
+++ b/scripts/verify-recomp-macos-alpha.sh
@@ -94,6 +94,7 @@ for required_symbol in \
   _goldenpad_recomp_consume_inventory_slot \
   _goldenpad_recomp_consume_reload \
   _goldenpad_recomp_queue_mouse_look \
+  _goldenpad_recomp_set_fire_rate_probe_enabled \
   _goldenpad_recomp_get_input_context
 do
   if ! nm -gU "$executable" | awk -v required="$required_symbol" '$3 == required { found = 1 } END { exit !found }'; then

--- a/scripts/verify-recomp-prototype-host.sh
+++ b/scripts/verify-recomp-prototype-host.sh
@@ -54,6 +54,7 @@ for required_symbol in \
     goldenpad_recomp_set_controller_connected \
     goldenpad_recomp_set_two_player_test_mode \
     goldenpad_recomp_set_four_player_test_mode \
+    goldenpad_recomp_set_fire_rate_probe_enabled \
     goldenpad_recomp_queue_touch_look \
     goldenpad_recomp_gameplay_input_active \
     goldenpad_recomp_current_control_style \

--- a/scripts/verify-recomp-prototype-ipa.sh
+++ b/scripts/verify-recomp-prototype-ipa.sh
@@ -32,7 +32,7 @@ fi
 test "$(plutil -extract CFBundleDisplayName raw "$app_path/Info.plist")" = "GoldenPad"
 test "$(plutil -extract CFBundleIdentifier raw "$app_path/Info.plist")" = "com.chrissotraidis.goldenpad.recomp-prototype"
 test "$(plutil -extract CFBundleShortVersionString raw "$app_path/Info.plist")" = "0.1.0"
-test "$(plutil -extract CFBundleVersion raw "$app_path/Info.plist")" = "4"
+test "$(plutil -extract CFBundleVersion raw "$app_path/Info.plist")" = "5"
 test "$(plutil -extract UIFileSharingEnabled raw "$app_path/Info.plist")" = "true"
 test "$(plutil -extract LSSupportsOpeningDocumentsInPlace raw "$app_path/Info.plist")" = "true"
 


### PR DESCRIPTION
## Summary

- scale the one shared positive player/guard automatic-fire interval by the original N64 frame cost of three
- preserve zero and negative semi-automatic classifications, first-shot behavior, controls, Aim, tank behavior, damage, ammo, renderer, and saves
- advance the production mobile bundle to build 5 and add Preview 5 release documentation and rollback identity
- retain the bounded fire-rate diagnostic off by default

## Validation

- physical iPad discriminator: Preview 4 fired 20 Phantom shots in 58 ticks; Preview 5 fired the exact expected 12 shots in 100 ticks, ammo 20 to 8
- user accepted navigation, movement, controls, gameplay, and runtime quality
- repair-aware Preview 4 baseline, probe contract, deterministic fire-rate test, full 1.1-1.4 input/Aim/tank matrix, ROM scan, license manifest, and whitespace checks passed
- fresh ARM64 iPhone/iPad build and native arm64 Mac build passed
- two independent packaging runs produced byte-identical audited artifacts
- unsigned IPA SHA-256: d4d6c6d7a00e79d1dd4759a97f3ae544c6112dff7c00ea9e57e21199a25c0db7
- Mac Alpha SHA-256: 3dec5864aa637a7115f46a41fd81b8b2077ac44904bf48d7396c54c03a6faee2

## Evidence boundary

No complete candidate guard window or explicit PP7 sequence was captured physically. Guards use the same patched getter, and unchanged nonpositive classifications have source and deterministic coverage. Issue #17 remains open for reporter Mac verification; this PR retains the accepted Preview 4 tank mapping unchanged.