### PR TITLE
Add optional second touch Fire control for Preview 8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ set(GOLDENPAD_RECOMP_BUNDLE_IDENTIFIER "com.chrissotraidis.goldenpad.recomp-prot
     "Bundle identifier used by the isolated recompilation prototype")
 set(GOLDENPAD_RECOMP_DISPLAY_NAME "GoldenPad" CACHE STRING
     "Display name used by the isolated recompilation prototype")
-set(GOLDENPAD_RECOMP_BUILD_VERSION "7" CACHE STRING
+set(GOLDENPAD_RECOMP_BUILD_VERSION "8" CACHE STRING
     "Bundle build version used by the isolated recompilation prototype")
 set(GOLDENPAD_RECOMP_MAC_BUNDLE_IDENTIFIER "com.chrissotraidis.goldenpad.macos" CACHE STRING
     "Bundle identifier used by the native GoldenPad Mac app")
@@ -469,6 +469,7 @@ if(GOLDENPAD_RECOMP_PROTOTYPE)
         Sources/RecompPrototypeInput.swift
         Sources/RecompPrototypeMetalCanvas.swift
         Sources/RecompPrototypeROMStore.swift
+        Sources/RecompTouchFireState.swift
         Sources/RecompPrototypeTouchLayout.swift
         ${goldenpad_recomp_resources}
         ${goldenpad_recomp_rt64_bridge}

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You need an iPhone or iPad running iOS/iPadOS 17 or later, a Mac or Windows
 computer, an Apple ID, and your own original US GoldenEye 007 Nintendo 64 ROM.
 
 > **No jailbreak or JIT is required. Do not search for a TLB-free ROM.**
-> Preview 7 accepts your ordinary `.z64`, `.v64`, `.n64`, or `.rom` dump and
+> Preview 8 accepts your ordinary `.z64`, `.v64`, `.n64`, or `.rom` dump and
 > prepares the required private runtime copy automatically on the device.
 
 1. Install **AltStore Classic** by following its official
@@ -65,7 +65,7 @@ computer, an Apple ID, and your own original US GoldenEye 007 Nintendo 64 ROM.
    Use AltStore Classic with AltServer, not AltStore PAL. PAL cannot install an
    arbitrary unsigned `.ipa` downloaded from GitHub.
 2. Download
-   [`GoldenPad-0.1.0-preview.7-unsigned.ipa`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.7/GoldenPad-0.1.0-preview.7-unsigned.ipa).
+   [`GoldenPad-0.1.0-preview.8-unsigned.ipa`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.8/GoldenPad-0.1.0-preview.8-unsigned.ipa).
    This is the iPhone/iPad app. Do not download the separate Mac `.zip`.
 3. Open AltStore Classic on the device, go to **My Apps**, tap **+**, and choose
    the downloaded GoldenPad `.ipa` from Files. Follow iOS's prompts to trust
@@ -115,15 +115,15 @@ the repository or application package.
 | Option | Status | What to do |
 |---|---|---|
 | Local Simulator build | **Verified** | Build with the complete verifier below, then run from Xcode or `simctl`. |
-| Local iPhone/iPad build | **Preview 7 accepted** | Preview 6 behavior is retained; embedded Metal libraries now explicitly target iOS 17. Physical iPadOS acceptance passed. |
+| Local iPhone/iPad build | **Preview 8 accepted** | Adds an optional second Fire button while retaining Preview 7 behavior and iOS 17 Metal targets. Physical iPadOS acceptance passed. |
 | Native Apple-Silicon Mac build | **Preview 7 Alpha** | GoldenPad officially supports Apple Silicon Macs in Alpha status. [Download the coordinated arm64 Mac Alpha](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.7/GoldenPad-0.1.0-preview.7-macos-arm64-alpha.zip); its executable and package are byte-identical to Preview 6, including the known sluggish horizontal mouse turning and thin far-right blue edge. |
-| Unsigned `.ipa` | **Audited Preview 7** | The reproducible, ROM-free release passed local and hosted package audits; follow [Play on iPhone or iPad](#play-on-iphone-or-ipad). |
-| GitHub release | **Preview 7** | [Release notes, downloads and SHA-256](https://github.com/chrissotraidis/goldenpad/releases/tag/v0.1.0-preview.7). |
+| Unsigned `.ipa` | **Audited Preview 8** | The reproducible, ROM-free release passed package audits; follow [Play on iPhone or iPad](#play-on-iphone-or-ipad). |
+| GitHub release | **Preview 8 mobile / Preview 7 Mac** | [Preview 8 mobile release notes, download and SHA-256](https://github.com/chrissotraidis/goldenpad/releases/tag/v0.1.0-preview.8). |
 | App Store / TestFlight | **Not announced** | Store distribution requires separate rights, signing, review, and device acceptance. |
 
 The mobile baseline was accepted through normal single-player gameplay on a
 physical iPhone and iPad, including the editable touch layout and Xbox/MFi
-controller path. Preview 7 retains the bounded in-app ROM importer, frozen
+controller path. Preview 8 retains the bounded in-app ROM importer, frozen
 experimental multiplayer render repair, Preview 4 shared control mapping, and
 Runway/Streets tank path while correcting player and guard automatic-fire
 cadence. It also repairs Mac menu navigation and the iPad utility-menu hit
@@ -141,10 +141,10 @@ mobile-parity or notarized Mac release.
 |---|---|
 | Native runtime | Statically recompiled game code runs as Apple ARM64; no JIT or emulator wrapper |
 | Rendering | RT64 presents high-resolution Metal output on physical iPad hardware |
-| Setup | Preview 7 imports the user's original NTSC-U retail dump from Files and converts it privately on device; no game data is included |
+| Setup | Preview 8 imports the user's original NTSC-U retail dump from Files and converts it privately on device; no game data is included |
 | Gameplay | Original front end and live Dam/Facility gameplay render and accept normal input |
-| Touch | Tuned GoldenPad move and relative-look zones plus aim, fire, action, weapon, duck, and Start controls |
-| Customization | Separate persisted iPhone/iPad layouts with per-control drag, resize, opacity and reset, plus look sensitivity and hold/toggle aim |
+| Touch | Tuned GoldenPad move and relative-look zones plus aim, fire, action, weapon, duck, and Start controls; an optional second Fire button is available |
+| Customization | Separate persisted iPhone/iPad layouts with per-control drag, resize, opacity and reset, plus look sensitivity, hold/toggle aim, and a default-off second Fire toggle |
 | Controllers | `GCController` with accepted Player 1 movement, right-stick look, buttons, and automatic touch-overlay hiding |
 | Multiplayer | Experimental; the frozen Preview 2 render baseline removes the former large black/checkerboard corruption on physical iPad, while slight lighting flicker and real three/four-controller routing remain open |
 | Audio | Native game PCM feeds `AVAudioEngine` through a bounded stereo ring |
@@ -172,10 +172,10 @@ emulator. Another N64 game or GoldenEye revision cannot be substituted.
 
 ## Release files and advanced setup
 
-### Preview 7 downloads
+### Preview 8 mobile download
 
 Download
-[`GoldenPad-0.1.0-preview.7-unsigned.ipa`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.7/GoldenPad-0.1.0-preview.7-unsigned.ipa)
+[`GoldenPad-0.1.0-preview.8-unsigned.ipa`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.8/GoldenPad-0.1.0-preview.8-unsigned.ipa)
 and its adjacent `.sha256` file. The IPA is intentionally unsigned. Follow
 [Play on iPhone or iPad](#play-on-iphone-or-ipad) for the supported AltStore
 Classic installation path.
@@ -186,9 +186,9 @@ the required TLB-free transformation privately on the device, verifies the
 exact output, and starts the native runtime automatically. A valid Preview 1
 `GoldenEye_TLBFREE.z64` is reused unchanged during an in-place update. See the
 [Preview 2 ROM import design and acceptance record](docs/PREVIEW_2_ROM_IMPORT.md),
-which Preview 7 retains unchanged.
+which Preview 8 retains unchanged.
 
-The separate Apple-Silicon Mac Alpha is
+Preview 8 is mobile-only. The unchanged Apple-Silicon Mac Alpha remains
 [`GoldenPad-0.1.0-preview.7-macos-arm64-alpha.zip`](https://github.com/chrissotraidis/goldenpad/releases/download/v0.1.0-preview.7/GoldenPad-0.1.0-preview.7-macos-arm64-alpha.zip).
 It is an ad-hoc-signed, non-notarized arm64 app and remains below mobile release
 quality. It uses the same user-supplied-data boundary and must not be described
@@ -197,7 +197,7 @@ as mobile parity.
 <details>
 <summary><strong>Preview 1 manual setup (legacy only)</strong></summary>
 
-> **Preview 2 through Preview 7 users do not need these steps or a prebuilt TLB-free ROM.** This
+> **Preview 2 through Preview 8 users do not need these steps or a prebuilt TLB-free ROM.** This
 > section is retained only for people intentionally running the older Preview 1
 > artifact.
 
@@ -272,7 +272,7 @@ retail input and generated output remain yours and must not be redistributed.
 > currently be reproduced from the public checkout alone because its generated
 > game-code inputs are private and intentionally untracked. The public build
 > commands below produce the older `GoldenPad Legacy` fallback. To use the
-> current primary release, follow **Preview 7** and **First launch** instead.
+> current primary release, follow **Preview 8** and **First launch** instead.
 
 You need:
 
@@ -335,7 +335,7 @@ reference path.
 
 GoldenPad never downloads or bundles game data.
 
-1. Install the unsigned Preview 7 IPA by following
+1. Install the unsigned Preview 8 IPA by following
    [Play on iPhone or iPad](#play-on-iphone-or-ipad).
 2. Launch GoldenPad and choose your own supported original NTSC-U retail ROM
    from Files. The importer accepts `.z64`, `.v64`, `.n64`, and `.rom` byte
@@ -372,7 +372,7 @@ the game runtime are separate stages with different fixes.
   PAL, Japanese, modified, overdumped, and other revisions are rejected.
 - `.z64`, `.v64`, `.n64`, and `.rom` are accepted. Renaming another file or ROM
   does not change its contents and will not pass validation.
-- Preview 7 performs the TLB-free conversion itself. Do not download, request,
+- Preview 8 performs the TLB-free conversion itself. Do not download, request,
   or manually create a TLB-free ROM for the current release.
 - If GoldenPad cannot read a valid file from a cloud or third-party provider,
   copy it into **On My iPhone** or **On My iPad** in Files and try again.
@@ -406,7 +406,7 @@ GoldenEye movement semantics with modern relative look:
 
 | Control | Behavior |
 |---|---|
-| **MOVE** | Large left virtual stick; forward/back and turn, with no sidestep in the current template |
+| **MOVE** | Large left virtual stick; forward/back plus the active modern sidestep mapping |
 | **LOOK** | Relative right-thumb swipe region; movement stops when the swipe stops |
 | **FIRE** | N64 Z / primary fire |
 | **AIM** | N64 R; Toggle by default, with Hold available |
@@ -424,14 +424,18 @@ Touch Controls also contains:
 
 - look sensitivity;
 - Toggle or Hold aim behavior;
+- **Add left-side Fire button**, which is off by default and adds a duplicate
+  N64 Z control that can be moved, resized, and faded independently;
 - the current iPhone or iPad touch layout.
 
-The current touch template does not expose GoldenEye's native C-left/C-right
-sidestep inputs. [Issue #8](https://github.com/chrissotraidis/goldenpad/issues/8)
-tracks the verified modern-semantics repair: MOVE horizontal should strafe while
-LOOK horizontal turns, with Original N64 C-buttons preserved as a separate
-controller mode. This is an input-semantics change, not a touch-layout rewrite;
-the accepted iPhone/iPad placement profiles remain regression controls.
+Both Fire buttons publish the same action safely: if both are held, releasing
+one keeps Fire active until the other is released.
+
+Preview 4 completed the modern-semantics repair tracked in
+[issue #8](https://github.com/chrissotraidis/goldenpad/issues/8): MOVE horizontal
+sidesteps while LOOK horizontal turns. **Original N64 C-buttons** remains a
+separate controller mode for the native layout. The accepted iPhone/iPad
+placement profiles remain regression controls.
 
 In edit mode, drag a control directly over the running game. The selected
 control receives a yellow outline and the always-visible top slider resizes it
@@ -497,28 +501,28 @@ MGB64 symbols. The older MGB64 IPA workflow remains a fallback only.
 
 ## Current limitations
 
-- Preview 7 retains Preview 5's native-60-Hz automatic player/guard firing
+- Preview 8 retains Preview 5's native-60-Hz automatic player/guard firing
   cadence repair through
   one shared source-derived interval conversion. It does not change semi-auto
   classifications, first-shot behavior, damage, ammunition, or controls.
 - Preview 4 replaced the separate movement adapter with one shared mapping that
   follows GoldenEye's active 1.1 through 1.4 control style. Physical iPad
   testing accepted normal movement, native left-stick Aim, and Runway tank
-  controls. Preview 7 retains Preview 6's Mac mission-menu navigation repair
+  controls. Preview 8 retains Preview 6's Mac mission-menu navigation repair
   and the tank mapping. The Mac reporter confirmed both in Preview 6 and closed
   the report
   ([issue #17](https://github.com/chrissotraidis/goldenpad/issues/17)).
 - A deterministic first-frame RT64/Metal crash is reported on an A12X iPad Pro
   with Preview 1. A12-family hardware is not yet validated; the compatibility
   fix or minimum GPU policy remains open ([issue #9](https://github.com/chrissotraidis/goldenpad/issues/9)).
-- Preview 7 corrects an independent issue #19 failure by explicitly targeting
+- Preview 8 retains Preview 7's independent issue #19 correction, explicitly targeting
   every embedded Metal library at iOS 17. The diagnostic build passed on the
   affected iPhone 13 mini; the A12X first-draw crash remains separate.
 - Multiplayer has a stable experimental render baseline, not final acceptance.
   Slight lighting flicker and real three/four-controller routing remain open.
 - Peer-to-peer, LAN, internet, relay, and rollback multiplayer are not
   implemented.
-- Preview 7 retains Preview 2's complete, package-audited in-app retail-ROM conversion.
+- Preview 8 retains Preview 2's complete, package-audited in-app retail-ROM conversion.
   A clean physical-iPhone installation has reached the empty-container setup
   screen; fresh real-ROM import, wrong-ROM, cancellation and low-storage
   coverage remains open in the focused importer acceptance record.
@@ -555,8 +559,8 @@ retained only as the deprecated legacy fallback.
 <details>
 <summary><strong>Where is the IPA?</strong></summary>
 
-Preview 7 is available from the
-[GitHub release](https://github.com/chrissotraidis/goldenpad/releases/tag/v0.1.0-preview.7).
+Preview 8 is available from the
+[GitHub release](https://github.com/chrissotraidis/goldenpad/releases/tag/v0.1.0-preview.8).
 It is an unsigned, ROM-free developer-preview IPA and must be re-signed. It does
 not include game data; follow [Play on iPhone or iPad](#play-on-iphone-or-ipad)
 for installation and first-launch instructions.
@@ -566,10 +570,10 @@ for installation and first-launch instructions.
 <summary><strong>Do I need JIT or a TLB-free ROM?</strong></summary>
 
 No. GoldenPad's game code is compiled ahead of time, so the iPhone/iPad release
-does not need JIT. Preview 7 accepts the supported original US retail dump and
+does not need JIT. Preview 8 accepts the supported original US retail dump and
 creates the required TLB-free runtime copy privately on the device. Do not use
 the old Preview 1 manual conversion instructions for Preview 2, Preview 3,
-Preview 4, Preview 5, Preview 6, or Preview 7.
+Preview 4, Preview 5, Preview 6, Preview 7, or Preview 8.
 </details>
 
 <details>
@@ -637,6 +641,7 @@ override those current authority documents.
 | [`docs/RELEASE_NOTES_0.1.0-preview.5.md`](docs/RELEASE_NOTES_0.1.0-preview.5.md) | Preview 5 automatic-fire authenticity repair, checksums, physical evidence, and rollback boundary |
 | [`docs/RELEASE_NOTES_0.1.0-preview.6.md`](docs/RELEASE_NOTES_0.1.0-preview.6.md) | Preview 6 Mac menu/input repair, iPad utility-menu repair, checksums, and acceptance boundary |
 | [`docs/RELEASE_NOTES_0.1.0-preview.7.md`](docs/RELEASE_NOTES_0.1.0-preview.7.md) | Preview 7 Metal deployment-target compatibility correction, checksums, and acceptance boundary |
+| [`docs/RELEASE_NOTES_0.1.0-preview.8.md`](docs/RELEASE_NOTES_0.1.0-preview.8.md) | Preview 8 optional second touch Fire button, checksum, and physical acceptance boundary |
 | [`docs/PREVIEW_4_BASELINE.md`](docs/PREVIEW_4_BASELINE.md) | Frozen Preview 4 source, artifact, accepted-behavior, diagnostic, and rollback identity |
 | [`docs/TD01_FIRE_RATE_LOOP.md`](docs/TD01_FIRE_RATE_LOOP.md) | Bounded fire-rate measurement sequence and mandatory gameplay stop gate |
 | [`docs/MULTIPLAYER_ROADMAP.md`](docs/MULTIPLAYER_ROADMAP.md) | Local ownership, determinism, LAN research, network feasibility, and go/no-go gates |

--- a/Sources/RecompPrototypeInput.swift
+++ b/Sources/RecompPrototypeInput.swift
@@ -282,6 +282,7 @@ final class RecompPrototypeInput: ObservableObject {
     @Published private(set) var fourPlayerTestModeActive = false
     @Published private(set) var touchControlsVisible = true
     private var touchButtons: UInt16 = 0
+    private var touchFireState = RecompTouchFireState()
     private var touchMovement = SIMD2<Float>.zero
     private var touchLook = SIMD2<Float>.zero
     private var touchCrouchIsPressed = false
@@ -517,6 +518,11 @@ final class RecompPrototypeInput: ObservableObject {
         publish()
     }
 
+    func setFirePressed(_ pressed: Bool, source: RecompTouchFireSource) {
+        touchFireState.setPressed(pressed, source: source)
+        setButton(N64.z, pressed: touchFireState.isPressed)
+    }
+
     func releaseTouchInput() {
         clearTouchInputState()
         publish()
@@ -524,6 +530,7 @@ final class RecompPrototypeInput: ObservableObject {
 
     private func clearTouchInputState() {
         touchButtons = 0
+        touchFireState.reset()
         touchAimActive = false
         touchMovement = .zero
         touchLook = .zero
@@ -949,7 +956,7 @@ struct RecompPrototypeTouchControls: View {
     var body: some View {
         GeometryReader { geometry in
             ZStack {
-                ForEach(placements) { placement in
+                ForEach(placements.filter(\.isEnabled)) { placement in
                     control(placement, canvas: geometry.size)
                 }
             }
@@ -1005,6 +1012,8 @@ struct RecompPrototypeTouchControls: View {
                 ) {
                     if placement.id == .crouch {
                         input.setCrouchPressed($0)
+                    } else if let fireSource = placement.id.fireSource {
+                        input.setFirePressed($0, source: fireSource)
                     } else {
                         input.setButton(placement.id.n64Mask, pressed: $0)
                     }
@@ -1014,7 +1023,7 @@ struct RecompPrototypeTouchControls: View {
         }
         .opacity(resolved.resolvedOpacity)
         .position(x: canvas.width * resolved.x, y: canvas.height * resolved.y)
-        .accessibilityLabel(placement.id.label)
+        .accessibilityLabel(placement.id.accessibilityLabel)
     }
 }
 

--- a/Sources/RecompPrototypeTouchLayout.swift
+++ b/Sources/RecompPrototypeTouchLayout.swift
@@ -40,7 +40,7 @@ enum RecompTouchDeviceClass: String, CaseIterable, Codable {
 }
 
 enum RecompTouchControlID: String, CaseIterable, Codable, Identifiable {
-    case move, look, fire, aim, action, crouch, weapon, pause
+    case move, look, fire, secondaryFire, aim, action, crouch, weapon, pause
 
     var id: String { rawValue }
 
@@ -48,7 +48,7 @@ enum RecompTouchControlID: String, CaseIterable, Codable, Identifiable {
         switch self {
         case .move: "MOVE"
         case .look: "LOOK"
-        case .fire: "FIRE"
+        case .fire, .secondaryFire: "FIRE"
         case .aim: "AIM"
         case .action: "ACTION"
         case .crouch: "DUCK"
@@ -60,7 +60,7 @@ enum RecompTouchControlID: String, CaseIterable, Codable, Identifiable {
     var n64Mask: UInt16 {
         switch self {
         case .move, .look: 0
-        case .fire: 0x2000
+        case .fire, .secondaryFire: 0x2000
         case .aim: 0x0010
         case .action: 0x4000
         case .crouch: 0
@@ -71,7 +71,7 @@ enum RecompTouchControlID: String, CaseIterable, Codable, Identifiable {
 
     var tint: Color {
         switch self {
-        case .fire, .aim: .gray
+        case .fire, .secondaryFire, .aim: .gray
         case .weapon: .blue
         case .action: .green
         case .crouch: .yellow
@@ -92,6 +92,22 @@ enum RecompTouchControlID: String, CaseIterable, Codable, Identifiable {
     var usesRoundedRectangle: Bool {
         self == .move || self == .look
     }
+
+    var editorLabel: String {
+        self == .secondaryFire ? "FIRE 2" : label
+    }
+
+    var accessibilityLabel: String {
+        self == .secondaryFire ? "Additional Fire" : label
+    }
+
+    var fireSource: RecompTouchFireSource? {
+        switch self {
+        case .fire: .primary
+        case .secondaryFire: .secondary
+        default: nil
+        }
+    }
 }
 
 struct RecompTouchPlacement: Identifiable, Codable, Equatable {
@@ -100,9 +116,14 @@ struct RecompTouchPlacement: Identifiable, Codable, Equatable {
     var y: CGFloat
     var scale: CGFloat
     var opacity: CGFloat? = nil
+    var enabled: Bool? = nil
 
     var resolvedOpacity: CGFloat {
         opacity ?? 0.72
+    }
+
+    var isEnabled: Bool {
+        enabled ?? (id != .secondaryFire)
     }
 
     func sanitized() -> RecompTouchPlacement {
@@ -125,6 +146,7 @@ enum RecompTouchLayoutDefaults {
                 placement(.move, 0.13, 0.82, 1.14),
                 placement(.look, 0.78, 0.72),
                 placement(.fire, 0.91, 0.71, 1.16),
+                placement(.secondaryFire, 0.24, 0.58, enabled: false),
                 placement(.aim, 0.91, 0.58),
                 placement(.action, 0.91, 0.84, 0.94),
                 placement(.crouch, 0.81, 0.89, 0.82),
@@ -138,6 +160,7 @@ enum RecompTouchLayoutDefaults {
                 placement(.move, 0.188389, 0.726667),
                 placement(.look, 0.781991, 0.687179, 0.70),
                 placement(.fire, 0.938389, 0.573504, 1.10),
+                placement(.secondaryFire, 0.30, 0.48, 0.95, enabled: false),
                 placement(.aim, 0.942733, 0.408547, 0.95),
                 placement(.action, 0.932070, 0.744444, 0.90),
                 placement(.crouch, 0.909953, 0.898291, 0.78),
@@ -151,9 +174,10 @@ enum RecompTouchLayoutDefaults {
         _ id: RecompTouchControlID,
         _ x: CGFloat,
         _ y: CGFloat,
-        _ scale: CGFloat = 1
+        _ scale: CGFloat = 1,
+        enabled: Bool? = nil
     ) -> RecompTouchPlacement {
-        RecompTouchPlacement(id: id, x: x, y: y, scale: scale)
+        RecompTouchPlacement(id: id, x: x, y: y, scale: scale, enabled: enabled)
     }
 }
 
@@ -261,10 +285,14 @@ struct RecompPrototypeLiveTouchLayoutEditor: View {
         placements.firstIndex { $0.id == selectedID }
     }
 
+    private var secondaryFireEnabled: Bool {
+        placements.first(where: { $0.id == .secondaryFire })?.isEnabled ?? false
+    }
+
     var body: some View {
         GeometryReader { geometry in
             ZStack {
-                ForEach(placements) { placement in
+                ForEach(placements.filter(\.isEnabled)) { placement in
                     editorControl(placement, canvas: geometry.size)
                 }
 
@@ -310,9 +338,19 @@ struct RecompPrototypeLiveTouchLayoutEditor: View {
                 .fontWeight(.semibold)
             }
 
+            Toggle(
+                "Add left-side Fire button",
+                isOn: Binding(
+                    get: { secondaryFireEnabled },
+                    set: { setSecondaryFireEnabled($0) }
+                )
+            )
+            .font(.caption.weight(.semibold))
+            .accessibilityHint("Adds a second movable Fire control without changing the original Fire button")
+
             if let index = selectedIndex {
                 HStack(spacing: 12) {
-                    Text(placements[index].id.label)
+                    Text(placements[index].id.editorLabel)
                         .font(.caption.weight(.bold))
                         .frame(width: 62, alignment: .leading)
                     Slider(
@@ -323,7 +361,7 @@ struct RecompPrototypeLiveTouchLayoutEditor: View {
                         in: 0.55...1.60,
                         step: 0.05
                     )
-                    .accessibilityLabel("\(placements[index].id.label) size")
+                    .accessibilityLabel("\(placements[index].id.editorLabel) size")
                     Text("\(Int((placements[index].scale * 100).rounded()))%")
                         .font(.caption.monospacedDigit())
                         .frame(width: 42, alignment: .trailing)
@@ -341,7 +379,7 @@ struct RecompPrototypeLiveTouchLayoutEditor: View {
                         in: 0.20...1,
                         step: 0.05
                     )
-                    .accessibilityLabel("\(placements[index].id.label) opacity")
+                    .accessibilityLabel("\(placements[index].id.editorLabel) opacity")
                     Text("\(Int((placements[index].resolvedOpacity * 100).rounded()))%")
                         .font(.caption.monospacedDigit())
                         .frame(width: 42, alignment: .trailing)
@@ -420,7 +458,7 @@ struct RecompPrototypeLiveTouchLayoutEditor: View {
                     )
                 }
         )
-        .accessibilityLabel(placement.id.label)
+        .accessibilityLabel(placement.id.accessibilityLabel)
         .accessibilityHint("Drag to move; use the size and opacity sliders at the top")
     }
 
@@ -448,5 +486,11 @@ struct RecompPrototypeLiveTouchLayoutEditor: View {
     private func updateSelectedOpacity(_ opacity: CGFloat) {
         guard let index = selectedIndex else { return }
         placements[index].opacity = min(max(opacity, 0.20), 1)
+    }
+
+    private func setSecondaryFireEnabled(_ enabled: Bool) {
+        guard let index = placements.firstIndex(where: { $0.id == .secondaryFire }) else { return }
+        placements[index].enabled = enabled
+        selectedID = enabled ? .secondaryFire : placements.first(where: { $0.isEnabled })?.id
     }
 }

--- a/Sources/RecompTouchFireState.swift
+++ b/Sources/RecompTouchFireState.swift
@@ -1,0 +1,24 @@
+enum RecompTouchFireSource: String, CaseIterable, Hashable {
+    case primary
+    case secondary
+}
+
+struct RecompTouchFireState: Equatable {
+    private(set) var activeSources: Set<RecompTouchFireSource> = []
+
+    var isPressed: Bool {
+        !activeSources.isEmpty
+    }
+
+    mutating func setPressed(_ pressed: Bool, source: RecompTouchFireSource) {
+        if pressed {
+            activeSources.insert(source)
+        } else {
+            activeSources.remove(source)
+        }
+    }
+
+    mutating func reset() {
+        activeSources.removeAll(keepingCapacity: true)
+    }
+}

--- a/Tests/RecompTouchFireStateTests.swift
+++ b/Tests/RecompTouchFireStateTests.swift
@@ -1,0 +1,29 @@
+@main
+struct RecompTouchFireStateTests {
+    static func main() {
+        var state = RecompTouchFireState()
+        expect(!state.isPressed, "Fire starts released")
+
+        state.setPressed(true, source: .primary)
+        expect(state.isPressed, "Primary Fire presses Z")
+
+        state.setPressed(true, source: .secondary)
+        state.setPressed(false, source: .primary)
+        expect(state.isPressed, "Releasing primary Fire preserves held secondary Fire")
+
+        state.setPressed(false, source: .secondary)
+        expect(!state.isPressed, "Fire releases after both touch sources release")
+
+        state.setPressed(true, source: .secondary)
+        state.reset()
+        expect(!state.isPressed, "Input reset releases every Fire source")
+
+        print("PASS: primary and optional secondary touch Fire aggregate safely")
+    }
+
+    private static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        guard condition() else {
+            fatalError("FAIL: \(message)")
+        }
+    }
+}

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -27,7 +27,7 @@ package with:
 ```sh
 ./scripts/package-recomp-prototype-ipa.sh
 ./scripts/verify-recomp-prototype-ipa.sh \
-  dist/GoldenPad-0.1.0-preview.7-unsigned.ipa
+  dist/GoldenPad-0.1.0-preview.8-unsigned.ipa
 ```
 
 The packager copies the signed app into a temporary staging directory, removes
@@ -42,10 +42,10 @@ validation stay inside the app container. An in-place update reuses an existing
 valid `GoldenEye_TLBFREE.z64`. No retail input, save, generated source, signing
 identity, or provisioning profile is placed in the IPA.
 
-Preview 7 retains Preview 6's accepted controls and utility overlay plus Preview
-5's tank mapping and automatic-fire repair. Its embedded device and Simulator
-Metal libraries are explicitly targeted at iOS 17. The audited IPA SHA-256 is
-`4f6d26616fbc1d098ba1dce598ea8e958162c82efc975aa483db7e19bd9c58c4`.
+Preview 8 adds a default-off duplicate touch Fire control with independent
+layout persistence and safe multi-touch aggregation. It retains Preview 7's
+accepted controls and explicit iOS 17 Metal targets. The audited IPA SHA-256 is
+`773223b7ed7787c18526fb63281a6a3e4960b87adb0a912b0c2b77d0f1312a1b`.
 
 ## Native Apple-Silicon Mac alpha
 

--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -220,6 +220,15 @@ choice across an app relaunch; that requires runtime testing.
 
 ## Current GoldenPad behavior
 
+### Preview 8 optional touch Fire control
+
+Preview 8 adds **Add left-side Fire button** under Touch Controls. It is off by
+default and duplicates the primary N64 Z action without changing the accepted
+layout. When enabled, it has independent persisted position, scale, and opacity
+for iPhone and iPad. Primary and secondary touch sources are aggregated, so
+releasing either finger while the other remains held keeps Fire active; reset
+neutralizes both sources.
+
 ### Stable Preview 3 on iPhone/iPad
 
 The source of truth for the accepted controls release is tag

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -1,9 +1,8 @@
 # Next steps
 
-Updated: 2026-08-25
+Updated: 2026-08-27
 
-This is the short operational queue for GoldenPad's Preview 7 compatibility
-promotion. It does not
+This is the short operational queue after GoldenPad Preview 8. It does not
 replace the authoritative documents:
 
 - [`TECH_DEBT.md`](TECH_DEBT.md) owns priority, evidence, and closure state;
@@ -19,10 +18,13 @@ the same change rather than choosing whichever wording is more convenient.
 | Order | Work | Output required before moving on |
 | ---: | --- | --- |
 | Complete | **Preview 7 compatibility promotion** | Merged, published, downloaded, and re-audited with byte-identical hosted assets. |
-| 1 | **Affected-device confirmation** | Await the posted issue #19 production Preview 7 result and issue #9 corrected-target result. Issue #17 is closed; issue #8 controller verification remains open. |
-| 2 | **Optional second touch Fire button** | One independent control with unchanged current defaults and a focused phone/tablet acceptance pass. |
+| Complete | **Preview 8 optional second Fire button** | Default-off duplicate Fire input, independent layout persistence, multi-touch aggregation, deterministic IPA, and physical iPad acceptance passed. |
+| 1 | **Affected-device confirmation** | Await the posted issue #19 production Preview 7 result and issue #9 corrected-target result. Issue #17 is closed; issue #8 modern controls are maintainer-accepted and its reporter should test Preview 8's added Fire button. |
+| 2 | **Input lifecycle containment** | Take TD-14 modal neutralization and TD-07 controller disconnect behavior as separate repairs. |
 
-Preview 6 is the accepted release baseline. Preview 7 changes only embedded
+Preview 8 is the accepted mobile baseline. It adds only a default-off duplicate
+Fire control with independent position, size, and opacity; simultaneous touches
+aggregate without cancelling Fire early. Preview 7 changed only embedded
 Metal deployment targeting and production identity. Its Mac payload is
 byte-identical to Preview 6; horizontal mouse sluggishness remains known Mac
 debt, not a Preview 7 regression. Preview 7 retains Preview 5's frozen
@@ -39,19 +41,15 @@ changing released behavior.
 
 ## Do immediately after
 
-1. **Optional second touch Fire button**
-   - Add one optional, independently movable/resizable Fire control.
-   - Preserve current defaults and reject overlapping or latched touch input.
-   - Accept phone and tablet layouts before including it in a later preview.
-2. **TD-14 modal/run-loop neutralization**
+1. **TD-14 modal/run-loop neutralization**
    - Fail first on held touch/controller input across Settings, Share, watch,
      pause, and scroll tracking.
    - Publish neutral before presentation and forbid replay on dismissal.
-3. **TD-07 disconnect neutralization and lifecycle probe**
+2. **TD-07 disconnect neutralization and lifecycle probe**
    - Publish neutral when the active controller disappears.
    - Never move touch ownership implicitly.
    - Preserve normal touch/controller Player 1 behavior.
-4. **TD-04, TD-05, and TD-06 discriminators**
+3. **TD-04, TD-05, and TD-06 discriminators**
    - Lifecycle: run the physical matrix first, then instrument the observed wait
      class; do not assume a drawable-only stall.
    - Audio: correlate an audible physical event with counters; 22,050 Hz rate
@@ -59,7 +57,7 @@ changing released behavior.
    - Flicker: fixed player order is rejected; the uncalibrated zero
      `formatChanged` signal is narrowing, not closure. Capture the first affected
      physical frame before another RT64 experiment.
-5. **TD-12/TD-13 hygiene**
+4. **TD-12/TD-13 hygiene**
    - Give the runtime-managed ROM copy the same backup/protection policy as the
      Documents copy, with hash-preserving migration/readback.
    - Script the private-input game-bearing build so two clean build directories

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -15,16 +15,14 @@ The native Apple-Silicon macOS extension is a separate gated product track. Its
 research decision, architecture and implementation gates are recorded in
 [`MACOS_NATIVE_FEASIBILITY_2026-08-21.md`](MACOS_NATIVE_FEASIBILITY_2026-08-21.md).
 
-## Current execution plan (2026-08-25)
+## Current execution plan (2026-08-27)
 
-Preview 7 is published from merge commit
-`1f9ca4e7e668708937c88d77adb0ba6f41483256`. It explicitly targets iOS 17 for
-every embedded Metal library and changes no gameplay, input, audio, storage,
-lifecycle, multiplayer, or Mac runtime behavior. Physical iPadOS acceptance,
-preservation checks, deterministic packaging, and hosted re-audits passed. The
-Mac payload is byte-identical to Preview 6; horizontal-mouse sluggishness remains
-known debt rather than a Preview 7 regression. The optional second touch Fire
-button is the next independent feature.
+Preview 8 is the accepted mobile baseline. It adds one optional duplicate Fire
+control, disabled by default, with independent persisted layout values and
+multi-touch aggregation. Build `8` passed physical iPadOS acceptance,
+preservation checks, input tests, and deterministic packaging while retaining
+Preview 7's iOS 17 Metal target. The Mac Alpha remains Preview 7 and is
+byte-identical to Preview 6.
 
 Relative sizes are scope indicators, not calendar promises: **S** is one bounded
 seam/probe, **M** crosses a game/host or generated-patch boundary, **L** adds a
@@ -33,8 +31,8 @@ service.
 
 | Work | Size | Primary risk |
 | --- | ---: | --- |
-| Preview 7 compatibility promotion | S | Production identity, Metal-target provenance, and preservation regression |
-| Optional second touch Fire button | S | Layout persistence, overlapping touch targets, or duplicated/latched Fire input |
+| Preview 7 compatibility promotion | Complete | Production identity, Metal-target provenance, and preservation regression |
+| Optional second touch Fire button | Released in Preview 8 | Layout persistence, overlapping touch targets, or duplicated/latched Fire input |
 | TD-01 sustained-player measurement | Complete | Three physical-iPad Phantom magazines were identical at 20 events over 58 ticks |
 | TD-02/issue #8 controller verification | S | Touch is reporter-confirmed; physical controller result remains pending |
 | TD-01 authenticity patch | Released in Preview 5 | Retain its isolated rollback and evidence boundary |
@@ -70,13 +68,14 @@ Execute and land these as separate review units:
 | Order | Work package | Why now | Required output | Promotion gate |
 | ---: | --- | --- | --- | --- |
 | Complete | **Preview 7 production promotion** | Issue #19's affected iPhone passed the bounded iOS 17-target diagnostic | Production bundle build `7`, audited IPA and byte-identical Preview 6 Mac archive, preserved-data readback, and hands-on iPadOS/Mac acceptance | PASS: exact artifacts passed twice, published assets matched locally, and no unrelated behavior changed |
+| Complete | **Preview 8 optional second Fire** | User-requested duplicate Fire surface | Default-off control, independent saved layout, aggregated Z state, build `8`, and audited IPA | PASS: focused tests, in-place preserved-data install, and physical iPad acceptance |
 | 1 | **TD-01 sustained-player probe completion** | Complete; player magnitude now distinguishes the current cadence from the authentic target | Three ordinary-input Phantom magazines each recorded 20 events in 58 ticks, normalized to 34.4828; retained guard evidence is 13/17/18 per 100 ticks | PASS: three identical player numbers, matching ammo deltas, no gameplay-state writes, and protected data preserved |
 | Parallel user-facing lane | **Issue #8 and #19 release verification** | Issue #8 touch is positive and issue #19's diagnostic is positive | Issue #8 controller result and issue #19 production Preview 7 result | Do not close either report beyond the behavior its reporter actually verified |
 | Parallel evidence lane | **TD-03 A12X crash artifact/reproduction** | High-severity compatibility report, but no safe patch exists without affected evidence | Full redacted `.ips`, current Preview 4 reproduction, original-signature comparison, and affected/newer device comparison | First failing RT64/Metal boundary isolated or deliberate tested support-floor decision |
 
 Reporter confirmation and A12 evidence work can proceed without changing
-accepted Preview 7 controls. Preview 7 is published; keep the optional Fire
-button and TD-14/TD-07 behavior changes as separate later candidates. Follow
+accepted Preview 8 controls. Preview 8 is the mobile baseline; keep TD-14/TD-07
+behavior changes as separate later candidates. Follow
 [`TD01_FIRE_RATE_LOOP.md`](TD01_FIRE_RATE_LOOP.md) for the completed measurement,
 repair, acceptance, and rollback record. Any later input change must
 be reviewed separately from controller-lifecycle work because both touch input

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -217,6 +217,27 @@ A12-specific work, renderer experiments, audio changes, or storage changes.
 - [x] Ask issue #19's reporter to verify the production Preview 7 IPA. Keep
   issue #9 separate unless affected A12 hardware passes this exact artifact.
 
+## Preview 8 optional second Fire promotion
+
+Preview 8 is mobile-only and adds one optional duplicate Fire surface. The Mac
+Alpha remains Preview 7.
+
+- [x] Add a default-off left-side Fire control with independent position,
+  scale, opacity, and persisted enabled state for iPhone and iPad layouts.
+- [x] Aggregate both touch sources into one N64 Z state; prove releasing one
+  held source cannot release or latch the other.
+- [x] Pass the focused Fire-state test, full input matrix, source hygiene,
+  build-identity, ROM-data, package, and iOS 17 Metal-target audits.
+- [x] Build production `GoldenPad` version `0.1.0` build `8`.
+- [x] Package the unsigned IPA twice with identical SHA-256
+  `773223b7ed7787c18526fb63281a6a3e4960b87adb0a912b0c2b77d0f1312a1b`.
+- [x] Install build `8` in place on the physical iPad and verify protected ROM,
+  runtime, save, and preference data remains intact.
+- [x] Obtain hands-on iPadOS acceptance of the exact candidate.
+- [ ] Merge, publish `v0.1.0-preview.8`, independently download both assets,
+  compare them byte for byte, and rerun the IPA verifier.
+- [ ] Reply to the issue #8 reporter with the public Preview 8 link.
+
 The remaining sections preserve the `GoldenPad Legacy` clean-checkout and
 packaging procedure.
 

--- a/docs/RELEASE_NOTES_0.1.0-preview.8.md
+++ b/docs/RELEASE_NOTES_0.1.0-preview.8.md
@@ -1,0 +1,51 @@
+# GoldenPad 0.1.0 Preview 8
+
+Preview 8 is a deliberately narrow iPhone/iPad feature release. It adds the
+requested optional second touch Fire button and retains Preview 7's accepted
+gameplay, controls, renderer settings, iOS 17 Metal target, ROM conversion,
+saves, and audio. The unchanged Apple-Silicon Mac Alpha remains Preview 7.
+
+## What changed
+
+- **Touch Controls → Add left-side Fire button** enables a duplicate N64 Z
+  control. It is disabled by default.
+- The additional Fire button has its own saved position, scale, and opacity for
+  iPhone and iPad layouts.
+- Both Fire surfaces aggregate into one action: releasing either while the
+  other remains held keeps Fire active, and reset clears both safely.
+- The iPhone/iPad production bundle advances to version `0.1.0` build `8`.
+
+No renderer, audio, controller-routing, lifecycle, multiplayer, ROM, save, or
+Mac runtime change is included.
+
+## Acceptance
+
+- [x] Focused primary/secondary/simultaneous Fire-state tests and complete input
+  matrix.
+- [x] Signed production ARM64 build and complete ROM-free package audit.
+- [x] Two byte-identical unsigned IPA packaging passes.
+- [x] Explicit iOS 17 Metal deployment target retained throughout the payload.
+- [x] In-place physical iPad update with protected game data and preferences
+  preserved.
+- [x] Hands-on physical iPad gameplay acceptance of the exact candidate.
+
+## Download
+
+- `GoldenPad-0.1.0-preview.8-unsigned.ipa`
+  - SHA-256: `773223b7ed7787c18526fb63281a6a3e4960b87adb0a912b0c2b77d0f1312a1b`
+  - unsigned ARM64 app-content SHA-256: `be03451c0b0450c43096d49d944642a82bfb0f3c310f70289831e51fcd28dc6d`
+  - accepted signed-candidate executable SHA-256: `6d90224ad63fb50c0eaae9d76e42d105e152e105b3dc9a4e12dcb80db5984dff3`
+
+The IPA is intentionally unsigned and contains no ROM, save, provisioning
+profile, Apple signing identity, private build path, or generated source.
+
+## Known limitations
+
+- Residual split-screen flicker and other graphical artifacting remain open.
+- A12/A12X issue #9 remains unresolved.
+- Issue #19's affected-device diagnostic succeeded; production-release reporter
+  confirmation remains pending.
+- Stable real Player 2 through Player 4 controller ownership and network
+  multiplayer remain incomplete.
+- Lifecycle, storage-hygiene, and reproducible private-input build proof remain
+  separate technical debt.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,12 +1,12 @@
 # Status
 
-Updated: 2026-08-25
+Updated: 2026-08-27
 
 ## Current at a glance
 
 | Surface | Current truth |
 | --- | --- |
-| Public release | Preview 7 is published from merge commit `1f9ca4e7e668708937c88d77adb0ba6f41483256` with separately audited unsigned iPhone/iPad and arm64 Mac Alpha artifacts. Every hosted asset is byte-identical to its accepted local file. |
+| Public release | Preview 8 is the current mobile release; the unchanged arm64 Mac Alpha remains Preview 7. |
 | Primary runtime | Static GoldenEye ARM64 output + N64ModernRuntime + RT64/Plume/Metal. MGB64 is Legacy only. |
 | Accepted baseline | Preview 5 mobile gameplay/controls plus physically accepted Preview 6 Mac menu and keyboard/mouse controls, iPad utility-menu actions, and the issue #19 diagnostic build on the affected iPhone 13 mini. |
 | Major gameplay repair | Preview 5 fixes TD-01 by scaling the shared positive player/guard automatic-fire interval by 3 while preserving nonpositive semi-auto classifications. Physical iPad telemetry changed the Phantom from 20 events/58 ticks to the exact expected 12/100 with accepted controls/gameplay. |
@@ -14,9 +14,9 @@ Updated: 2026-08-25
 | Local multiplayer | Experimental rendering works; real P2–P4 controller ownership, reconnect behavior, and residual flicker remain open. |
 | Input lifecycle | Settings/share touch neutralization, disconnect-to-none ownership collapse, and mobile run-loop tracking remain open TD-14/TD-07 gaps. |
 | Network multiplayer | Not implemented. It is no-go until local ownership and deterministic state-hash gates pass. |
-| Preview 7 behavior | Preview 6's controls, automatic-fire cadence, renderer settings, ROM flow, saves, audio, touch layouts, Mac app, and limitations are retained unchanged. |
-| Immediate engineering gate | Take the optional second touch Fire button as a separate Preview 8 candidate. Mac horizontal-mouse sluggishness remains measured follow-up debt. |
-| Immediate user-facing follow-up | Production Preview 7 test requests are posted to issue #19 and the separate A12X issue #9. Await reporter results. Issue #17 is reporter-closed; issue #8 touch is positive with controller confirmation pending. |
+| Preview 8 behavior | Adds one default-off, independently editable duplicate Fire button. Preview 7's controls, cadence, Metal target, ROM flow, saves, audio, renderer settings, and limitations remain unchanged. |
+| Immediate engineering gate | Keep Preview 8 frozen; isolate renderer flicker and lifecycle/controller debt separately. Mac horizontal-mouse sluggishness remains measured follow-up debt. |
+| Immediate user-facing follow-up | Production Preview 7 test requests are posted to issue #19 and the separate A12X issue #9. Await reporter results. Issue #17 is reporter-closed; issue #8's modern controls are maintainer-accepted and its reporter is invited to test Preview 8's extra Fire button. |
 | Storage/build hygiene | The runtime-managed Application Support ROM copy lacks the Documents copy's explicit backup/protection attributes; game-bearing build provenance remains private-input/manual. |
 
 Documentation ownership:
@@ -39,6 +39,8 @@ Documentation ownership:
   Preview 6's public delta, artifact identities, acceptance, and limitations.
 - [`RELEASE_NOTES_0.1.0-preview.7.md`](RELEASE_NOTES_0.1.0-preview.7.md) records
   the bounded compatibility promotion and its pending production gates.
+- [`RELEASE_NOTES_0.1.0-preview.8.md`](RELEASE_NOTES_0.1.0-preview.8.md) records
+  the optional second Fire control and its physical acceptance boundary.
 
 ## Summary
 
@@ -49,7 +51,15 @@ detailed current evidence and unresolved physical gates are recorded in
 [`RT64_N64RECOMP_MORNING_HANDOFF_2026-08-21.md`](RT64_N64RECOMP_MORNING_HANDOFF_2026-08-21.md)
 and [`RT64_N64RECOMP_PROTOTYPE.md`](RT64_N64RECOMP_PROTOTYPE.md).
 
-Preview 7 is intentionally limited to the issue #19 Metal deployment-target
+Preview 8 is a mobile-only feature release. It adds an optional second Fire
+button under Touch Controls, disabled by default, with its own saved position,
+scale, and opacity. Both Fire surfaces aggregate into one N64 Z action so
+releasing one while the other is held cannot cancel or latch Fire. The accepted
+build is version `0.1.0` build `8`; it retains Preview 7's explicit iOS 17 Metal
+targets and all other accepted behavior. The user accepted the installed build
+on a physical iPad. The Mac Alpha remains the byte-identical Preview 7 artifact.
+
+Preview 7 was intentionally limited to the issue #19 Metal deployment-target
 correction. Preview 6 embedded libraries inherited an iOS 26.5 target despite
 the app declaring iOS 17. The exact side-by-side diagnostic artifact rebuilt
 all device and Simulator libraries with explicit iOS 17 AIR triples and passed
@@ -806,12 +816,11 @@ evidence ledger below is preserved as historical validation for
 
 ## Next gate
 
-Preview 7 is the published compatibility release selected from the physically
-successful issue #19 iOS 17 Metal-target experiment. Preview 4's exact rollback
+Preview 8 is the accepted mobile release with the default-off second Fire
+control. Preview 7 remains the Mac Alpha and compatibility rollback. Preview 4's exact rollback
 identity remains frozen in [`PREVIEW_4_BASELINE.md`](PREVIEW_4_BASELINE.md).
 Obtain issue #19 production-artifact confirmation; issue #9 remains a separate
-A12 evidence lane. Next, take the optional Fire button, TD-14 modal
-neutralization, TD-07 controller containment, physical
+A12 evidence lane. Next, take TD-14 modal neutralization, TD-07 controller containment, physical
 lifecycle/audio/flicker classification, TD-12 storage hygiene, and TD-13 build
 proof as separate units before broad
 multiplayer or renderer changes. Do not import matching-target SDK

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -1,6 +1,6 @@
 # Technical debt and upstream watch
 
-Updated: 2026-08-25
+Updated: 2026-08-27
 
 This is GoldenPad's authoritative engineering-debt ledger. It records current
 defects, evidence strength, repair order, acceptance gates, rejected approaches,
@@ -201,22 +201,27 @@ Preview 7 retains Preview 6's accepted controls and Preview 5's exact expected
 12 Phantom events per 100 ticks. Its byte-identical Mac payload retains known
 horizontal mouse sluggishness without introducing a Preview 7 regression.
 
+Preview 8 adds only the default-off duplicate touch Fire control. Focused tests
+prove that primary and secondary touches publish one N64 Z state and that
+releasing either source does not cancel or latch the other. Its in-place iPad
+installation preserved the ROM and preferences, and the user accepted the
+feature in gameplay. Renderer flicker, controller ownership, lifecycle, audio,
+storage, and compatibility debt remain separate.
+
 The next landing sequence is:
 
 1. obtain issue #19 production-artifact confirmation for the published Preview
    7 release;
-2. implement the optional second touch Fire button as one independently
-   movable/resizable control and accept it separately on phone and tablet;
-3. close TD-14 modal/run-loop neutralization and TD-07 controller collapse as
+2. close TD-14 modal/run-loop neutralization and TD-07 controller collapse as
    separate input-lifecycle units;
-4. run the physical audio/lifecycle/flicker evidence gates and add only the
+3. run the physical audio/lifecycle/flicker evidence gates and add only the
    counters selected by those observations;
-5. act on A12X issue #9 with the corrected target, then a bounded Tier-1 repair
+4. act on A12X issue #9 with the corrected target, then a bounded Tier-1 repair
    or tested support-floor decision if the first-draw crash remains;
-6. keep the accepted TD-08 Mac input repair frozen and take only a justified
+5. keep the accepted TD-08 Mac input repair frozen and take only a justified
    TD-09 edge repair;
-7. close TD-12 storage hygiene and TD-13 build-proof gaps independently; and
-8. implement stable real multi-controller ownership before any network layer.
+6. close TD-12 storage hygiene and TD-13 build-proof gaps independently; and
+7. implement stable real multi-controller ownership before any network layer.
 
 Do not begin peer discovery, matchmaking, relay, or rollback work while TD-07
 is open. A transport demo would not prove multiplayer feasibility and would

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -602,6 +602,26 @@ downloaded into a fresh directory and matched the accepted local files byte for
 byte. The hosted IPA and Mac ZIP then passed their complete package verifiers
 with the same app-content hashes recorded above.
 
+Preview 8 optional-Fire acceptance:
+
+- the production iPhone/iPad identity is version `0.1.0` build `8`;
+- the additional left-side Fire control is disabled by default and retains its
+  own persisted position, scale, opacity, and enabled state on phone and tablet;
+- focused tests prove primary-only, secondary-only, simultaneous press,
+  release-one, release-both, and reset behavior for the aggregated N64 Z state;
+- the signed candidate executable SHA-256 is
+  `6d90224ad63fb50c0eaae9d76e42d105e152e105b3dc9a4e12dcb80db5984dff3`;
+- two unsigned IPA packaging passes reproduced SHA-256
+  `773223b7ed7787c18526fb63281a6a3e4960b87adb0a912b0c2b77d0f1312a1b`
+  and sorted app-content SHA-256
+  `be03451c0b0450c43096d49d944642a82bfb0f3c310f70289831e51fcd28dc6d`;
+- all embedded Metal libraries retain only the iOS 17 AIR target;
+- build `8` installed in place on the physical iPad, with the Documents ROM and
+  preferences byte-identical before and after; protected Application Support
+  inputs were unchanged; and
+- the user tested the exact installed candidate and reported that it works and
+  is great. Existing graphical artifacting/flicker remains separate work.
+
 ## Desktop baseline
 
 ```sh

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -1,5 +1,29 @@
 # Worklog
 
+## 2026-08-27 - prepare Preview 8 optional second Fire release
+
+- Added a default-off **Add left-side Fire button** toggle to the live touch
+  editor. The duplicate N64 Z surface has independent position, scale, opacity,
+  and persisted enabled state for phone and tablet layouts.
+- Added one aggregated touch-Fire state so simultaneous primary and secondary
+  presses cannot cancel or latch each other when either finger releases.
+- Advanced only the mobile product to version `0.1.0` build `8`; the native
+  Apple-Silicon Mac Alpha remains Preview 7 unchanged.
+- Passed the focused Fire-state suite, complete input matrix, source/data
+  hygiene, signed ARM64 build, package audit, and explicit iOS 17 Metal-target
+  checks.
+- Packaged the unsigned IPA twice at SHA-256
+  `773223b7ed7787c18526fb63281a6a3e4960b87adb0a912b0c2b77d0f1312a1b`,
+  with sorted app-content SHA-256
+  `be03451c0b0450c43096d49d944642a82bfb0f3c310f70289831e51fcd28dc6d`.
+- Installed build `8` in place on the physical iPad. Pre/post readback preserved
+  the Documents ROM and preferences byte for byte; protected Application
+  Support inputs were unchanged. The user tested the candidate and reported
+  that it works and is great.
+- Kept residual split-screen flicker/artifacting, issue #9, issue #19 reporter
+  confirmation, controller ownership, lifecycle, audio, storage, and Mac work
+  outside this release.
+
 ## 2026-08-25 - prepare Preview 7 compatibility promotion
 
 - Selected the physically confirmed issue #19 iOS 17 Metal-target correction

--- a/scripts/package-recomp-prototype-ipa.sh
+++ b/scripts/package-recomp-prototype-ipa.sh
@@ -5,7 +5,7 @@ repo_root=$(cd "$(dirname "$0")/.." && pwd)
 "$repo_root/scripts/verify-recomp-input-matrix.sh"
 
 app_path=${GOLDENPAD_RECOMP_APP:-"$repo_root/build-recomp-prototype-device/Release-iphoneos/GoldenPadRecompPrototype.app"}
-release_name=${GOLDENPAD_RELEASE_NAME:-0.1.0-preview.7}
+release_name=${GOLDENPAD_RELEASE_NAME:-0.1.0-preview.8}
 reference_source=${GOLDENPAD_RECOMP_REFERENCE_SOURCE_DIR:-"$repo_root/ref/goldeneye64recomp"}
 rt64_source=${GOLDENPAD_RECOMP_RT64_SOURCE_DIR:-"$repo_root/ref/rt64"}
 output_name="GoldenPad-${release_name}-unsigned.ipa"

--- a/scripts/verify-preview4-baseline.sh
+++ b/scripts/verify-preview4-baseline.sh
@@ -7,9 +7,9 @@ baseline_tree=4232141f9d14d2f6197e43173694f649828e730f
 mode=${1:-strict}
 
 case "$mode" in
-    strict|--allow-td01-probe|--allow-td01-repair|--allow-preview6|--allow-preview7) ;;
+    strict|--allow-td01-probe|--allow-td01-repair|--allow-preview6|--allow-preview7|--allow-preview8) ;;
     *)
-        echo "Usage: $0 [--allow-td01-probe|--allow-td01-repair|--allow-preview6|--allow-preview7]" >&2
+        echo "Usage: $0 [--allow-td01-probe|--allow-td01-repair|--allow-preview6|--allow-preview7|--allow-preview8]" >&2
         exit 2
         ;;
 esac
@@ -47,10 +47,26 @@ Tests/RecompControlMappingTests.swift
 patches/goldeneye64recomp-ios-modern-controls.patch'
     preview7_diff="$preview6_diff
 patches/rt64-ios-embedded.patch"
+    preview8_diff='CMakeLists.txt
+Config/RecompPrototypeInfo.plist.in
+Sources/Mac/GoldenPadMacApp.swift
+Sources/Mac/RecompMacInput.swift
+Sources/RecompControlMapping.swift
+Sources/RecompPrototypeApp.swift
+Sources/RecompPrototypeInput.swift
+Sources/RecompPrototypeTouchLayout.swift
+Sources/RecompTouchFireState.swift
+Support/RecompPrototype/recomp_game_start.cpp
+Support/RecompPrototype/recomp_rt64_surface_stub.cpp
+Tests/RecompControlMappingTests.swift
+Tests/RecompTouchFireStateTests.swift
+patches/goldeneye64recomp-ios-modern-controls.patch
+patches/rt64-ios-embedded.patch'
     if ! { [ "$mode" = "--allow-td01-probe" ] && [ "$runtime_diff" = "$probe_diff" ]; } &&
         ! { [ "$mode" = "--allow-td01-repair" ] && [ "$runtime_diff" = "$repair_diff" ]; } &&
         ! { [ "$mode" = "--allow-preview6" ] && [ "$runtime_diff" = "$preview6_diff" ]; } &&
-        ! { [ "$mode" = "--allow-preview7" ] && [ "$runtime_diff" = "$preview7_diff" ]; }; then
+        ! { [ "$mode" = "--allow-preview7" ] && [ "$runtime_diff" = "$preview7_diff" ]; } &&
+        ! { [ "$mode" = "--allow-preview8" ] && [ "$runtime_diff" = "$preview8_diff" ]; }; then
         echo "FAIL: runtime diff exceeds the selected Preview 4 measurement boundary" >&2
         printf '%s\n' "$runtime_diff" >&2
         exit 1
@@ -83,7 +99,9 @@ do
 done
 
 echo "PASS: current branch descends from the exact Preview 4 tree"
-if [ "$mode" = "--allow-preview7" ]; then
+if [ "$mode" = "--allow-preview8" ]; then
+    echo "PASS: runtime diff adds only Preview 8 identity and the optional aggregated second touch Fire control"
+elif [ "$mode" = "--allow-preview7" ]; then
     echo "PASS: runtime diff is limited to Preview 6 behavior, Preview 7 identity, and the iOS 17 Metal-target correction"
 elif [ "$mode" = "--allow-preview6" ]; then
     echo "PASS: runtime diff is limited to Preview 6 Mac input, mobile utility-menu, identity, and retained Preview 5 repair paths"

--- a/scripts/verify-recomp-input-matrix.sh
+++ b/scripts/verify-recomp-input-matrix.sh
@@ -16,6 +16,31 @@ xcrun swiftc \
 
 "$test_root/verify-recomp-input-matrix"
 
+xcrun swiftc \
+  -module-cache-path "$test_root/swift-module-cache" \
+  "$repo_root/Sources/RecompTouchFireState.swift" \
+  "$repo_root/Tests/RecompTouchFireStateTests.swift" \
+  -o "$test_root/verify-recomp-touch-fire"
+
+"$test_root/verify-recomp-touch-fire"
+
+for secondary_fire_marker in \
+  'case move, look, fire, secondaryFire' \
+  'placement(.secondaryFire, 0.24, 0.58, enabled: false)' \
+  'placement(.secondaryFire, 0.30, 0.48, 0.95, enabled: false)' \
+  'ForEach(placements.filter(\.isEnabled))' \
+  'input.setFirePressed($0, source: fireSource)'
+do
+  if ! grep -Fq "$secondary_fire_marker" \
+    "$repo_root/Sources/RecompPrototypeTouchLayout.swift" \
+    "$repo_root/Sources/RecompPrototypeInput.swift"; then
+    echo "FAIL: optional secondary Fire path is missing $secondary_fire_marker" >&2
+    exit 1
+  fi
+done
+
+echo "PASS: optional secondary Fire is disabled by default and routed through aggregated input"
+
 for mac_frontend_marker in \
   'goldenpad_recomp_frontend_input_active' \
   'frontEndActive: frontEndInputActive' \

--- a/scripts/verify-recomp-prototype-host.sh
+++ b/scripts/verify-recomp-prototype-host.sh
@@ -74,6 +74,8 @@ for required_text in \
     'iPad Touch Layout' \
     'recomp.touchLayout.phone.v1' \
     'recomp.touchLayout.tablet.v1' \
+    'Add left-side Fire button' \
+    'Additional Fire' \
     'Choose Original ROM' \
     'Your original file will not be changed.' \
     'The file you select stays in its original location.' \

--- a/scripts/verify-recomp-prototype-ipa.sh
+++ b/scripts/verify-recomp-prototype-ipa.sh
@@ -9,7 +9,7 @@ fi
 ipa_path=$1
 expected_display_name=${GOLDENPAD_EXPECTED_DISPLAY_NAME:-GoldenPad}
 expected_bundle_identifier=${GOLDENPAD_EXPECTED_BUNDLE_IDENTIFIER:-com.chrissotraidis.goldenpad.recomp-prototype}
-expected_build_version=${GOLDENPAD_EXPECTED_BUILD_VERSION:-7}
+expected_build_version=${GOLDENPAD_EXPECTED_BUILD_VERSION:-8}
 expected_metal_target=${GOLDENPAD_EXPECTED_METAL_TARGET:-apple-ios17.0.0}
 if [ ! -f "$ipa_path" ] || [[ "$ipa_path" != *.ipa ]]; then
   echo "Expected an existing .ipa file: $ipa_path" >&2


### PR DESCRIPTION
## Summary

- add a default-off second touch Fire button with independent layout editing
- aggregate both touch Fire sources so releasing one cannot cancel or latch the other
- advance the mobile app and package identity to Preview 8
- update release documentation while keeping the Mac Alpha on Preview 7

## Verification

- physical iPad in-place install and gameplay accepted by the maintainer
- protected ROM/runtime data and preferences preserved
- focused Fire-state tests and complete input matrix pass
- Preview 4 baseline guard accepts only the Preview 8 boundary
- unsigned IPA packaged twice byte-identically
- IPA SHA-256: `773223b7ed7787c18526fb63281a6a3e4960b87adb0a912b0c2b77d0f1312a1b`
- package audit: 18 members, no ROM/save/signing material, iOS 17 Metal target retained
